### PR TITLE
fix(storeapi): Allows fallback to the old API for JWT generation

### DIFF
--- a/storeapi/base/impl/StoreContext.cpp
+++ b/storeapi/base/impl/StoreContext.cpp
@@ -106,6 +106,12 @@ std::string StoreContext::GenerateUserJwt(std::string token,
   auto hUserId = winrt::to_hstring(userId);
   auto hJwt = self.GetCustomerPurchaseIdAsync(hToken, hUserId).get();
   if (hJwt.empty()) {
+    // Although the preferred API for the MS Store is the one exported in the
+    // `Windows::Services::Store` namespace, it has consistently and silently
+    // failed to generate the user JWT, producing just an empty string. The old
+    // (deprecated) `Windows::ApplicationModel::Store` namespace, on the other
+    // hand, succeeded consistently in my tests, as long as the app is deployed
+    // (throwing exceptions otherwise).
     hJwt = winrt::Windows::ApplicationModel::Store::CurrentApp::
                GetCustomerPurchaseIdAsync(hToken, hUserId)
                    .get();


### PR DESCRIPTION
The `Windows.Services.Store` namespace `StoreContext` class is consistently failing to generate the user JWT without an error message, just returning an empty string, which is not helpful.

To date I'm not sure what's going on under the hood, but the fact is that, once deployed, using the old (deprecated) `Windows.ApplicationModel.Store` namespace `CurrentApp` class always succeeds (or generates a useful error message if the access token has issues - such as being expired).

So, this PR adds allows the old namespace call as a fallback for such cases. 

With such fix in place I'm seeing the agent logs consistently hitting the wall of the WSL SaaS backend failing to respond to the `GET /v1/subscription` call, which is only made after we suceed in generating the JWT (which follows sucessfully checking the current expiration date with the Store API).
