### PR TITLE
Solve GRPC races in tests

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
@@ -198,7 +198,7 @@ func startDaemon(t *testing.T) (app *agent.App, done func()) {
 		require.NoError(t, err, "Run should exits without any error")
 	}()
 	a.WaitReady()
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Second)
 
 	return a, func() {
 		wg.Wait()

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
@@ -240,7 +240,7 @@ func TestDefaultAddrFile(t *testing.T) {
 
 			a.SetArgs("-vvv")
 
-			tk := time.AfterFunc(5*time.Second, a.Quit)
+			tk := time.AfterFunc(10*time.Second, a.Quit)
 			defer func() {
 				if tk.Stop() {
 					a.Quit()


### PR DESCRIPTION
Reverts part of PR #91.

Read commit descriptions for more detail. Should improve testing and avoid this race:

https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/4697197189/jobs/8328010492?pr=97