### PR TITLE
Run debian build action in a self-hosted container

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -246,7 +246,8 @@ jobs:
 
   build-wsl-pro-service:
     name: Build wsl-pro-service debian package
-    runs-on: ubuntu-latest
+    # Using self-hosted runner because tests have a tendency to run out of memory
+    runs-on: [self-hosted, Linux, X64, small]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This action is quite flaky on Github runners, presumably due to resource constraints. I'm quite sure that is the problem because:
- The debian package never fails to build on my machine
- It's the test phase that fails, but the tests on their own (in the other workflow) always succeed.
- The tests that fail do so because their subprocesses are killed, I suspect the OS is killing them due to memory issues.

We have both small and large containers, I'll try with the small ones and see if that's enough.