### PR TITLE
Fix wrong filename for docs

### DIFF
--- a/windows-agent/generate/generate.yaml
+++ b/windows-agent/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../doc/3.-Windows-Agent-command-line-reference.md
+  docs: ../doc/03.-Windows-Agent-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:

--- a/wsl-pro-service/generate/generate.yaml
+++ b/wsl-pro-service/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../doc/4.-WSL-Pro-Service-command-line-reference.md
+  docs: ../doc/04.-WSL-Pro-Service-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:


### PR DESCRIPTION
It was missing the leading zero

This'll fix the `Update readme and CLI ref files` workflow that is now broken:
https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/6198085059/job/16827878713

This does NOT fix the also broken `Update internal dependencies`:
https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/6198085059/job/16827878713.