### PR TITLE
fix(gui-ubuntupro): Update GUI strings to proprosed desgin

### DIFF
--- a/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
+++ b/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
@@ -80,7 +80,7 @@ Future<void> testManualTokenInput(WidgetTester tester) async {
   await tester.pumpAndSettle();
 
   // submits the input.
-  final button = find.text(l10n.apply);
+  final button = find.text(l10n.confirm);
   await tester.tap(button);
   await tester.pumpAndSettle();
 

--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -126,7 +126,7 @@ void main() {
         await tester.pump();
 
         // submits the input.
-        final button = find.text(l10n.apply);
+        final button = find.text(l10n.confirm);
         await tester.tap(button);
         await tester.pumpAndSettle();
 

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -7,7 +7,7 @@
     "tokenErrorInvalidEncoding": "Token is corrupted",
     "tokenInputTitle": "Already have a token?",
     "tokenInputHint": "Paste your Ubuntu Pro token here",
-    "apply": "Confirm",
+    "confirm": "Confirm",
     "applyProToken": "Apply Pro Token",
     "applyingProToken": "Applying token {token}",
     "@applyingProToken": {

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -29,7 +29,7 @@
     "proHeading": "Open source software security by the publishers\nof Ubuntu, now available on Windows.",
     "subscribeNow": "Subscribe Now",
     "subscribeNowTooltipDisabled": "Coming soon",
-    "learnMore": "About Ubuntu Pro",
+    "about": "About Ubuntu Pro",
 
     "subscriptionIsActive": "Your subscription is active!",
     "storeManaged": "This subscription is managed through Microsoft Store.",

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -5,9 +5,9 @@
     "tokenErrorTooLong": "Token is too long",
     "tokenErrorInvalidPrefix": "Token prefix is invalid",
     "tokenErrorInvalidEncoding": "Token is corrupted",
-    "tokenInputTitle": "I already have a token",
-    "tokenInputHint": "Paste here your Ubuntu Pro token",
-    "apply": "Apply",
+    "tokenInputTitle": "Already have a token?",
+    "tokenInputHint": "Paste your Ubuntu Pro token here",
+    "apply": "Confirm",
     "applyProToken": "Apply Pro Token",
     "applyingProToken": "Applying token {token}",
     "@applyingProToken": {
@@ -26,15 +26,15 @@
     "agentStateQuerying": "Checking Ubuntu Pro background agent's state.",
     "agentStateUnreachable": "Attempting to recover Ubuntu Pro background agent.",
 
-    "proHeading": "The most comprehensive subscription\nfor open-source software security\nnow available on WSL",
+    "proHeading": "Open source software security by the publishers\nof Ubuntu, now available on Windows.",
     "subscribeNow": "Subscribe Now",
     "subscribeNowTooltipDisabled": "Coming soon",
-    "learnMore": "Learn More",
+    "learnMore": "About Ubuntu Pro",
 
     "subscriptionIsActive": "Your subscription is active!",
-    "storeManaged": "This subscription is managed through Microsoft Store",
+    "storeManaged": "This subscription is managed through Microsoft Store.",
     "manageSubscription": "Manage your subscription",
-    "orgManaged": "This subscription is owned and managed by your company",
+    "orgManaged": "This subscription is owned and managed by your organization.",
     "manuallyManaged": "Visit {proDashboardLink} to manage your subscription.",
     "@manuallyManaged": {
         "placeholders": {
@@ -43,7 +43,7 @@
             }
         }
     },
-    "detachPro": "Detach Pro",
+    "detachPro": "Detach Ubuntu Pro",
 
     "updatingSubscriptionInfo": "Updating the subscription information.",
     "purchaseStatusSuccess":"Thank you for subscribing to Ubuntu Pro.",
@@ -53,4 +53,3 @@
     "purchaseStatusServer":"Something went wrong with Microsoft Store. Please try again later.",
     "purchaseStatusUnknown": "Unknown error when trying to purchase the subscription. Consider restarting this app."
 }
-

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscribe_now_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscribe_now_page.dart
@@ -75,7 +75,7 @@ class SubscribeNowPage extends StatelessWidget {
                           const Color(0xff010101),
                         ),
                       ),
-              child: Text(lang.learnMore),
+              child: Text(lang.about),
             ),
           ],
         ),

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscribe_now_widgets.dart
@@ -81,7 +81,7 @@ class _ProTokenInputFieldState extends State<ProTokenInputField> {
                 // allows the suffix button to stand out when enabled while keeping its custom look.
                 foregroundColor: Theme.of(context).colorScheme.onSurface,
               ),
-              child: Text(lang.apply),
+              child: Text(lang.confirm),
             ),
           ),
           onChanged: _token.update,

--- a/gui/packages/ubuntupro/test/pages/subscription_status/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subscription_status/subscribe_now_page_test.dart
@@ -28,7 +28,7 @@ void main() {
     final lang = AppLocalizations.of(context);
 
     expect(called, isFalse);
-    final button = find.text(lang.learnMore);
+    final button = find.text(lang.about);
     await tester.tap(button);
     await tester.pump();
     expect(called, isTrue);

--- a/gui/packages/ubuntupro/test/pages/subscription_status/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subscription_status/subscribe_now_page_test.dart
@@ -136,7 +136,7 @@ void main() {
     // submits the input.
     final context = tester.element(find.byType(SubscribeNowPage));
     final lang = AppLocalizations.of(context);
-    final button = find.text(lang.apply);
+    final button = find.text(lang.confirm);
     await tester.tap(button);
     await tester.pump();
 


### PR DESCRIPTION
The proposed changes for the Ubuntu Pro Flutter GUI design have differing strings, so this PR changes those strings and also the keys associated with them so they make more sense. These are all cosmetic changes and do not alter the functionality of the application.

*Force push was to correct the email used for the sake of CLA signing*

---

UDENG-1986