### PR TITLE
maint(wsl-pro-service): Get rid of -parallel=4 in debian test rules

### DIFF
--- a/wsl-pro-service/debian/rules
+++ b/wsl-pro-service/debian/rules
@@ -23,7 +23,7 @@ override_dh_auto_install:
 	mv debian/wsl-pro-service/usr/bin/ debian/wsl-pro-service/usr/libexec/
 
 override_dh_auto_test:
-	cd _build && GOWORK=off go test -mod=vendor -parallel=4 github.com/canonical/ubuntu-pro-for-windows/wsl-pro-service/...
+	cd _build && GOWORK=off go test -mod=vendor github.com/canonical/ubuntu-pro-for-windows/wsl-pro-service/...
 
 # dwz does not support golang binaries yet
 override_dh_dwz:


### PR DESCRIPTION
This flag existed because we thought the OOM was killing our tests. We discovered that was not the case and solved it in ef8c055. This means that this flag unnecessary.