### PR TITLE
Go 1.21.0 is the real released Go version

### DIFF
--- a/agentapi/go.mod
+++ b/agentapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/agentapi
 
-go 1.21
+go 1.21.0
 
 require (
 	google.golang.org/grpc v1.57.0

--- a/common/go.mod
+++ b/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/common
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.3.1

--- a/end-to-end/go.mod
+++ b/end-to-end/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/end-to-end
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/canonical/ubuntu-pro-for-windows/common v0.0.0-20230817064205-3ab157a2dd98

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.21.0
 
 use (
 	./agentapi

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/tools
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/canonical/ubuntu-pro-for-windows/windows-agent v0.0.0-20230601072749-e7ce40e197de

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/windows-agent
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/canonical/landscape-hostagent-api v0.0.0-20230606055347-dd0b7f618303

--- a/wsl-pro-service/go.mod
+++ b/wsl-pro-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/wsl-pro-service
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/canonical/ubuntu-pro-for-windows/agentapi v0.0.0-20230817064205-3ab157a2dd98

--- a/wslserviceapi/go.mod
+++ b/wslserviceapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-pro-for-windows/wslserviceapi
 
-go 1.21
+go 1.21.0
 
 require (
 	google.golang.org/grpc v1.57.0


### PR DESCRIPTION
Go 1.21 is any unreleased version of Go tip until first rc. The real first release starting with 1.21 series is 1.21.0. https://go.dev/doc/toolchain.