### PR TITLE
Fix unmarshalling rest servers

### DIFF
--- a/mocks/contractserver/contractsmockserver/contractsmockserver.go
+++ b/mocks/contractserver/contractsmockserver/contractsmockserver.go
@@ -34,8 +34,8 @@ type Settings struct {
 }
 
 // Unmarshal tricks the type system so marshalling YAML will just work when called from the restserver.Settings interface.
-func (s Settings) Unmarshal(in []byte, unmarsheller func(in []byte, out interface{}) (err error)) (restserver.Settings, error) {
-	err := unmarsheller(in, &s)
+func (s Settings) Unmarshal(in []byte, unmarshaller func(in []byte, out interface{}) (err error)) (restserver.Settings, error) {
+	err := unmarshaller(in, &s)
 	return s, err
 }
 

--- a/mocks/restserver/application.go
+++ b/mocks/restserver/application.go
@@ -24,7 +24,7 @@ type Server interface {
 
 // Settings is the minimal interface a settings backend must provide to the Application.
 type Settings interface {
-	Unmarshal(in []byte, unmarsheller func(in []byte, out interface{}) (err error)) (Settings, error)
+	Unmarshal(in []byte, unmarshaller func(in []byte, out interface{}) (err error)) (Settings, error)
 }
 
 // App encapsulates creating and managing the CLI and lifecycle.

--- a/mocks/storeserver/storemockserver/storemockserver.go
+++ b/mocks/storeserver/storemockserver/storemockserver.go
@@ -98,8 +98,8 @@ type Settings struct {
 }
 
 // Unmarshal tricks the type system so marshalling YAML will just work when called from the restserver.Settings interface.
-func (s Settings) Unmarshal(in []byte, unmarsheller func(in []byte, out interface{}) (err error)) (restserver.Settings, error) {
-	err := unmarsheller(in, &s)
+func (s Settings) Unmarshal(in []byte, unmarshaller func(in []byte, out interface{}) (err error)) (restserver.Settings, error) {
+	err := unmarshaller(in, &s)
 	return s, err
 }
 


### PR DESCRIPTION
In converting the rest servers settings to interfaces I ended up messing with the ability to unmarshal YAML (or any other text serialization, actually). This fixes that bug by indirecting the unmarshalling activity to the concrete Settings implementation. This code looks a bit weird in my opinion. Suggestions to make it better are welcome. The key factor is: we cannot unmarshall into an interface without applying some kind of reflection or type-tag switching.

Current main:

```
go run .\mocks\storeserver\storeserver\main.go .\defaults.yaml
panic: interface conversion: restserver.Settings is map[interface {}]interface {}, not storemockserver.Settings

goroutine 1 [running]:
main.serverFactory({0x85d780?, 0xc00003d170?})
        D:/p4w/hide-winrt/mocks/storeserver/storeserver/main.go:13 +0xe7
github.com/canonical/ubuntu-pro-for-windows/mocks/restserver.(*App).rootCmd.func2(0xc000004300?, {0xc000040350, 0x1, 0x8beb60?})
        D:/p4w/hide-winrt/mocks/restserver/application.go:152 +0x228
github.com/spf13/cobra.(*Command).execute(0xc000004300, {0xc00006e3b0, 0x1, 0x1})
```

With the proposed changes:

```
go run .\mocks\storeserver\storeserver\main.go .\defaults.yaml
Write 'exit' to stop serving
```

The first commit is unrelated to that bug, but I found it too small to run the CI over it in a standalone PR.
The storemockserver would return an array of products as the top-level entry in the JSON response for GET `/products`. Although valid JSON, the MS JsonObject API didn't like that approach, it expects an object.
So, with that change, we return `{"products":["..."]}` instead of a top-level array.