### PR TITLE
Cancel concurrent runs in the same branch

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: QA-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   quality-go:
     name: "Go Quality checks"


### PR DESCRIPTION
This'll prevent redundant runs from wasting resources.

We launch 16 jobs per commit, so it'd probably be a good idea to avoid running the CI when unnecessary. This pull requests cancels old jobs when a new commit is pushed to a branch.