### PR TITLE
Increase permissions for mo dir creation

### DIFF
--- a/tools/generate/internal/locales/locales.go
+++ b/tools/generate/internal/locales/locales.go
@@ -316,7 +316,7 @@ func generateMo(textdomain, in, out string) error {
 
 		candidate := filepath.Join(in, f.Name())
 		outDir := filepath.Join(baseLocaleDir, strings.TrimSuffix(f.Name(), ".po"), "LC_MESSAGES")
-		if err := os.MkdirAll(outDir, 0750); err != nil {
+		if err := os.MkdirAll(outDir, 0755); err != nil {
 			return fmt.Errorf("couldn't create %q: %v", out, err)
 		}
 		if out, err := exec.Command("msgfmt",


### PR DESCRIPTION
The permissions to create the `.mo` files are insufficient, as seen is this run:
https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/4664606678/jobs/8257021058

This PR raises them to 0750.