### PR TITLE
Remove useless functions in Landscape config test mock

### DIFF
--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -746,11 +746,3 @@ func (m mockConfig) LandscapeURL(ctx context.Context) (string, error) {
 	}
 	return m.landscapeURL, nil
 }
-
-func (m mockConfig) Pseudonym() string {
-	return "PSEUDONYM"
-}
-
-func (m mockConfig) Hostname() string {
-	return "HOSTNAME"
-}


### PR DESCRIPTION
This was used in some iteration of implementing the Landscape client and I forgot to remove it when we went for another approach