### PR TITLE
ci(docs): minimise the amount of documentation check in parallel

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -1,13 +1,19 @@
 name: Main Documentation Checks
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true  
+  cancel-in-progress: true
 
 jobs:
   documentation-checks:


### PR DESCRIPTION
Only restrict push to the main branch, the rest will go through PR and so, the PR trigger will already run.
Before, the documentation check was run twice on PR.