### PR TITLE
fix(mocks): ensure the C++ HTTP client doesn't cache

### DIFF
--- a/storeapi/base/impl/WinMockContext.cpp
+++ b/storeapi/base/impl/WinMockContext.cpp
@@ -7,6 +7,7 @@
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Web.Http.Filters.h>
 #include <winrt/Windows.Web.Http.h>
 #include <winrt/base.h>
 
@@ -181,7 +182,13 @@ IAsyncOperation<Uri> buildUri(winrt::hstring& relativePath,
 IAsyncOperation<JsonObject> call(winrt::hstring relativePath,
                                  UrlParams const& params) {
   // Initialize only once.
-  static winrt::Windows::Web::Http::HttpClient httpClient{};
+  namespace http = winrt::Windows::Web::Http;
+  static http::Filters::HttpBaseProtocolFilter filter{};
+  filter.CacheControl().ReadBehavior(
+      http::Filters::HttpCacheReadBehavior::NoCache);
+  filter.CacheControl().WriteBehavior(
+      http::Filters::HttpCacheWriteBehavior::NoCache);
+  static http::HttpClient httpClient{filter};
 
   Uri uri = co_await buildUri(relativePath, params);
 


### PR DESCRIPTION
This behavior surprised me. Only a very advanced debugging technique (the ancient printf-debugging) could reveal what was going on under the hood: the http client was caching responses.

The log fragment below is from one of my attempts to run the TestPurchase end-to-end test scenario. Here's what is happening:

1. The GUI starts, so does the agent.
2. At startup the agent checks whether there is an active subscription.
3. That check causes the http client to call `GET /products`
4. I added a printf in the handler to list all products found
5. We can see in the logs that `GET /products` was called and the product was not yet subscribed.
6. Then the GUI does a purchase. That requires fetching a product, which causes another `GET /products` followed by a `GET /purchase`. All succeeds.
7. The GUI notifies the agent of the success.
8. The agent should check the expiration date of the current product before deciding to call the Contracts Server backend.
9. That check would have caused another `GET /products`, but there is none after the purchase call.

```
2023/10/06 15:09:30 Setup: Generating test image from "Ubuntu"
2023/10/06 15:10:06 Setup: Installed "Ubuntu"
2023/10/06 15:10:35 Setup: Installed wsl-pro-service into "Ubuntu"
2023/10/06 15:10:58 Setup: Exported image
2023/10/06 15:10:58 Setup: Generated test image from "Ubuntu"
=== RUN   TestPurchase
=== RUN   TestPurchase/Success_when_applying_pro_token_before_registration
    purchase_test.go:101: Starting agent
flutter: The Dart VM service is listening on http://127.0.0.1:56342/rX0NGCu7E5I=/
flutter: 00:00 +0: TestPurchase
2023/10/06 15:11:15 INFO Received request endpoint=/products method=GET
2023/10/06 15:11:15 INFO products found: [{9P25B50XMKXT Annual Subscription (production) To this lovely mock of the production product ID false Durable 0001-01-01 00:00:00 +0000 UTC}]
    purchase_test.go:101: Started agent
    purchase_test.go:106: Registering distro "testDistro_UP4W_TestPurchase_Success_when_applying_pro_token_before_registration_15629193005924503274"
2023/10/06 15:11:15 INFO Received request endpoint=/products method=GET
2023/10/06 15:11:15 INFO products found: [{9P25B50XMKXT Annual Subscription (production) To this lovely mock of the production product ID false Durable 0001-01-01 00:00:00 +0000 UTC}]
2023/10/06 15:11:15 INFO Received request endpoint=/purchase method=GET
flutter: gRPC Error (code: 2, codeName: UNKNOWN, message: could not validate subscription against Microsoft Store: could not get ProToken from Microsoft Store: could not obtain pro token: the subscription has been expired since 292277026596-12-04 12:30:08 -0300 -03, details: [], rawResponse: null, trailers: {})
```

After configuring the http client to cache nothing, the missing check appeared. The agent was doing the right thing, but the HTTP implementation was not calling `GET /products` a second time in behalf of the agent because there was a cache.