### PR TITLE
fix(docs): Fix paths in command line reference generate.yaml

### DIFF
--- a/windows-agent/generate/generate.yaml
+++ b/windows-agent/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../docs/07-windows-agent-command-line-reference.md
+  docs: ../docs/dev/07-windows-agent-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:

--- a/wsl-pro-service/generate/generate.yaml
+++ b/wsl-pro-service/generate/generate.yaml
@@ -1,7 +1,7 @@
 project-root: ".."
 docs:
   readme: README.md
-  docs: ../docs/08-wsl-pro-service-command-line-reference.md
+  docs: ../docs/dev/08-wsl-pro-service-command-line-reference.md
   man: generated/usr/share,
   completions: generated/usr/share
 i18n:


### PR DESCRIPTION
The command-line reference autogeneration was broken back in #457.

See an example workflow in the main branch: https://github.com/canonical/ubuntu-pro-for-windows/actions/runs/7489933356/job/20387682229



:)