### PR TITLE
Defines a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,26 +1,8 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files to always be normalized and converted
-# to native line endings on checkout.
-*.c text
-*.cpp text
-*.dart text
-*.go text
-*.h text
-*.hpp text
-*.json text
-*.lock
-*.md text
-*.mod text
-*.pot
-*.proto text
-*.sum text
-*.txt text
-*.work
-*.yaml text
-
 # Declare files that will always have CRLF line endings on checkout.
+*.appxmanifest text eol=crlf
 *.props text eol=crlf
 *.sln text eol=crlf
 *.targets text eol=crlf


### PR DESCRIPTION
For consistent line endings.

Just noticed one small improvement opportunity. Since we'll likely be switching between Linux and Windows, it's good to ensure we won't be trapped by EOL inconsistences.