### PR TITLE
Bugfix: TestConnected may log after finishing

### DIFF
--- a/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
@@ -117,7 +117,7 @@ func TestConnected(t *testing.T) {
 			}
 
 			ctx, cancel := context.WithCancel(ctx)
-			t.Cleanup(func() { cancel() })
+			defer cancel()
 
 			db, err := database.New(ctx, t.TempDir(), nil)
 			require.NoError(t, err, "Setup: empty database New() should return no error")
@@ -126,10 +126,10 @@ func TestConnected(t *testing.T) {
 			require.NoError(t, err, "Setup: wslinstance New() should never return an error")
 
 			grpcServer, ctrlAddr := serveWSLInstance(t, ctx, srv)
-			t.Cleanup(grpcServer.Stop)
+			defer grpcServer.Stop()
 
 			wsl := newWslDistroMock(t, ctx, ctrlAddr)
-			t.Cleanup(wsl.stopClient)
+			defer wsl.stopClient()
 
 			// WSL-side server is not serving yet.
 			now := beforeLinuxServe
@@ -141,7 +141,7 @@ func TestConnected(t *testing.T) {
 			wantErrNeverReceivePort := tc.wantDone < afterDatabaseQuery && tc.wantDone != never
 			if !tc.skipLinuxServe {
 				go wsl.serve(t, wantErrNeverReceivePort)
-				t.Cleanup(wsl.stopServer)
+				defer wsl.stopServer()
 			}
 
 			// WSL-side server is serving, but no info has been sent yet.


### PR DESCRIPTION
Using `t.Cleanup` instead of `defer` can be considered a bad practice. Although very similar, defer is called right before the test finishes, whereas the cleanup is triggered right after. This means that any goroutine that may assert or log is susceptible to do so once the test is over. This'll cause a panic, as seen here:

https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/4565779740/jobs/8057379439?pr=73

These changes fix this issue by releasing resources with defer rather than cleanup.