### PR TITLE
fix(end-to-end): Run end-to-end tests on Ubuntu-Preview

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -128,7 +128,7 @@ jobs:
       - name: Set up Ubuntu
         uses: Ubuntu/WSL/.github/actions/wsl-install@main
         with:
-          distro: "Ubuntu"
+          distro: "Ubuntu-Preview"
       - name: Set up Go
         # actions/setup-go is broken
         shell: powershell

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -50,10 +50,10 @@ const (
 	prebuiltPath = "UP4W_TEST_BUILD_PATH"
 
 	// referenceDistro is the WSL distro that will be used to generate the test image.
-	referenceDistro = "Ubuntu"
+	referenceDistro = "Ubuntu-Preview"
 
 	// referenceDistro is the WSL distro that will be used to generate the test image.
-	referenceDistroAppx = "CanonicalGroupLimited.Ubuntu"
+	referenceDistroAppx = "CanonicalGroupLimited.UbuntuPreview"
 
 	// up4wAppxPackage is the Ubuntu Pro For Windows package.
 	up4wAppxPackage = "CanonicalGroupLimited.UbuntuProForWindows"


### PR DESCRIPTION
So far the debian pkg was built in docker's Ubuntu:devel and the tests were run in Jammy. This worked...until it didn't, as now the pkg fails to install due to missing dependecies (it's surprising it worked for so long :D).

Anyways, this PR changes the end-to-end tests to use a Noble image rather than Jammy. We do this by using Ubuntu-Preview instead of Ubutu.