### PR TITLE
Mitigate race in wslinstance's TestConnected

### DIFF
--- a/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
@@ -500,7 +500,7 @@ func stopWSLClientOnMatchingStep(wantStopStep, currentStep step, wsl *wslDistroM
 func checkConnectedStatus(t *testing.T, wantDoneStep step, wantErr bool, currentStep step, srv wrappedService) (continueTest bool) {
 	t.Helper()
 
-	connectedErr, stopped := srv.wait(100 * time.Millisecond)
+	connectedErr, stopped := srv.wait(300 * time.Millisecond)
 	if currentStep != wantDoneStep {
 		require.False(t, stopped, "Connect() function should still be running at step %q but is has now stopped (should stop at step %q)", currentStep, wantDoneStep)
 		return true


### PR DESCRIPTION
There is a home-cooked version of `Eventually`. These kind of checks are never reace-safe, you can only increase your confidence by increasing timeouts.

Since Github machines seem to run quite a bit slower than my local dev machine, I sometimes underestimate the length of timeouts. Hopefully this is the case here.

---

UDENG-1382