### PR TITLE
fix(WSL-Pro-Service): Increase timeout on the daemon's TestServeAndQuit

### DIFF
--- a/wsl-pro-service/internal/daemon/daemon_test.go
+++ b/wsl-pro-service/internal/daemon/daemon_test.go
@@ -343,7 +343,7 @@ func TestReconnection(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				return agentData.BackConnectionCount.Load() != 0
-			}, 30*time.Second, time.Second, "Service should eventually connect to the agent")
+			}, time.Minute, time.Second, "Service should eventually connect to the agent")
 
 			require.Equal(t, int32(1), systemd.readyNotifications.Load(), "Service should have notified systemd after connecting to the control stream")
 			require.Equal(t, int32(1), agentData.ConnectionCount.Load(), "Service should have connected to the control stream")


### PR DESCRIPTION
I honestly cannot understand why it is failing: I tried running with GOMAXPROCS=1, and adding time.Sleeps in there to mimic a slow machine. But I still pass the tests 🤷.

Let's hope this does it though.