### PR TITLE
Visual Enhancements - window size

### DIFF
--- a/gui/packages/ubuntupro/windows/runner/main.cpp
+++ b/gui/packages/ubuntupro/windows/runner/main.cpp
@@ -25,7 +25,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
-  Win32Window::Size size(1280, 720);
+  Win32Window::Size size(800, 450); //16:9
   if (!window.Create(L"ubuntupro", origin, size)) {
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Breaking #90 into smaller PRs.

Out of my purest opinion. I believe a small window with 16:9 proportion looks best for an almost empty area. That's the size we've been using in our internal demos.