### PR TITLE
Agent firewall rules

### DIFF
--- a/msix/UbuntuProForWindows/Package.appxmanifest
+++ b/msix/UbuntuProForWindows/Package.appxmanifest
@@ -3,10 +3,11 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="desktop uap uap5 rescap">
+  IgnorableNamespaces="desktop desktop2 uap uap5 rescap">
 
   <Identity
     Name="CanonicalGroupLimited.UbuntuProForWindows"
@@ -60,6 +61,15 @@
 		</Extensions>
     </Application>
   </Applications>
+
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules" Executable="agent\ubuntu-pro-agent.exe" EntryPoint="Windows.FullTrustApplication">
+      <desktop2:FirewallRules Executable="agent\ubuntu-pro-agent.exe">
+        <desktop2:Rule Profile="private" IPProtocol="TCP" Direction="in"></desktop2:Rule>
+        <desktop2:Rule Profile="private" IPProtocol="TCP" Direction="out"></desktop2:Rule>
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
 
   <Capabilities>
     <Capability Name="internetClient" />


### PR DESCRIPTION
This PR uses the Appx manifest declaration to enable local and remote TCP connections to the agent, only on private networks. Changes are only noticeable on deployment, i.e. installing the MSIX.

Callers from WSL 2 are like remote clients on a private network.

No port range restriction.

Applies only to the background agent.

Without this change, after deployment the agent couldn't be accessed from a WSL 2 instance. Only callers running on the host would be able to talk to it.

See docs: https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-desktop2-firewallrules