### PR TITLE
feat(config): Implement notification system for Config

### DIFF
--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -47,7 +47,7 @@ func New(ctx context.Context, cachePath string) (m *Config) {
 	return m
 }
 
-// Notify appends a callback. It'll be called very time any configuration changes.
+// Notify appends a callback. It'll be called every time any configuration changes.
 func (c *Config) Notify(f func()) {
 	c.notifiers = append(c.notifiers, f)
 }

--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -32,6 +32,9 @@ type Config struct {
 
 	// Sync
 	mu *sync.Mutex
+
+	// notifiers are called after any configuration changes.
+	notifiers []func()
 }
 
 // New creates and initializes a new Config object.
@@ -42,6 +45,11 @@ func New(ctx context.Context, cachePath string) (m *Config) {
 	}
 
 	return m
+}
+
+// Notify appends a callback. It'll be called very time any configuration changes.
+func (c *Config) Notify(f func()) {
+	c.notifiers = append(c.notifiers, f)
 }
 
 // Subscription returns the ProToken and the method it was acquired with (if any).
@@ -129,6 +137,10 @@ func (c *Config) set(ctx context.Context, field *string, value string) error {
 
 	old := *field
 	*field = value
+
+	for _, f := range c.notifiers {
+		go f()
+	}
 
 	if err := c.dump(); err != nil {
 		log.Errorf(ctx, "Could not update settings: %v", err)
@@ -248,6 +260,10 @@ func (c *Config) collectRegistrySettingsTasks(ctx context.Context, data Registry
 
 	if errs != nil {
 		log.Warningf(ctx, "Could not obtain some updated registry settings: %v", errs)
+	}
+
+	for _, f := range c.notifiers {
+		go f()
 	}
 
 	// Dump updated checksums


### PR DESCRIPTION
I want cloud-init & landscape to be pinged by the config every time something changes. However, I don't want these two utilities to be dependencies of config. If anything, I want the dependency the other way around! Cloud-init and Landscape should import config.

So I must somehow call these utilities from the config without importing them. My solution: callbacks. Any utility can now wait on config changes by using:

```go
conf.Notify(func() {
    fmt.Println("Hello, world")
})
```
and this function will be called every time the config is changed (via GUI, registry, or any future methods).

This is used in Landscape #515 and Cloud-init #506.