### PR TITLE
Fix missing variable in debian package build.

### DIFF
--- a/wsl-pro-service/debian/update-internal-dependencies
+++ b/wsl-pro-service/debian/update-internal-dependencies
@@ -4,6 +4,8 @@ set -eu
 # Add repo as private
 go env -w GOPRIVATE=github.com/canonical/ubuntu-pro-for-windows
 
+UP4W_SKIP_INTERNAL_DEPENDENCY_UPDATE=${UP4W_SKIP_INTERNAL_DEPENDENCY_UPDATE:-""}
+
 if [ -n "${UP4W_SKIP_INTERNAL_DEPENDENCY_UPDATE}" ]; then
     echo "Skipping internal dependency update"
     exit 0


### PR DESCRIPTION
Debian package build no longer fails when `UP4W_SKIP_INTERNAL_DEPENDENCY_UPDATE` is not set. This was only a problem when running locally.
