### PR TITLE
Fix workspace dependency updater

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -125,6 +125,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
+          # ^ 0 means infinity in this context. This is necessary to later be able to compute diffs.
       - name: Set up git
         uses: ./.github/actions/setup-git
         with:


### PR DESCRIPTION
To check if our dependencies are up to date or not without spamming the commit history, we diff from HEAD to the commit the dependency points to. Hence, we need the commit history to decide wether to go get the latest revision of the module.