### PR TITLE
fix: only start the unit in WSL

### DIFF
--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Bridge to Ubuntu Pro agent on Windows
+ConditionVirtualization=wsl
 
 [Service]
 Type=notify


### PR DESCRIPTION
This a WSL only unit and it must not start in other environments.