### PR TITLE
fix(end-to-end): Fix Ubuntu Pro Token registry key used in E2E tests

### DIFF
--- a/end-to-end/organization_token_test.go
+++ b/end-to-end/organization_token_test.go
@@ -100,6 +100,6 @@ func activateOrgSubscription(t *testing.T) {
 	require.NoErrorf(t, err, "Setup: could not open UbuntuPro registry key")
 	defer key.Close()
 
-	err = key.SetStringValue("ProTokenOrg", token)
+	err = key.SetStringValue("UbuntuProToken", token)
 	require.NoError(t, err, "could not write token in registry")
 }


### PR DESCRIPTION
The key value in which the Ubuntu Pro token is stored was changed in PR #369 from `ProTokenOrg` to `UbuntuProToken`.

This error went unnoticed because the E2E tests were not working until #397.