### PR TITLE
Start the agent with a merged view of the env vars

### DIFF
--- a/gui/packages/ubuntupro/lib/core/environment.dart
+++ b/gui/packages/ubuntupro/lib/core/environment.dart
@@ -33,4 +33,26 @@ class Environment {
 
     return Platform.environment[key];
   }
+
+  Map<String, String>? _merged;
+
+  /// Returns a merged view of the environment variables mixed with the overrides. Useful when passing to child processes.
+  Map<String, String> get merged {
+    if (_merged == null) {
+      // Start with nullable values because _overrides accepts null values as a way to remove items from the Environment.
+      // ignore: omit_local_variable_types
+      final Map<String, String?> map = {
+        ...Platform.environment,
+        ...?_overrides
+      };
+
+      // We then remove the entries where values are null.
+      map.removeWhere((key, value) => value == null);
+
+      // And finish with a map of a different type -- non-nullable String values.
+      _merged = map.map((key, value) => MapEntry(key, value!));
+    }
+
+    return _merged!;
+  }
 }

--- a/gui/packages/ubuntupro/lib/launch_agent.dart
+++ b/gui/packages/ubuntupro/lib/launch_agent.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
+import 'core/environment.dart';
+
 /// Starts the Windows background agent from its well-known location relative
 /// to the root of the deployed application package [agentRelativePath].
 //
@@ -21,6 +23,7 @@ Future<bool> launchAgent(String agentRelativePath) async {
     await Process.start(
       agentPath,
       [],
+      environment: Environment.instance.merged,
     );
     return true;
   } on ProcessException catch (err) {


### PR DESCRIPTION
The Environment class was a construct to ease testing the GUI components. Sharing it with the agent at startup is useful for integration testing, because it allows the GUI to talk to a sandboxed agent, such as passing an override for the `env:LOCALAPPDATA` variable for a specific test. Of course this will only have effect on the scenario where the GUI starts the agent, which is not the main use case for this application.

Usefulness is also limited by the fact that the `wsl-pro-service` inside WSL instances cannot detect such env changes.

So as long as the GUI doesn't need any WSL instance talking to the agent, this construct is desirable for testing. Should we need anything different, then we need to reconsider the way we make the agent's address visible to the other components.