### PR TITLE
Centers the "EnterTokenPage" contents

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/enter_token/enter_token_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/enter_token/enter_token_page.dart
@@ -45,7 +45,6 @@ class EnterProTokenPage extends StatelessWidget {
         child: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               SizedBox(
                 width: textFieldWidth(context),


### PR DESCRIPTION
Following the break-up of #90 in smaller pieces.
Matching the demo presentations.
Having the fields left-aligned looks weird.