### PR TITLE
Implemented database GetAll

### DIFF
--- a/windows-agent/internal/distros/database/database.go
+++ b/windows-agent/internal/distros/database/database.go
@@ -87,6 +87,18 @@ func (db *DistroDB) Get(name string) (distro *distro.Distro, ok bool) {
 	return d, ok
 }
 
+// GetAll returns a slice with all the distros in the database.
+func (db *DistroDB) GetAll() (all []*distro.Distro) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	for _, v := range db.distros {
+		all = append(all, v)
+	}
+
+	return all
+}
+
 // GetDistroAndUpdateProperties fetches a distro from the database, guranteeing that the
 // returned distro is valid, is in the database, and matches the given properties. If needed:
 // * A pre-existing distro with the same name may be removed from the database.


### PR DESCRIPTION
Returns a slice with all the distros.

I purposely decided to not filter the list with `IsValid`, because it's a check that is outdated as soon as the function returns.

The database is inherently asyncronous so you never have a guarantee that a distro was not invalidated in between you doing `GetAll` and you actually using the distro. You could trigger a clean-up before the call but you're still exposed to the same race.

The right way to do things is to ask for forgiveness instead of permission. Any attempt at using a distro when it is no longer valid will produce a `distro.NotValidError`, so the good way of doing things is:

```go
distros := db.GetAll()
for i := range distros {
    err := DoThing(distros[i])
    if errors.Is(err, distro.NotValidError{}) {
        // Distro is no longer valid: do whatever appropiate
    }
    if err != nil {
        // Error for some other reason: do whatever appropiate
    }

    // No error
}

WSL-440