### PR TITLE
ci: Pin build-debian to mantic

### DIFF
--- a/.github/deb-build-docker/Dockerfile
+++ b/.github/deb-build-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:devel
+FROM ubuntu:mantic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,5 +11,5 @@ RUN \
    add-apt-repository -y --ppa ppa:ubuntu-wsl-dev/ppa && \
    sed -i "s#https#http#g" /etc/apt/sources.list.d/*
 
-FROM ubuntu:devel
+FROM ubuntu:mantic
 COPY --from=0 /etc/apt/sources.list.d/* /etc/apt/sources.list.d/


### PR DESCRIPTION
We need to pin the version until [our PPA](https://launchpad.net/~ubuntu-wsl-dev/+archive/ubuntu/ppa) is updated to noble. Just in general, it's best to pin the version, so as to make transitions more smooth and controlled.

As soon as we've updated our PPA, we should switch to `ubuntu:noble` and not `ubuntu:devel`, to avoid the issue we're facing now.