### PR TITLE
Forces the DLL to be built before the Go agent

### DIFF
--- a/msix/agent/agent.targets
+++ b/msix/agent/agent.targets
@@ -7,17 +7,30 @@
 		<!-- Comment below to see the console window poping up -->
 		<GoFlags>-ldflags -H=windowsgui</GoFlags>
 	</PropertyGroup>
-	<ItemGroup>
-        <GoLibFiles Include="$(OutDir)\*.dll" />
-        <None Include="@(GoLibFiles)">
-            <DeploymentContent>true</DeploymentContent>
-        </None>
-    </ItemGroup>
     <ItemGroup>
       <None Include="$(GoAppRoot)\**\*.go" />
     </ItemGroup>
-	<Target Name="Build">
-		<Message Text="Building Go artifacts to $(OutDir)" Importance="high"/>
+    <!-- Writes into the "DepAssemblies" item the location where building the @(ProjectReference) projectwill output its assemblies (without actually building it) -->
+    <Target Name="GetDepsOutputPaths" BeforeTargets="Build">
+        <MSBuild Projects="@(ProjectReference)" Targets="GetTargetPath">
+            <Output TaskParameter="TargetOutputs" ItemName="DepAssemblies" />
+        </MSBuild>
+    </Target>
+    <!-- Forces building the @(ProjectReference) project before building this project -->
+    <Target Name="BuildDeps" BeforeTargets="Build">
+        <Message Text="Building @(ProjectReference)" Importance="high" />
+        <MSBuild Projects="@(ProjectReference)" Targets="Build">
+        </MSBuild>
+    </Target>
+	<Target Name="Build" DependsOnTargets="BuildDeps">
+        <!-- Here we can be confident that "DepAssemblies" have been computed and built -->
+        <ItemGroup>
+            <None Include="@(DepAssemblies)">
+                <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+                <DeploymentContent>true</DeploymentContent>
+            </None>
+        </ItemGroup>
+        <Message Text="Building Go artifacts to $(OutDir) and bundling @(DepAssemblies)" Importance="high"/>
         <MakeDir Directories="$(OutDir)" />
 		<Exec Command="go build $(GoFlags) $(GoAppDir) " WorkingDirectory="$(OutDir)" />
 	</Target>


### PR DESCRIPTION
Inspired by [this conversation](https://github.com/canonical/ubuntu-pro-for-windows/pull/180#issuecomment-1673704497) around when the GUI binary is available on disk, I decided to look into how the agent's build process places the `storeapi.dll` binary with it in the final package layout.

Just adding a `ProjectReference` declaration into the `agent.vcxproj` was not enough to enforce the build order we needed.

https://github.com/canonical/ubuntu-pro-for-windows/blob/main/msix/agent/agent.vcxproj#L123-L125

Thus very often when building the appx from a clean env the DLL would not be added to the package.

The proposed approach enforces first building whatever project is linked to the `agent.vcxproj` via `ProjectReference` declaration and only build the agent after that target (`BuildDeps`) completes.

Another target was added (`GetDepsOutputPaths`) to compute the paths of the assemblies that building the `ProjectReference` projects will generate beforehand, so we can later refer to them instead of searching files with globs as previously done, replacing this

```xml
    <ItemGroup>
        <GoLibFiles Include="$(OutDir)\*.dll" />
        <None Include="@(GoLibFiles)">
```

with this

```xml
        <ItemGroup>
            <None Include="@(DepAssemblies)">
```

XML Programming S2