### PR TITLE
feat(wsl-pro-service): Add systemd confinement restrictions to wsl-pro.service

### DIFF
--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -8,5 +8,26 @@ ExecStart=/usr/libexec/wsl-pro-service -vv
 Restart=always
 RestartSec=2s
 
+# Some daemon restrictions
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=true
+PrivateDevices=yes
+PrivateMounts=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+
+# Only permit system calls used by common system services, excluding any special purpose calls
+SystemCallFilter=@system-service
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I took the service file from https://github.com/ubuntu/authd/blob/main/systemd/authd.service and made a couple changes:

1. Remove `ProcSubset=pid` as we need to access `/proc/mounts` to find the Windows filesystem, and `/proc/net/route` for the default gateway.
2. Remove `CapabilityBoundingSet=CAP_CHOWN` as it broke `landscape-config`.

---

UDENG-1884
