### PR TITLE
ci(docs): fix command line reference generation

### DIFF
--- a/windows-agent/generate/generate.yaml
+++ b/windows-agent/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../docs/05-windows-agent-command-line-reference.md
+  docs: ../docs/06-windows-agent-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:

--- a/wsl-pro-service/generate/generate.yaml
+++ b/wsl-pro-service/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../docs/06-wsl-pro-service-command-line-reference.md
+  docs: ../docs/07-wsl-pro-service-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:


### PR DESCRIPTION
We were targetting the previous paths before renumbering.

UDENG-1724