### PR TITLE
fix(landscape): Landscape reconnect signal does nothing

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -798,6 +798,7 @@ golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=
 golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
+golang.org/x/net v0.16.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.4.0/go.mod h1:RznEsdpjGAINPTOF0UH/t+xJ75L18YO3Ho6Pyn+uRec=

--- a/mocks/landscape/landscapemockservice/landscape_mock_service.go
+++ b/mocks/landscape/landscapemockservice/landscape_mock_service.go
@@ -247,6 +247,10 @@ func (s *Service) firstContact(ctx context.Context, cancel func(), hostInfo Host
 
 	return hostInfo.UID, func() {
 		cancel()
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
 		*h.connected = false
 	}, nil
 }

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -19,6 +19,8 @@ import (
 // a new connection needs to be constructed. Holds no data, but has the methods to send info to
 // Landscape, and redirects the received commands to the executor.
 type connection struct {
+	settings connectionSettings
+
 	ctx    context.Context
 	cancel func()
 
@@ -27,6 +29,20 @@ type connection struct {
 	once       sync.Once
 
 	receivingCommands sync.WaitGroup
+}
+
+// connectionSettings contains data that is immutable for a connection.
+// A change of these settings requires a reconnect.
+type connectionSettings struct {
+	url             string
+	certificatePath string
+}
+
+func newConnectionSettings(c landscapeHostConf) connectionSettings {
+	return connectionSettings{
+		url:             c.hostagentURL,
+		certificatePath: c.sslPublicKey,
+	}
 }
 
 // newConnection attempts to connect to the Landscape server, and blocks until the first
@@ -42,28 +58,32 @@ func newConnection(ctx context.Context, d serviceData) (conn *connection, err er
 		return nil, errors.New("no hostagent URL provided in the Landscape configuration")
 	}
 
-	conn = &connection{}
-
 	// A context to control the Landscape client with (needed for as long as the connection lasts)
-	conn.ctx, conn.cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+
+	conn = &connection{
+		settings: newConnectionSettings(conf),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+
+	creds, err := transportCredentials(conn.settings.certificatePath)
+	if err != nil {
+		return nil, err
+	}
 
 	// A context to control only the Dial (only needed for this function)
 	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	creds, err := conf.transportCredentials()
-	if err != nil {
-		return nil, err
-	}
-
-	grpcConn, err := grpc.DialContext(dialCtx, conf.hostagentURL, grpc.WithTransportCredentials(creds))
+	grpcConn, err := grpc.DialContext(dialCtx, conn.settings.url, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, err
 	}
 	conn.grpcConn = grpcConn
 
 	cl := landscapeapi.NewLandscapeHostAgentClient(grpcConn)
-	client, err := cl.Connect(conn.ctx)
+	client, err := cl.Connect(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +96,9 @@ func newConnection(ctx context.Context, d serviceData) (conn *connection, err er
 		defer conn.receivingCommands.Done()
 
 		if err := conn.receiveCommands(executor{d}); err != nil {
-			log.Warningf(conn.ctx, "Stopped listening for Landscape commands: %v", err)
+			log.Warningf(ctx, "Stopped listening for Landscape commands: %v", err)
 		} else {
-			log.Info(conn.ctx, "Finished listening for Landscape commands.")
+			log.Info(ctx, "Finished listening for Landscape commands.")
 		}
 	}()
 

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -156,14 +156,7 @@ func (conn *connection) connected() bool {
 		return false
 	}
 
-	switch conn.grpcConn.GetState() {
-	case connectivity.Idle:
-		return false
-	case connectivity.Shutdown:
-		return false
-	}
-
-	return true
+	return conn.grpcConn.GetState() == connectivity.Ready
 }
 
 // disconnect stops the connection and releases resources.

--- a/windows-agent/internal/proservices/landscape/controller.go
+++ b/windows-agent/internal/proservices/landscape/controller.go
@@ -29,6 +29,12 @@ func (c Controller) SendUpdatedInfo(ctx context.Context) error {
 	return c.sendInfo(info)
 }
 
+// Reconnect makes Landscape drop its current connection and start a new one.
+// Blocks until the new connection is available (or failed).
+func (c Controller) Reconnect(ctx context.Context) (succcess bool) {
+	return c.forceReconnect(ctx)
+}
+
 // tryReconnect sends a "please, connect" signal to the Landscape client and blocks until
 // this connection is established, or until the context is canceled. Returns true if the
 // connection was successfully established.

--- a/windows-agent/internal/proservices/landscape/controller.go
+++ b/windows-agent/internal/proservices/landscape/controller.go
@@ -34,33 +34,48 @@ func (c Controller) SendUpdatedInfo(ctx context.Context) error {
 // connection was successfully established.
 func (c Controller) tryReconnect(ctx context.Context) bool {
 	if c.connected() {
-		// Fast path: connection already exists
 		return true
 	}
 
-	select {
-	case <-ctx.Done():
-		return false
-	case <-c.hasStopped():
-		return false
-	case <-c.signalRetryConnection():
-	}
+	return c.forceReconnect(ctx)
+}
 
-	// Petition to reconnect went through, we now wait until it completes
-	ticker := time.NewTicker(time.Second)
+func (c Controller) forceReconnect(ctx context.Context) bool {
+	c.reconnect()
+
+	// Wait until disconnection
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {
-		if c.connected() {
-			return true
-		}
-
 		select {
 		case <-ctx.Done():
 			return false
 		case <-c.hasStopped():
 			return false
 		case <-ticker.C:
+		}
+
+		if !c.connected() {
+			break
+		}
+	}
+
+	// Waiting until re-connection
+	ticker = time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-c.hasStopped():
+			return false
+		case <-ticker.C:
+		}
+
+		if c.connected() {
+			return true
 		}
 	}
 }

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -487,10 +487,10 @@ func testReceiveCommand(t *testing.T, distrosettings distroSettings, testSetup f
 	}
 
 	// Set up Landscape client
-	clientService, err := landscape.New(tb.conf, tb.db, landscape.WithHostname("HOSTNAME"))
+	clientService, err := landscape.New(ctx, tb.conf, tb.db, landscape.WithHostname("HOSTNAME"))
 	require.NoError(t, err, "Landscape NewClient should not return an error")
 
-	err = clientService.Connect(ctx)
+	err = clientService.Connect()
 	require.NoError(t, err, "Setup: Connect should return no errors")
 
 	tb.clientService = clientService

--- a/windows-agent/internal/proservices/landscape/interfaces.go
+++ b/windows-agent/internal/proservices/landscape/interfaces.go
@@ -19,6 +19,6 @@ type serviceData interface {
 // serviceConn is an internal interface to manage the connection to the Landscape service.
 type serviceConn interface {
 	connected() bool
-	signalRetryConnection() <-chan struct{}
+	reconnect()
 	sendInfo(*landscapeapi.HostAgentInfo) error
 }

--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -548,9 +548,7 @@ func TestReconnect(t *testing.T) {
 	changeAddress := func(ctx context.Context, s *landscape.Service, c *mockConfig) {
 		// We change the address to an equivalent one, so that the reconnect is triggered abd the connection succeeds
 		c.mu.Lock()
-		fmt.Println(c.landscapeClientConfig)
 		c.landscapeClientConfig = strings.ReplaceAll(c.landscapeClientConfig, "127.0.0.1", "localhost")
-		fmt.Println(c.landscapeClientConfig)
 		c.mu.Unlock()
 
 		c.triggerNotifications()
@@ -639,8 +637,6 @@ func TestReconnect(t *testing.T) {
 				tc.trigger(ctx, service, conf)
 				close(ch)
 			}()
-
-			fmt.Println("AAAAAAAAA")
 
 			const timeout = 10 * time.Second
 			const tickRate = 100 * time.Millisecond

--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -546,7 +546,7 @@ func TestReconnect(t *testing.T) {
 	}
 
 	changeAddress := func(ctx context.Context, s *landscape.Service, c *mockConfig) {
-		// We change the address to an equivalent one, so that the reconnect is triggered abd the connection succeeds
+		// We change the address to an equivalent one, so that the reconnect is triggered and the connection succeeds
 		c.mu.Lock()
 		c.landscapeClientConfig = strings.ReplaceAll(c.landscapeClientConfig, "127.0.0.1", "localhost")
 		c.mu.Unlock()

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -14,17 +14,18 @@ import (
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/database"
 	log "github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/grpc/logstreamer"
 	"github.com/ubuntu/decorate"
+	"google.golang.org/grpc/connectivity"
 )
 
 // Service orquestrates the Landscape hostagent connection. It lasts for the entire lifetime of the program.
 // It creates the executor and ensures there is always an active connection, creating a new one otherwise.
 type Service struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	running chan struct{}
+
 	db   *database.DistroDB
 	conf Config
-
-	// stopped indicates that the Client has been stopped and is no longer usable
-	stopped chan struct{}
-	once    sync.Once
 
 	// Cached hostName
 	hostName string
@@ -33,10 +34,10 @@ type Service struct {
 	conn   *connection
 	connMu sync.RWMutex
 
-	// retryConnection is used in order to ask the keepConnected
+	// connRetrier is used in order to ask the keepConnected
 	// function to try again now (instead of waiting for the retrial
 	// time). Do not use directly. Instead use signalRetryConnection().
-	retryConnection chan struct{}
+	connRetrier *retryConnection
 }
 
 // Config is a configuration provider for ProToken and the Landscape URL.
@@ -57,7 +58,7 @@ type options struct {
 type Option = func(*options)
 
 // New creates a new Landscape service object.
-func New(conf Config, db *database.DistroDB, args ...Option) (*Service, error) {
+func New(ctx context.Context, conf Config, db *database.DistroDB, args ...Option) (*Service, error) {
 	var opts options
 
 	for _, f := range args {
@@ -72,122 +73,143 @@ func New(conf Config, db *database.DistroDB, args ...Option) (*Service, error) {
 		opts.hostname = hostname
 	}
 
-	c := &Service{
-		conf:            conf,
-		db:              db,
-		hostName:        opts.hostname,
-		stopped:         make(chan struct{}),
-		retryConnection: make(chan struct{}),
+	ctx, cancel := context.WithCancel(ctx)
+
+	s := &Service{
+		ctx:         ctx,
+		cancel:      cancel,
+		conf:        conf,
+		db:          db,
+		hostName:    opts.hostname,
+		connRetrier: newRetryConnection(),
 	}
 
-	return c, nil
+	return s, nil
 }
 
 // Connect starts the connection and starts talking to the server.
 // Call Stop to deallocate resources.
-func (s *Service) Connect(ctx context.Context) (err error) {
+func (s *Service) Connect() (err error) {
 	defer decorate.OnError(&err, "could not connect to Landscape")
 
 	if s.connected() {
 		return errors.New("already connected")
 	}
 
-	// Dummy connection to indicate that a first attempt was attempted
-	s.conn = &connection{}
-
-	defer func() {
-		go s.keepConnected(ctx)
-	}()
-
-	// First connection
-	conn, err := s.newConnection(ctx)
-	if err != nil {
-		return err
-	}
-
-	s.connMu.Lock()
-	s.conn = conn
-	s.connMu.Unlock()
-
-	return nil
+	return s.keepConnected()
 }
 
-// keepConnected supervises the connection. If it drops, reconnection is attempted.
-func (s *Service) keepConnected(ctx context.Context) {
+// keepConnected supervises the connection. It attempts connecting before returning.
+// The connection will be re-created if:
+// - the active one drops.
+// - a reconnection is requested via connRetrier.
+func (s *Service) keepConnected() error {
 	const growthFactor = 2
 	const minWait = time.Second
 	const maxWait = 10 * time.Minute
-	wait := time.Second
+	wait := 0 * time.Second // No wait in the first iteration
 
-	// The loop body is inside this function so that defers can be used
-	keepLoooping := true
-	for keepLoooping {
-		keepLoooping = func() (keepLooping bool) {
-			// Using a timer rather than a time.After to avoid leaking
-			// the timer for up to $maxWait.
-			tk := time.NewTimer(wait)
-			defer tk.Stop()
+	s.running = make(chan struct{})
+	started := make(chan error)
+
+	go func() {
+		defer close(s.running)
+
+		defer s.disconnect()
+		first := true
+
+		for {
+			// Waiting before reconnecting
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-s.connRetrier.Await():
+			case <-time.After(wait):
+			}
+
+			log.Info(s.ctx, "Landscape: connecting")
+			connectionDone, err := s.connectOnce(s.ctx)
+
+			if first {
+				started <- err
+				close(started)
+				wait = minWait
+				first = false
+			}
+
+			if err != nil {
+				log.Warningf(s.ctx, "Landscape: %v", err)
+				continue
+			}
+
+			log.Info(s.ctx, "Landscape: connected")
 
 			select {
-			case <-tk.C:
-				wait = min(growthFactor*wait, maxWait)
-			case <-s.retryConnection:
+			case <-s.ctx.Done():
+				log.Info(s.ctx, "Landscape: connection stopped by context")
+				return
+			case <-s.connRetrier.Await():
+				log.Infof(s.ctx, "Landscape: reconnection requested: reconnecting in %d seconds", wait/time.Second)
+				s.connRetrier.Reset()
+				s.disconnect()
 				wait = minWait
-			case <-s.stopped:
-				// Stop was called
-				return false
+			case <-connectionDone:
+				log.Infof(s.ctx, "Landscape: connection dropped: reconnecting in %d seconds", wait/time.Second)
+				wait = min(growthFactor*wait, maxWait)
 			}
+		}
+	}()
 
-			s.connMu.Lock()
-			defer s.connMu.Unlock()
-
-			// We don't want a queue of petitions to form. It does not matter why
-			// we are retrying: just by virtue of retrying we are fulfilling all
-			// requests at once. Hence, we close and reopen to unblock all senders.
-			//
-			// This is why senders need to use this channel under the connMu mutex
-			// See the signalRetryConnection method.
-			close(s.retryConnection)
-			s.retryConnection = make(chan struct{})
-
-			if s.conn == nil {
-				// Stop was called
-				return false
-			}
-
-			if s.conn.connected() {
-				// Connection still active
-				return true
-			}
-
-			s.conn.disconnect()
-
-			conn, err := s.newConnection(ctx)
-			if err != nil {
-				log.Warningf(ctx, "Landscape reconnect: %v", err)
-				return true
-			}
-
-			s.conn = conn
-			wait = minWait
-			return true
-		}()
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	case err := <-started:
+		return err
 	}
+}
+
+func (s *Service) connectOnce(ctx context.Context) (<-chan struct{}, error) {
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+
+	if s.conn != nil {
+		s.conn.disconnect()
+		s.conn = nil
+	}
+
+	_, src, err := s.conf.Subscription(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("skipping connection: could not obtain Ubuntu Pro token: %v", err)
+	}
+	if src == config.SourceNone {
+		return nil, errors.New("skipping connection: no Ubuntu Pro token provided")
+	}
+
+	conn, err := newConnection(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+
+	connectionDone := make(chan struct{})
+	go func() {
+		defer close(connectionDone)
+		conn.grpcConn.WaitForStateChange(ctx, connectivity.Ready)
+	}()
+
+	s.connRetrier.Reset()
+	s.conn = conn
+	return connectionDone, nil
 }
 
 // Stop terminates the connection and deallocates resources.
 func (s *Service) Stop(ctx context.Context) {
-	s.once.Do(func() {
-		close(s.stopped)
+	s.cancel()
+	s.connRetrier.Stop()
 
-		s.connMu.Lock()
-		defer s.connMu.Unlock()
-
-		if s.conn != nil {
-			s.conn.disconnect()
-			s.conn = nil
-		}
-	})
+	select {
+	case <-s.running:
+	case <-ctx.Done():
+	}
 }
 
 // Controller creates a controler for this service.
@@ -198,21 +220,12 @@ func (s *Service) Controller() Controller {
 	}
 }
 
-// newConnection validates we meet necessary client-side requirements before
-// starting a new connection to Landscape.
-//
-// Doing this avoids overloading the server with connections that will be
-// immediately rejected.
-func (s *Service) newConnection(ctx context.Context) (*connection, error) {
-	_, src, err := s.conf.Subscription(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not obtain Ubuntu Pro token: %v", err)
+func (s *Service) disconnect() {
+	s.connMu.Lock()
+	if s.conn != nil {
+		s.conn.disconnect()
 	}
-	if src == config.SourceNone {
-		return nil, errors.New("no Ubuntu Pro token provided")
-	}
-
-	return newConnection(ctx, s)
+	s.connMu.Unlock()
 }
 
 // The following methods expose some internals for the other components to use.
@@ -220,15 +233,12 @@ func (s *Service) newConnection(ctx context.Context) (*connection, error) {
 // signalRetryConnection signals the Landscape client to attempt to connect to Landscape.
 // It will not block if there is an ative connection. until the reconnect petition
 // has been received.
-func (s *Service) signalRetryConnection() <-chan struct{} {
-	s.connMu.Lock()
-	defer s.connMu.Unlock()
-
-	return s.retryConnection
+func (s *Service) reconnect() {
+	s.connRetrier.Request()
 }
 
 func (s *Service) hasStopped() <-chan struct{} {
-	return s.stopped
+	return s.ctx.Done()
 }
 
 func (s *Service) config() Config {

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -82,14 +82,14 @@ func newHostAgentInfo(ctx context.Context, c serviceData) (info *landscapeapi.Ho
 //
 // If this credential is not specified, an insecure credential is returned.
 // If the credential is specified but erroneous, an error is returned.
-func (conf landscapeHostConf) transportCredentials() (cred credentials.TransportCredentials, err error) {
+func transportCredentials(sslPublicKeyPath string) (cred credentials.TransportCredentials, err error) {
 	defer decorate.OnError(&err, "Landscape credentials")
 
-	if conf.sslPublicKey == "" {
+	if sslPublicKeyPath == "" {
 		return insecure.NewCredentials(), nil
 	}
 
-	cert, err := os.ReadFile(conf.sslPublicKey)
+	cert, err := os.ReadFile(sslPublicKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not load SSL public key file: %v", err)
 	}

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -83,12 +83,12 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 
 	uiService := ui.New(ctx, conf, db)
 
-	landscape, err := landscape.New(conf, db)
+	landscape, err := landscape.New(ctx, conf, db)
 	if err != nil {
 		return s, err
 	}
 
-	if err := landscape.Connect(ctx); err != nil {
+	if err := landscape.Connect(); err != nil {
 		log.Warningf(ctx, err.Error())
 	}
 


### PR DESCRIPTION
It just doesn't work.

This PR does multiple things around reconnection:
1. Fix the signal so that the Controller can ask Landscape to reconnect. (UDENG-2195)
2. Improve the way the connection is monitored, and restart it if it fails.
3. Implement a notification system in Config. Use this to reconnect to Landscape every time the relevant config is changed (UDENG-2196).