### PR TITLE
maint: Create ubuntupro dir and move address file inside of it

### DIFF
--- a/common/consts.go
+++ b/common/consts.go
@@ -14,7 +14,7 @@ const (
 	UserProfileDir = ".ubuntupro"
 
 	// ListeningPortFileName corresponds to the base name of the file hosting the addressing of our GRPC server.
-	ListeningPortFileName = ".ubuntupro"
+	ListeningPortFileName = ".address"
 
 	// MsStoreProductID is the ID of the product in the Microsoft Store
 	//

--- a/common/consts.go
+++ b/common/consts.go
@@ -5,9 +5,13 @@ const (
 	// TEXTDOMAIN is the gettext domain for l10n.
 	TEXTDOMAIN = `ubuntu-pro`
 
-	// LocalAppDataDir is the relative path name used in user's cache dir to store process transient data.
+	// LocalAppDataDir is the relative path name used to store data private to the Appx.
 	//  ${env:LocalAppData}/{LocalAppDataDir}
 	LocalAppDataDir = "Ubuntu Pro"
+
+	// UserProfileDir is the relative path name used to store data that needs to be shared between components.
+	//  ${env:UserProfile}/{UserProfileDir}
+	UserProfileDir = ".ubuntupro"
 
 	// ListeningPortFileName corresponds to the base name of the file hosting the addressing of our GRPC server.
 	ListeningPortFileName = ".ubuntupro"

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -280,8 +280,8 @@ func filesToCleanUp() ([]string, error) {
 		prefixEnv string
 		path      string
 	}{
-		{prefixEnv: "LocalAppData", path: "Ubuntu Pro"},
-		{prefixEnv: "UserProfile", path: ".ubuntupro"},
+		{prefixEnv: "LocalAppData", path: common.LocalAppDataDir},
+		{prefixEnv: "UserProfile", path: common.UserProfileDir},
 	}
 
 	var out []string

--- a/end-to-end/utils_test.go
+++ b/end-to-end/utils_test.go
@@ -121,7 +121,7 @@ func startAgent(t *testing.T, ctx context.Context, arg string, environ ...string
 	require.NotEmptyf(t, home, "Agent setup: $env:UserProfile should not be empty")
 
 	require.Eventually(t, func() bool {
-		_, err := os.Stat(filepath.Join(home, ".ubuntupro"))
+		_, err := os.Stat(filepath.Join(home, common.UserProfileDir, common.ListeningPortFileName))
 		if errors.Is(err, fs.ErrNotExist) {
 			return false
 		}

--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -89,7 +89,7 @@ void main() {
             [p.basenameWithoutExtension(agentImageName)],
           );
         }
-        File(p.join(tmpHome!.path, '.ubuntupro')).deleteSync();
+        File(p.join(tmpHome!.path, '.ubuntupro/.address')).deleteSync();
       });
 
       tearDownAll(() async {

--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -2,7 +2,7 @@
 const kDefaultHost = '127.0.0.1';
 
 /// The name of the file where the Agent's drop its service connection information.
-const kAddrFileName = '.ubuntupro';
+const kAddrFileName = '.ubuntupro/.address';
 
 /// The default border margin.
 const kDefaultMargin = 32.0;

--- a/gui/packages/ubuntupro/lib/pages/startup/agent_monitor.dart
+++ b/gui/packages/ubuntupro/lib/pages/startup/agent_monitor.dart
@@ -131,7 +131,8 @@ class AgentStartupMonitor {
         final agentDir =
             await File(_addrFilePath!).parent.create(recursive: true);
         final watch = agentDir.watch(events: FileSystemEvent.create).firstWhere(
-              (event) => p.normalize(event.path) == p.normalize(_addrFilePath!),
+              (event) =>
+                  p.canonicalize(event.path) == p.canonicalize(_addrFilePath!),
             );
         if (!await agentLauncher()) {
           // Terminal state, cannot recover nor retry.

--- a/gui/packages/ubuntupro/lib/pages/startup/startup_model.dart
+++ b/gui/packages/ubuntupro/lib/pages/startup/startup_model.dart
@@ -62,8 +62,8 @@ class StartupModel extends ChangeNotifier {
     return completer.future;
   }
 
-  /// Assumes the agent crashed, i.e. the `.ubuntupro` file exists but the agent cannot respond to PING requets.
-  /// Thus, we delete the existing `.ubuntupro` file and try launching the agent.
+  /// Assumes the agent crashed, i.e. the address file exists but the agent cannot respond to PING requets.
+  /// Thus, we delete the existing address file and try launching the agent.
   Future<void> resetAgent() async {
     assert(
       _view == ViewState.retry,

--- a/gui/packages/ubuntupro/test/core/agent_api_paths_part4_test.dart
+++ b/gui/packages/ubuntupro/test/core/agent_api_paths_part4_test.dart
@@ -11,7 +11,7 @@ void main() {
   final _ = Environment(overrides: {'LOCALAPPDATA': null, 'USERPROFILE': null});
 
   test('complete failure due environment', () {
-    final dir = agentAddrFilePath('.ubuntupro');
+    final dir = agentAddrFilePath('.ubuntupro/.address');
 
     expect(dir, isNull);
   });

--- a/gui/packages/ubuntupro/test/core/agent_api_paths_test.dart
+++ b/gui/packages/ubuntupro/test/core/agent_api_paths_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntupro/core/agent_api_paths.dart';
 
 void main() {
-  tearDownAll(() => File('./.ubuntupro').deleteSync());
+  tearDownAll(() => File('./.address').deleteSync());
 
   test('read port from line', () {
     const port = 56768;
@@ -28,7 +28,7 @@ void main() {
   });
 
   test('read port from addr file', () async {
-    const filePath = './.ubuntupro';
+    const filePath = './.address';
     const port = 56768;
     const line = '[::]:$port';
     final addr = File(filePath);
@@ -50,7 +50,7 @@ void main() {
   });
 
   test('empty file', () async {
-    const filePath = './.ubuntupro';
+    const filePath = './.address';
     final addr = File(filePath);
     addr.writeAsStringSync('');
 
@@ -61,7 +61,7 @@ void main() {
   });
 
   test('access denied', () async {
-    const filePath = './.ubuntupro';
+    const filePath = './.address';
     final addr = File(filePath);
     addr.writeAsStringSync('');
 
@@ -77,7 +77,7 @@ void main() {
   });
 
   test('bad format', () async {
-    const filePath = './.ubuntupro';
+    const filePath = './.address';
     const port = 56768;
     const line = 'Hello World $port';
     final addr = File(filePath);

--- a/gui/packages/ubuntupro/test/startup/agent_monitor_test.dart
+++ b/gui/packages/ubuntupro/test/startup/agent_monitor_test.dart
@@ -257,13 +257,14 @@ void main() {
   });
 }
 
-/// Writes a sample `.ubuntupro` file to the destination containing either a proper
+/// Writes a sample address file to the destination containing either a proper
 /// contents as if the agent would have written it or [line], if supplied.
-void writeDummyAddrFile(Directory appDir, {String? line}) {
-  final filePath = p.join(appDir.path, '.ubuntupro');
+void writeDummyAddrFile(Directory homeDir, {String? line}) {
+  final filePath = p.join(homeDir.path, kAddrFileName);
   const port = 56789;
   const goodLine = '[::]:$port';
   final addr = File(filePath);
+  addr.parent.createSync(recursive: true);
   addr.writeAsStringSync(line ?? goodLine);
   addTearDown(addr.deleteSync);
 }

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -133,13 +133,13 @@ func (a *App) serve(args ...option) error {
 }
 
 func setupDirectories(ctx context.Context, opt *options) (public, private string, err error) {
-	public, err = vauleOrAfterEnv(opt.publicDir, "UserProfile", common.LocalAppDataDir)
+	public, err = valueOrAfterEnv(opt.publicDir, "UserProfile", common.LocalAppDataDir)
 	if err != nil {
 		return "", "", err
 	}
 	log.Debugf(ctx, "Agent public directory: %s", public)
 
-	private, err = vauleOrAfterEnv(opt.privateDir, "LocalAppData", common.UserProfileDir)
+	private, err = valueOrAfterEnv(opt.privateDir, "LocalAppData", common.UserProfileDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -156,9 +156,9 @@ func setupDirectories(ctx context.Context, opt *options) (public, private string
 	return public, private, nil
 }
 
-// vauleOrAfterEnv is a helper for parsing optional inputs.
-// Returns "intput" if it is non-empty. Otherwise it returns "${env}/relative".
-func vauleOrAfterEnv(input string, env string, relative string) (string, error) {
+// valueOrAfterEnv is a helper for parsing optional inputs.
+// Returns "input" if it is non-empty. Otherwise it returns "${env}/relative".
+func valueOrAfterEnv(input string, env string, relative string) (string, error) {
 	if input != "" {
 		return input, nil
 	}

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -133,13 +133,13 @@ func (a *App) serve(args ...option) error {
 }
 
 func setupDirectories(ctx context.Context, opt *options) (public, private string, err error) {
-	public, err = valueOrAfterEnv(opt.publicDir, "UserProfile", common.LocalAppDataDir)
+	public, err = valueOrAfterEnv(opt.publicDir, "UserProfile", common.UserProfileDir)
 	if err != nil {
 		return "", "", err
 	}
 	log.Debugf(ctx, "Agent public directory: %s", public)
 
-	private, err = valueOrAfterEnv(opt.privateDir, "LocalAppData", common.UserProfileDir)
+	private, err = valueOrAfterEnv(opt.privateDir, "LocalAppData", common.LocalAppDataDir)
 	if err != nil {
 		return "", "", err
 	}

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
@@ -7,37 +7,35 @@ import (
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/registrywatcher/registry"
 )
 
-func withDaemonAddrDir(dir string) func(*options) {
+func WithPublicDir(dir string) func(*options) {
 	return func(o *options) {
-		o.daemonAddrDir = dir
+		o.publicDir = dir
 	}
 }
 
-func withProServicesCacheDir(dir string) func(*options) {
+func WithPrivateDir(dir string) func(*options) {
 	return func(o *options) {
-		o.proservicesCacheDir = dir
+		o.privateDir = dir
 	}
 }
 
-func withRegistry(r registrywatcher.Registry) func(*options) {
+func WithRegistry(r registrywatcher.Registry) func(*options) {
 	return func(o *options) {
 		o.registry = r
 	}
 }
 
 // NewForTesting creates a new App with overridden paths for the service and daemon caches.
-func NewForTesting(t *testing.T, daemonAddrDir, serviceCacheDir string) *App {
+func NewForTesting(t *testing.T, publicDir, privateDir string) *App {
 	t.Helper()
 
-	if daemonAddrDir == "" && serviceCacheDir == "" {
-		// Common temp cache directory
-		daemonAddrDir = t.TempDir()
-		serviceCacheDir = daemonAddrDir
-	} else if daemonAddrDir == "" {
-		daemonAddrDir = t.TempDir()
-	} else if serviceCacheDir == "" {
-		serviceCacheDir = t.TempDir()
+	if publicDir == "" {
+		publicDir = t.TempDir()
 	}
 
-	return New(withProServicesCacheDir(serviceCacheDir), withDaemonAddrDir(daemonAddrDir), withRegistry(registry.NewMock()))
+	if privateDir == "" {
+		privateDir = t.TempDir()
+	}
+
+	return New(WithPrivateDir(privateDir), WithPublicDir(publicDir), WithRegistry(registry.NewMock()))
 }

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -59,10 +59,7 @@ func (d Daemon) Serve(ctx context.Context) (err error) {
 
 	// Write a file on disk to signal selected ports to clients.
 	// We write it here to signal error when calling service.Start().
-	if err := os.WriteFile(d.listeningPortFilePath+".new", []byte(addr), 0600); err != nil {
-		return err
-	}
-	if err := os.Rename(d.listeningPortFilePath+".new", d.listeningPortFilePath); err != nil {
+	if err := os.WriteFile(d.listeningPortFilePath, []byte(addr), 0600); err != nil {
 		return err
 	}
 	defer os.Remove(d.listeningPortFilePath)

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -61,7 +61,7 @@ func TestNew(t *testing.T) {
 				require.NoError(t, err, "Setup: could not write directory where database wants to put a file")
 			}
 
-			s, err := proservices.New(ctx, proservices.WithCacheDir(dir), proservices.WithRegistry(reg))
+			s, err := proservices.New(ctx, proservices.WithPrivateDir(dir), proservices.WithRegistry(reg))
 			if err == nil {
 				defer s.Stop(ctx)
 			}
@@ -81,7 +81,7 @@ func TestRegisterGRPCServices(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	ps, err := proservices.New(ctx, proservices.WithCacheDir(t.TempDir()), proservices.WithRegistry(registry.NewMock()))
+	ps, err := proservices.New(ctx, proservices.WithPrivateDir(t.TempDir()), proservices.WithRegistry(registry.NewMock()))
 	require.NoError(t, err, "Setup: New should return no error")
 	defer ps.Stop(ctx)
 

--- a/wsl-pro-service/go.mod
+++ b/wsl-pro-service/go.mod
@@ -5,9 +5,9 @@ go 1.21.0
 toolchain go1.21.5
 
 require (
-	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240131151255-f872a5c016b8
-	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240131151255-f872a5c016b8
-	github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240131151255-f872a5c016b8
+	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240201115117-8927d8283043
+	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240201115117-8927d8283043
+	github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240201115117-8927d8283043
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0

--- a/wsl-pro-service/go.sum
+++ b/wsl-pro-service/go.sum
@@ -1,9 +1,9 @@
-github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240131151255-f872a5c016b8 h1:1Ir4ukrItEe//kc4wZjvNg/I821y4Ar/0OYpAntr2f0=
-github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240131151255-f872a5c016b8/go.mod h1:ClPG5bBGtW4rfh4AAvqGILeCdwYLHPcbxmh44KLKo9c=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240131151255-f872a5c016b8 h1:qmUbKmeCi3wyzLsu8d+74EsrXnmW1hJflO/JcApqRHI=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240131151255-f872a5c016b8/go.mod h1:IaCk16F1RcAoIsgFv0+4h9/1uXZ/PjDrKTk8UKBQiTY=
-github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240131151255-f872a5c016b8 h1:QrRVJRF3sNwPOjE8u7xxgrKqyu0Wos7nNPe6Lvc80bA=
-github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240131151255-f872a5c016b8/go.mod h1:wWEX43zvkkyjeR+7pkxwI+27+wWtN5vuvW4AqYvHTn4=
+github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240201115117-8927d8283043 h1:OWCRELSA3a0iqS2o7cSAOXdjk6wGyQJOoEPgxlYrBuM=
+github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240201115117-8927d8283043/go.mod h1:ClPG5bBGtW4rfh4AAvqGILeCdwYLHPcbxmh44KLKo9c=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240201115117-8927d8283043 h1:I95zRwvmNN8n1/1aR9xb3UQDGxQ9soTgnMSdgzQEW8M=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240201115117-8927d8283043/go.mod h1:IaCk16F1RcAoIsgFv0+4h9/1uXZ/PjDrKTk8UKBQiTY=
+github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240201115117-8927d8283043 h1:Ayvhieh8CeRE4sjbxR172seQ912tI2fENN0c3YEintY=
+github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi v0.0.0-20240201115117-8927d8283043/go.mod h1:wWEX43zvkkyjeR+7pkxwI+27+wWtN5vuvW4AqYvHTn4=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/wsl-pro-service/internal/controlstream/controlstream.go
+++ b/wsl-pro-service/internal/controlstream/controlstream.go
@@ -47,7 +47,7 @@ func New(ctx context.Context, s system.System) (ControlStream, error) {
 	}
 
 	return ControlStream{
-		addrPath: filepath.Join(home, common.ListeningPortFileName),
+		addrPath: filepath.Join(home, common.UserProfileDir, common.ListeningPortFileName),
 		system:   s,
 	}, nil
 }

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -47,7 +47,7 @@ var (
 	linuxUserProfileDir   = "/mnt/d/Users/TestUser/"
 
 	// defaultAddrFile is the default path used in tests to store the address of the Windows Agent service.
-	defaultAddrFile = filepath.Join(linuxUserProfileDir, common.ListeningPortFileName)
+	defaultAddrFile = filepath.Join(linuxUserProfileDir, common.UserProfileDir, common.ListeningPortFileName)
 
 	//go:embed filesystem_defaults/os-release
 	defaultOsReleaseContents []byte


### PR DESCRIPTION
We'll soon have more "public" files (aka non restricted to the agent) due to the need to store cloud-init files. We'll put all these files inside `$env:UserProfile/.ubuntupro` to avoid filling the home directory with our garbage.

This PR does two things:
1. Refactor directory management in the agent to clarify this public vs. private distinction.
2. Move the address file into the public dir.
3. (bonus) fix a lot of things that broke as a consequence.

---

UDENG-2222