### PR TITLE
build(debian): Avoid spamming .gitconfig with the same safe directory in local build

### DIFF
--- a/tools/build/build-deb.ps1
+++ b/tools/build/build-deb.ps1
@@ -47,7 +47,9 @@ if ( "${LastExitCode}" -ne "0" ) {
 #!/bin/bash
 set -eu
 
-git config --global --add safe.directory "$(pwd)"
+git config --get-all safe.directory                        \
+    | grep "$(pwd)"                                        \
+    || git config --global --add safe.directory "$(pwd)"
 
 # Update internal dependencies in the repo because
 # we need git to work, and .git is not rsync'd.


### PR DESCRIPTION
Not cool:

```
[safe]
        directory = C:/tools/flutter-base-dir
        directory = /mnt/c/Users/edu19/Work/ubuntu-pro-for-windows
        directory = /mnt/c/Users/edu19/Work/ubuntu-pro-for-windows
        directory = /mnt/c/Users/edu19/Work/ubuntu-pro-for-windows
        directory = /mnt/c/Users/edu19/Work/ubuntu-pro-for-windows
        ...
```