### PR TITLE
maint: Simplify local deb-build script

### DIFF
--- a/tools/build/build-deb.ps1
+++ b/tools/build/build-deb.ps1
@@ -70,7 +70,6 @@ modules=("agentapi" "common" "contractsapi" "storeapi" "tools" "wsl-pro-service"
 
 for mod in ${modules[@]}; do
     rsync --recursive --quiet "${mod}" "${build_dir}"
-    echo "Synced $mod"
 done
 
 # Build


### PR DESCRIPTION
The original idea was to --exclude=docs, but then I figured out we could also exclude .github, as well as .vscode, and my local build folder, etc. Soon enough it became obvious that using a whitelist makes more sense than a black list.

This affects only the development build done locally. This script is not used by CI. It is used only in two situations:
- When invoked directly because you want to build the deb in your machine
- When running the E2E tests without `$env:UP4W_TEST_BUILD_PATH`. (The CI does assign it, so this script is not used).