### PR TITLE
Fix end-to-end build logs not being written

### DIFF
--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -111,8 +111,7 @@ func buildProject(ctx context.Context) (debPath string, err error) {
 
 			logPath := strings.ReplaceAll(fmt.Sprintf("%s.log", jobName), " ", "")
 			if f, err := os.Create(logPath); err != nil {
-				log.Printf("could not open log file %q for writing", logPath)
-				f = nil
+				log.Printf("%s: could not open log file %q for writing", jobName, logPath)
 			} else {
 				cmd.Stdout = f
 				cmd.Stderr = f
@@ -127,7 +126,6 @@ func buildProject(ctx context.Context) (debPath string, err error) {
 
 			log.Printf("Finished job: %s\n", jobName)
 			results <- nil
-
 		}()
 	}
 


### PR DESCRIPTION
There was a race whereby the end-to-end tests would exit before finishing to write the logs from the Appx and Deb builds, when either of the two failed.

This is now fixed by piping to the log file rather than dumping the logs at the end.