### PR TITLE
Store Plugin: static const method channel

### DIFF
--- a/gui/packages/p4w_ms_store/lib/p4w_ms_store_method_channel.dart
+++ b/gui/packages/p4w_ms_store/lib/p4w_ms_store_method_channel.dart
@@ -7,7 +7,7 @@ import 'p4w_ms_store_platform_interface.dart';
 class MethodChannelP4wMsStore extends P4wMsStorePlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final methodChannel = const MethodChannel('p4w_ms_store');
+  static const methodChannel = MethodChannel('p4w_ms_store');
 
   @override
   Future<PurchaseStatus> purchaseSubscription(String productId) async {

--- a/gui/packages/p4w_ms_store/test/p4w_ms_store_method_channel_test.dart
+++ b/gui/packages/p4w_ms_store/test/p4w_ms_store_method_channel_test.dart
@@ -5,7 +5,7 @@ import 'package:p4w_ms_store/p4w_ms_store_platform_interface.dart';
 
 void main() {
   final platform = MethodChannelP4wMsStore();
-  const channel = MethodChannel('p4w_ms_store');
+  const channel = MethodChannelP4wMsStore.methodChannel;
   const productId = 'awesome-addon';
 
   final binding = TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
The purpose of having this field was to easily access the method channel without repeating its name. Since it was annotated as "visibleForTesting", it makes sense to allow other test code to access that field. Even more useful when integration tests need to mock this plugin.

There might even be some negligible performance improvement here, but that's not the main motivation for the change. Surely a pessimisation won't happen because of this.