### PR TITLE
docs: Added LandscapeConfig keys

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -20,6 +20,7 @@ wsl
 WSL
 WSL's
 zsh
+Quickstart
 
 # Other jargon
 autoload

--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -57,7 +57,7 @@ account_name = standalone
 log_level = debug
 ```
 
-For more information, see [the Landscape guide on how to configure Ubuntu Pro for WSL](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape#heading--configure-ubuntu-pro-for-wsl-for-landscape).
+For more information, see [the Landscape guide on how to configure Ubuntu Pro for WSL](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape/#heading--configure-ubuntu-pro-for-wsl-for-landscape).
 
 ## Read more
 

--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -57,7 +57,7 @@ account_name = standalone
 log_level = debug
 ```
 
-For more information, see [how to configure Ubuntu Pro for WSL for Landscape](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape#heading--configure-ubuntu-pro-for-wsl-for-landscape) in the Landscape documentation.
+For more information, see [the Landscape guide on how to configure Ubuntu Pro for WSL](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape#heading--configure-ubuntu-pro-for-wsl-for-landscape).
 
 ## Read more
 

--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -42,21 +42,13 @@ This section is the same one you'd see in other Landscape platforms, with some c
 
 All other data is ignored by the Agent and passed on verbatim to the Landscape client. You can see the reference for all the other keys in the [Landscape repository](https://github.com/canonical/landscape-client/blob/master/example.conf).
 
-The following keys are used by the Landscape client:
-
-- `account_name`: The Landscape account name this computer belongs to. For self-hosted Landscape accounts, the account name defaults to “standalone”.
-- `url`: The main URL for the Landscape Server to connect this client to. This defaults to the URL of your Landscape account followed by `/message-system`.
-- `ping_url`: The ping URL you want this client to report to. This defaults to the URL of your Landscape account followed by `/ping`.
-- `log_level`: This can be one of: "debug", "info", "warning", "error", "critical"
-- (Optional) `registration_key`: An optional account-wide key used to register new clients. There is no key defined by default, but one can be set in your Landscape account.
-
 ### Example
 
 Here is an example of a self-hosted Landscape configuration:
 
 ```ini
 [host]
-url = https://landscape-server.domain.com/6554
+url = https://landscape-server.domain.com:6554
 
 [client]
 url = https://landscape-server.domain.com/message-system
@@ -64,6 +56,8 @@ ping_url  = https://landscape-server.domain.com/ping
 account_name = standalone
 log_level = debug
 ```
+
+For more information, see [how to configure Ubuntu Pro for WSL for Landscape](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape#heading--configure-ubuntu-pro-for-wsl-for-landscape) in the Landscape documentation.
 
 ## Read more
 

--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -30,7 +30,7 @@ This file contains two sections: host and client.
 
 This section contains a single key:
 
-- `url` is the URL to the Landscape Hostagent API endpoint.
+- `url`: The URL of your Landscape account followed by a colon (`:`) and the port number. Port 6554 is the default for Landscape Quickstart installations.
 
 ### Client section
 
@@ -42,13 +42,21 @@ This section is the same one you'd see in other Landscape platforms, with some c
 
 All other data is ignored by the Agent and passed on verbatim to the Landscape client. You can see the reference for all the other keys in the [Landscape repository](https://github.com/canonical/landscape-client/blob/master/example.conf).
 
+The following keys are used by the Landscape client:
+
+- `account_name`: The Landscape account name this computer belongs to. For self-hosted Landscape accounts, the account name defaults to “standalone”.
+- `url`: The main URL for the Landscape Server to connect this client to. This defaults to the URL of your Landscape account followed by `/message-system`.
+- `ping_url`: The ping URL you want this client to report to. This defaults to the URL of your Landscape account followed by `/ping`.
+- `log_level`: This can be one of: "debug", "info", "warning", "error", "critical"
+- (Optional) `registration_key`: An optional account-wide key used to register new clients. There is no key defined by default, but one can be set in your Landscape account.
+
 ### Example
 
 Here is an example of a self-hosted Landscape configuration:
 
 ```ini
 [host]
-url = https://landscape-server.domain.com/hostagent
+url = https://landscape-server.domain.com/6554
 
 [client]
 url = https://landscape-server.domain.com/message-system


### PR DESCRIPTION
I've added some missing info. Feel free to accept/reject as you see fit, but the port number on the URL should be accepted. AFAIK, adding the port number is expected to be temporary. I'll keep your docs updated if/when that changes.

I didn't want to delete the information you had already regarding the Agent keys, but I was a bit confused by that section and what users should do with the other keys. If you want to go over it some time, feel free to MM me or schedule a meeting. I know your docs are under construction though so I think it's fine for now too :smiley: 

Also, here's the link to the Landscape Docs for registering a WSL host, if that's helpful: https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape