### PR TITLE
Remove "Run Go tests with mocks (agentapi)"

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -171,7 +171,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        subproject: ["agentapi", "windows-agent", "wsl-pro-service", "common"]
+        subproject: ["windows-agent", "wsl-pro-service", "common"]
         exclude:
           - os: windows
             subproject: wsl-pro-service


### PR DESCRIPTION
The agent API contains no tests, only auto-generated code.