### PR TITLE
fix(windows-agent): Add Stop function to Config

### DIFF
--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -23,6 +23,9 @@ import (
 // Config manages configuration parameters. It is a wrapper around a dictionary
 // that reads and updates the config file.
 type Config struct {
+	ctx    context.Context
+	cancel func()
+
 	// data
 	subscription subscription
 	landscape    landscapeConf
@@ -35,6 +38,7 @@ type Config struct {
 
 	// observers are called after any configuration changes.
 	observers []func()
+	wg        sync.WaitGroup
 }
 
 // New creates and initializes a new Config object.
@@ -44,20 +48,59 @@ func New(ctx context.Context, cachePath string) (m *Config) {
 		mu:          &sync.Mutex{},
 	}
 
+	m.ctx, m.cancel = context.WithCancel(ctx)
+
 	return m
+}
+
+// Stop releases all resources associated with the config.
+func (c *Config) Stop() {
+	c.cancel()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.wg.Wait()
+}
+
+func (c *Config) stopped() bool {
+	select {
+	case <-c.ctx.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 // Notify appends a callback. It'll be called every time any configuration changes.
 func (c *Config) Notify(f func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.observers = append(c.observers, f)
 }
 
+// notifyObservers calls all the observers. Use it under a mutex.
 func (c *Config) notifyObservers() {
+	c.wg.Add(len(c.observers))
+
 	for _, f := range c.observers {
-		// This needs to be in a goroutine because notifyObservers is sometimes
+		f := f
+		// This needs to be in a goroutine because notifyObservers is always
 		// called under the config mutex. The callback trying to grab the mutex
 		// (to read the config) would cause a deadlock otherwise.
-		go f()
+		//
+		// We protect it under "stopped" to avoid running callbacks during the
+		// agent's shutdown.
+		go func() {
+			defer c.wg.Done()
+
+			if c.stopped() {
+				return
+			}
+
+			f()
+		}()
 	}
 }
 
@@ -65,6 +108,10 @@ func (c *Config) notifyObservers() {
 func (c *Config) Subscription() (token string, source Source, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return "", SourceNone, errors.New("config stopped")
+	}
 
 	if err := c.load(); err != nil {
 		return "", SourceNone, fmt.Errorf("config: could not get Ubuntu Pro subscription: %v", err)
@@ -81,6 +128,10 @@ func (c *Config) ProvisioningTasks(ctx context.Context, distroName string) ([]ta
 	// Refresh data from registry
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return nil, errors.New("config stopped")
+	}
 
 	if err := c.load(); err != nil {
 		return nil, fmt.Errorf("config: could not get provisioning tasks: %v", err)
@@ -102,6 +153,10 @@ func (c *Config) ProvisioningTasks(ctx context.Context, distroName string) ([]ta
 func (c *Config) LandscapeClientConfig() (string, Source, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return "", SourceNone, errors.New("config stopped")
+	}
 
 	if err := c.load(); err != nil {
 		return "", SourceNone, fmt.Errorf("config: could not get Landscape configuration: %v", err)
@@ -147,6 +202,10 @@ func (c *Config) set(field *string, value string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.stopped() {
+		return errors.New("config stopped")
+	}
+
 	// Load before dumping to avoid overriding recent changes to file
 	if err := c.load(); err != nil {
 		return err
@@ -170,6 +229,10 @@ func (c *Config) set(field *string, value string) error {
 func (c *Config) LandscapeAgentUID() (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return "", errors.New("config stopped")
+	}
 
 	if err := c.load(); err != nil {
 		return "", fmt.Errorf("config: could not get Landscape agent UID: %v", err)
@@ -260,6 +323,10 @@ func (c *Config) collectRegistrySettingsTasks(ctx context.Context, data Registry
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return nil, errors.New("config stopped")
+	}
 
 	// Load up-to-date state
 	if err := c.load(); err != nil {

--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -27,8 +27,7 @@ type Config struct {
 	cancel func()
 
 	// data
-	subscription subscription
-	landscape    landscapeConf
+	configState
 
 	// disk backing
 	storagePath string
@@ -39,6 +38,14 @@ type Config struct {
 	// observers are called after any configuration changes.
 	observers []func()
 	wg        sync.WaitGroup
+}
+
+// configState contains the actual configuration data.
+//
+// Its methods must be public for proper YAML (un)marshalling.
+type configState struct {
+	Subscription subscription
+	Landscape    landscapeConf
 }
 
 // New creates and initializes a new Config object.
@@ -106,18 +113,12 @@ func (c *Config) notifyObservers() {
 
 // Subscription returns the ProToken and the method it was acquired with (if any).
 func (c *Config) Subscription() (token string, source Source, err error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.stopped() {
-		return "", SourceNone, errors.New("config stopped")
-	}
-
-	if err := c.load(); err != nil {
+	s, err := c.get()
+	if err != nil {
 		return "", SourceNone, fmt.Errorf("config: could not get Ubuntu Pro subscription: %v", err)
 	}
 
-	token, source = c.subscription.resolve()
+	token, source = s.Subscription.resolve()
 	return token, source, nil
 }
 
@@ -126,24 +127,18 @@ func (c *Config) ProvisioningTasks(ctx context.Context, distroName string) ([]ta
 	var taskList []task.Task
 
 	// Refresh data from registry
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.stopped() {
-		return nil, errors.New("config stopped")
-	}
-
-	if err := c.load(); err != nil {
+	s, err := c.get()
+	if err != nil {
 		return nil, fmt.Errorf("config: could not get provisioning tasks: %v", err)
 	}
 
 	// Ubuntu Pro attachment
-	proToken, _ := c.subscription.resolve()
+	proToken, _ := s.Subscription.resolve()
 	taskList = append(taskList, tasks.ProAttachment{Token: proToken})
 
 	// Landscape config
-	lconf, _ := c.landscape.resolve()
-	taskList = append(taskList, tasks.LandscapeConfigure{Config: lconf, HostagentUID: c.landscape.UID})
+	lconf, _ := s.Landscape.resolve()
+	taskList = append(taskList, tasks.LandscapeConfigure{Config: lconf, HostagentUID: s.Landscape.UID})
 
 	return taskList, nil
 }
@@ -151,18 +146,12 @@ func (c *Config) ProvisioningTasks(ctx context.Context, distroName string) ([]ta
 // LandscapeClientConfig returns the value of the landscape server URL and
 // the method it was acquired with (if any).
 func (c *Config) LandscapeClientConfig() (string, Source, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.stopped() {
-		return "", SourceNone, errors.New("config stopped")
-	}
-
-	if err := c.load(); err != nil {
+	s, err := c.get()
+	if err != nil {
 		return "", SourceNone, fmt.Errorf("config: could not get Landscape configuration: %v", err)
 	}
 
-	conf, src := c.landscape.resolve()
+	conf, src := s.Landscape.resolve()
 	return conf, src, nil
 }
 
@@ -170,31 +159,56 @@ func (c *Config) LandscapeClientConfig() (string, Source, error) {
 func (c *Config) SetUserSubscription(proToken string) (err error) {
 	defer decorate.OnError(&err, "config: could not set user-provided Ubuntu Pro subscription")
 
-	if _, src := c.subscription.resolve(); src > SourceUser {
+	s, err := c.get()
+	if err != nil {
+		return fmt.Errorf("could not get exiting Ubuntu Pro subscription: %v", err)
+	}
+
+	if _, src := s.Subscription.resolve(); src > SourceUser {
 		return errors.New("higher priority subscription active")
 	}
 
-	return c.set(&c.subscription.User, proToken)
+	return c.set(&c.configState.Subscription.User, proToken)
 }
 
 // setStoreSubscription overwrites the value of the store-provided Ubuntu Pro token.
 func (c *Config) setStoreSubscription(proToken string) (err error) {
 	defer decorate.OnError(&err, "could not set Microsoft-Store-provided Ubuntu Pro subscription")
 
-	if _, src := c.subscription.resolve(); src > SourceMicrosoftStore {
+	s, err := c.get()
+	if err != nil {
+		return fmt.Errorf("could not get exiting Ubuntu Pro subscription: %v", err)
+	}
+
+	if _, src := s.Subscription.resolve(); src > SourceMicrosoftStore {
 		return errors.New("higher priority subscription active")
 	}
 
-	return c.set(&c.subscription.Store, proToken)
+	return c.set(&c.configState.Subscription.Store, proToken)
 }
 
 // SetLandscapeAgentUID overrides the Landscape agent UID.
 func (c *Config) SetLandscapeAgentUID(uid string) error {
-	if err := c.set(&c.landscape.UID, uid); err != nil {
+	if err := c.set(&c.Landscape.UID, uid); err != nil {
 		return fmt.Errorf("config: could not set Landscape agent UID: %v", err)
 	}
 
 	return nil
+}
+
+func (c *Config) get() (s configState, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopped() {
+		return s, errors.New("config stopped")
+	}
+
+	if err := c.load(); err != nil {
+		return s, err
+	}
+
+	return c.configState, nil
 }
 
 // set is a generic method to safely modify the config.
@@ -227,18 +241,12 @@ func (c *Config) set(field *string, value string) error {
 // LandscapeAgentUID returns the UID assigned to this agent by the Landscape server.
 // An empty string is returned if no UID has been assigned.
 func (c *Config) LandscapeAgentUID() (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.stopped() {
-		return "", errors.New("config stopped")
-	}
-
-	if err := c.load(); err != nil {
+	s, err := c.get()
+	if err != nil {
 		return "", fmt.Errorf("config: could not get Landscape agent UID: %v", err)
 	}
 
-	return c.landscape.UID, nil
+	return s.Landscape.UID, nil
 }
 
 // FetchMicrosoftStoreSubscription contacts Ubuntu Pro's contract server and the Microsoft Store
@@ -363,32 +371,32 @@ func (c *Config) collectRegistrySettingsTasks(ctx context.Context, data Registry
 // getTaskOnNewSubscription checks if the subscription has changed since the last time it was called. If so, the new subscription
 // is returned in the form of a task.
 func (c *Config) getTaskOnNewSubscription(ctx context.Context, data RegistryData, db *database.DistroDB) (task.Task, error) {
-	c.subscription.Organization = data.UbuntuProToken
+	c.configState.Subscription.Organization = data.UbuntuProToken
 
-	if !hasChanged(data.UbuntuProToken, &c.subscription.Checksum) {
+	if !hasChanged(data.UbuntuProToken, &c.configState.Subscription.Checksum) {
 		return nil, nil
 	}
 	log.Debug(ctx, "Config: new Ubuntu Pro subscription received from the registry")
 
-	proToken, _ := c.subscription.resolve()
+	proToken, _ := c.configState.Subscription.resolve()
 	return tasks.ProAttachment{Token: proToken}, nil
 }
 
 // getTaskOnNewLandscape checks if the Landscape settings has changed since the last time it was called. If so, the
 // new Landscape settings are returned in the form of a task.
 func (c *Config) getTaskOnNewLandscape(ctx context.Context, data RegistryData, db *database.DistroDB) (task.Task, error) {
-	c.landscape.OrgConfig = data.LandscapeConfig
+	c.Landscape.OrgConfig = data.LandscapeConfig
 
 	// We append them just so we can compute a combined checksum
-	serialized := fmt.Sprintf("%s%s", data.LandscapeConfig, c.landscape.UID)
-	if !hasChanged(serialized, &c.landscape.Checksum) {
+	serialized := fmt.Sprintf("%s%s", data.LandscapeConfig, c.Landscape.UID)
+	if !hasChanged(serialized, &c.Landscape.Checksum) {
 		return nil, nil
 	}
 
 	log.Debug(ctx, "Config: new Landscape configuration received from the registry")
 
-	lconf, _ := c.landscape.resolve()
-	return tasks.LandscapeConfigure{Config: lconf, HostagentUID: c.landscape.UID}, nil
+	lconf, _ := c.Landscape.resolve()
+	return tasks.LandscapeConfigure{Config: lconf, HostagentUID: c.Landscape.UID}, nil
 }
 
 // hasChanged detects if the current value is different from the last time it was used.

--- a/windows-agent/internal/config/config_marshal.go
+++ b/windows-agent/internal/config/config_marshal.go
@@ -10,15 +10,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type marshalHelper struct {
-	Landscape    landscapeConf
-	Subscription subscription
-}
-
 func (c *Config) load() (err error) {
 	defer decorate.OnError(&err, "could not load config from disk")
 
-	var h marshalHelper
+	var s configState
 
 	out, err := os.ReadFile(c.storagePath)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -27,19 +22,18 @@ func (c *Config) load() (err error) {
 		return fmt.Errorf("could not read config file: %v", err)
 	}
 
-	if err := yaml.Unmarshal(out, &h); err != nil {
+	if err := yaml.Unmarshal(out, &s); err != nil {
 		return fmt.Errorf("could not umarshal config file: %v", err)
 	}
 
 	// Registry data must not be overridden
-	tokenOrg := c.subscription.Organization
-	landscapeOrg := c.landscape.OrgConfig
+	tokenOrg := c.configState.Subscription.Organization
+	landscapeOrg := c.configState.Landscape.OrgConfig
 
-	c.subscription = h.Subscription
-	c.landscape = h.Landscape
+	c.configState = s
 
-	c.subscription.Organization = tokenOrg
-	c.landscape.OrgConfig = landscapeOrg
+	c.configState.Subscription.Organization = tokenOrg
+	c.configState.Landscape.OrgConfig = landscapeOrg
 
 	return nil
 }
@@ -47,12 +41,7 @@ func (c *Config) load() (err error) {
 func (c *Config) dump() (err error) {
 	defer decorate.OnError(&err, "could not store config to disk")
 
-	h := marshalHelper{
-		Landscape:    c.landscape,
-		Subscription: c.subscription,
-	}
-
-	out, err := yaml.Marshal(&h)
+	out, err := yaml.Marshal(c.configState)
 	if err != nil {
 		return fmt.Errorf("could not marshal config: %v", err)
 	}

--- a/windows-agent/internal/config/config_marshal.go
+++ b/windows-agent/internal/config/config_marshal.go
@@ -44,7 +44,7 @@ func (c *Config) load() (err error) {
 	return nil
 }
 
-func (c Config) dump() (err error) {
+func (c *Config) dump() (err error) {
 	defer decorate.OnError(&err, "could not store config to disk")
 
 	h := marshalHelper{

--- a/windows-agent/internal/config/config_test.go
+++ b/windows-agent/internal/config/config_test.go
@@ -378,9 +378,9 @@ func TestSetUserSubscription(t *testing.T) {
 	}{
 		"Success":                          {settingsState: userTokenHasValue, want: "new_token"},
 		"Success disabling a subscription": {settingsState: userTokenHasValue, emptyToken: true, want: ""},
-		"Success when there is a store token active": {settingsState: storeTokenHasValue, want: "store_token"},
 
-		"Error when the file cannot be opened": {settingsState: fileExists, breakFile: true, wantError: true},
+		"Error when there is a store token active": {settingsState: storeTokenHasValue, wantError: true},
+		"Error when the file cannot be opened":     {settingsState: fileExists, breakFile: true, wantError: true},
 	}
 
 	for name, tc := range testCases {

--- a/windows-agent/internal/config/config_test.go
+++ b/windows-agent/internal/config/config_test.go
@@ -90,6 +90,7 @@ func TestSubscription(t *testing.T) {
 
 			setup, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakFile)
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
 			setup(t, conf)
 
 			token, source, err := conf.Subscription()
@@ -146,6 +147,7 @@ func TestLandscapeConfig(t *testing.T) {
 
 			setup, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakFile)
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
 			setup(t, conf)
 
 			landscapeConf, source, err := conf.LandscapeClientConfig()
@@ -201,6 +203,7 @@ func TestLandscapeAgentUID(t *testing.T) {
 			}
 
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
 			setup(t, conf)
 
 			v, err := conf.LandscapeAgentUID()
@@ -313,6 +316,7 @@ func TestSetUserSubscription(t *testing.T) {
 
 			setup, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakFile)
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
 			setup(t, conf)
 
 			token := "new_token"
@@ -370,6 +374,7 @@ func TestSetLandscapeAgentUID(t *testing.T) {
 
 			setup, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakFile)
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
 			setup(t, conf)
 
 			uid := "new_uid"
@@ -443,6 +448,7 @@ func TestFetchMicrosoftStoreSubscription(t *testing.T) {
 
 			setup, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakConfigFile)
 			c := config.New(ctx, dir)
+			defer c.Stop()
 			setup(t, c)
 
 			// Set up the mock Microsoft store
@@ -548,6 +554,7 @@ func TestUpdateRegistryData(t *testing.T) {
 
 			_, dir := setUpMockSettings(t, ctx, db, tc.settingsState, tc.breakConfigFile)
 			c := config.New(ctx, dir)
+			defer c.Stop()
 
 			// Enter a first set of data to override the defaults
 			err = c.UpdateRegistryData(ctx, config.RegistryData{
@@ -651,6 +658,7 @@ func TestNotify(t *testing.T) {
 
 	_, dir := setUpMockSettings(t, ctx, db, untouched, false)
 	c := config.New(ctx, dir)
+	defer c.Stop()
 
 	var notifyCount atomic.Int32
 	var wantNotifyCount int32

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -455,10 +455,9 @@ func testReceiveCommand(t *testing.T, distrosettings distroSettings, testSetup f
 
 	// Set up agent components (config, database, etc.)
 	if tb.conf == nil {
-		tb.conf = &mockConfig{
-			proToken:              "TOKEN",
-			landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr()),
-		}
+		tb.conf = newMockConfig(ctx)
+		tb.conf.proToken = "TOKEN"
+		tb.conf.landscapeClientConfig = executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr())
 	}
 
 	db, err := database.New(ctx, t.TempDir(), tb.conf)

--- a/windows-agent/internal/proservices/ui/ui_test.go
+++ b/windows-agent/internal/proservices/ui/ui_test.go
@@ -30,6 +30,7 @@ func TestNew(t *testing.T) {
 	defer db.Close(ctx)
 
 	conf := config.New(ctx, dir)
+	defer conf.Stop()
 
 	_ = ui.New(context.Background(), conf, db)
 }
@@ -92,6 +93,8 @@ func TestAttachPro(t *testing.T) {
 			}
 
 			conf := config.New(ctx, dir)
+			defer conf.Stop()
+
 			if tc.higherPriorityToken {
 				err = conf.UpdateRegistryData(ctx, config.RegistryData{
 					UbuntuProToken: "organization_token",


### PR DESCRIPTION
This prevents using it during the process teardown. Particulary relevant to async work like the observers.

Using the config during teardown is, I believe, the reason why this test fails:

https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/7813886532/job/21314974693?pr=506#step:8:38

I think cloud-init is writing `agent.yaml` at the same time as the test teardown in trying to remove its temp directory. On Windows, you cannot remove an open file.