### PR TITLE
The interface cast fails without the double *

### DIFF
--- a/mocks/contractserver/contracts/main.go
+++ b/mocks/contractserver/contracts/main.go
@@ -10,7 +10,7 @@ import (
 
 func serverFactory(settings restserver.Settings) restserver.Server {
 	//nolint:forcetypeassert // Let the type coersion panic on failure.
-	return contractsmockserver.NewServer(settings.(contractsmockserver.Settings))
+	return contractsmockserver.NewServer(*settings.(*contractsmockserver.Settings))
 }
 
 func main() {


### PR DESCRIPTION
It seemed to have worked earlier without *s, but it doesn't.

My bad :(