### PR TITLE
fix(windows-agent): Fix panic due to early closure of database

### DIFF
--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -90,7 +90,13 @@ func New(ctx context.Context, args ...Option) (s Manager, err error) {
 	if err != nil {
 		return s, err
 	}
-	defer db.Close(ctx)
+	defer func() {
+		// Close DB if we return error
+		// Otherwise, it'll be closed in the call to Manager.Stop
+		if err != nil {
+			db.Close(ctx)
+		}
+	}()
 
 	if err := conf.UpdateRegistrySettings(ctx, opts.cacheDir, db); err != nil {
 		log.Warningf(ctx, "Could not update registry settings: %v", err)


### PR DESCRIPTION
This regression was introduced in f41de3b42e2f69f57eea33cd6f6fae49b7e26963