### PR TITLE
ci(jira): Update component in Jira workflow

### DIFF
--- a/.github/workflows/sync-gh-jira.yaml
+++ b/.github/workflows/sync-gh-jira.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: canonical/sync-issues-github-jira@v1
         with:
           webhook-url: ${{ secrets.JIRA_WEBHOOK_URL }}
-          component: 'S-WSL'
+          component: 'WSL'


### PR DESCRIPTION
We renamed the component Jira-side by removing the S- prefix. This PR mirrors this change.