### PR TITLE
Fixed build-deb script when run by non-root user

### DIFF
--- a/tools/build/build-deb.sh
+++ b/tools/build/build-deb.sh
@@ -5,9 +5,9 @@ set -eu
 cd $(dirname $(realpath "$0"))/../../wsl-pro-service
 
 # Install dependencies
-sudo apt update
-sudo apt install -y devscripts
-sudo apt -y build-dep .
+sudo DEBIAN_FRONTEND=noninteractive apt update
+sudo DEBIAN_FRONTEND=noninteractive apt install -y devscripts
+sudo DEBIAN_FRONTEND=noninteractive apt -y build-dep .
 
 # Build
 DEB_BUILD_OPTIONS=nocheck debuild


### PR DESCRIPTION
When using the build-deb.ps1 script, a distro with only a root user is created, so this problem was invisible to Windows users.

However, when using build-deb.sh directly from an Ubuntu machine with a non-root user, the script fails, and using `sudo build-deb.sh` is a bad idea (as the artifacts will be owned by root). It will also probably fail due to the fact that the .gitconfig will different and this repo is private bla bla bla.