### PR TITLE
fix(go.sum): refresh go.sum for wsl-pro-service

### DIFF
--- a/wsl-pro-service/go.sum
+++ b/wsl-pro-service/go.sum
@@ -38,16 +38,10 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/canonical/ubuntu-pro-for-windows/agentapi v0.0.0-20231023183501-458a10db4c16 h1:p894ThMw329hDKpS2tfsgZhUuWC1HfZAsq/vcRhDpGs=
-github.com/canonical/ubuntu-pro-for-windows/agentapi v0.0.0-20231023183501-458a10db4c16/go.mod h1:yZFCC1gVaFNjIJ7Glk3FBiaCokcV/Jk5B6tFIlHBgd8=
 github.com/canonical/ubuntu-pro-for-windows/agentapi v0.0.0-20231113084350-57c6acdb2d5b h1:RvQ13IIoGm/JsPQYZA7hOvjX0rWIDqLH4DKXq6SW+L0=
 github.com/canonical/ubuntu-pro-for-windows/agentapi v0.0.0-20231113084350-57c6acdb2d5b/go.mod h1:btQ/eVeGFXdXdifpHRo4V05VmmnhyhWWkecmVnvUbfQ=
-github.com/canonical/ubuntu-pro-for-windows/common v0.0.0-20231031122227-ff0fccdda501 h1:BUJqqqeV0onaJkBMDkKMUIl+hyh+QrsoAni2oE3AHz8=
-github.com/canonical/ubuntu-pro-for-windows/common v0.0.0-20231031122227-ff0fccdda501/go.mod h1:r2YGGGSeu2lnyVGB49O3fGgaLfppNwr9TlLimYH2muY=
 github.com/canonical/ubuntu-pro-for-windows/common v0.0.0-20231113084350-57c6acdb2d5b h1:e/2jgQO5wxcvIJBqQwD+hw40H0ytJAFRdOhnV+lQkUU=
 github.com/canonical/ubuntu-pro-for-windows/common v0.0.0-20231113084350-57c6acdb2d5b/go.mod h1:HWMzmvIFQ3dWWPE4paEDWOMpOkcjFb2akrccYrck+eM=
-github.com/canonical/ubuntu-pro-for-windows/wslserviceapi v0.0.0-20231025153609-b3e7db95a9ce h1:zuJOIrd+T+J5UVEiCHT9lK7sYS4VDJ5ZxI81Yvdr6jY=
-github.com/canonical/ubuntu-pro-for-windows/wslserviceapi v0.0.0-20231025153609-b3e7db95a9ce/go.mod h1:gjEBJv2vc1VUqqrv1ZTDcNmd3TBBCPIlmBaR63YSX9Y=
 github.com/canonical/ubuntu-pro-for-windows/wslserviceapi v0.0.0-20231113084350-57c6acdb2d5b h1:hohD71N1nVvCQID1D+0ci6dZANSl9pDjnEV0Gpu8M+A=
 github.com/canonical/ubuntu-pro-for-windows/wslserviceapi v0.0.0-20231113084350-57c6acdb2d5b/go.mod h1:b0s/D9Q81b42hO9zjFXs7xpMs4jltc+7GwIUGEv2/5U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
It seems it wasn’t refreshed recently to purge old version of artifacts.

UDENG-1723