### PR TITLE
fix: Align subscription status page with Provisioning design

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -35,13 +35,10 @@
     "storeManaged": "This subscription is managed through Microsoft Store.",
     "manageSubscription": "Manage your subscription",
     "orgManaged": "This subscription is owned and managed by your organization.",
-    "manuallyManaged": "Visit [{proDashboardLink}]({proDashboardLinkHref}) to manage your subscription.",
+    "manuallyManaged": "Visit {proDashboardLink} to manage your subscription.",
     "@manuallyManaged": {
         "placeholders": {
             "proDashboardLink": {
-                "type": "String"
-            },
-            "proDashboardLinkHref": {
                 "type": "String"
             }
         }

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -35,10 +35,13 @@
     "storeManaged": "This subscription is managed through Microsoft Store.",
     "manageSubscription": "Manage your subscription",
     "orgManaged": "This subscription is owned and managed by your organization.",
-    "manuallyManaged": "Visit {proDashboardLink} to manage your subscription.",
+    "manuallyManaged": "Visit [{proDashboardLink}]({proDashboardLinkHref}) to manage your subscription.",
     "@manuallyManaged": {
         "placeholders": {
             "proDashboardLink": {
+                "type": "String"
+            },
+            "proDashboardLinkHref": {
                 "type": "String"
             }
         }

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru/yaru.dart';
 
 import '/core/agent_api_client.dart';
 import 'subscribe_now_page.dart';
@@ -25,19 +26,19 @@ class SubscriptionStatusPage extends StatelessWidget {
       child: switch (model) {
         StoreSubscriptionStatusModel() => SubscriptionStatus(
             caption: lang.storeManaged,
-            actionButton: TextButton(
+            actionButton: OutlinedButton(
               onPressed: model.launchManagementWebPage,
-              style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF0094FF),
-              ),
               child: Text(lang.manageSubscription),
             ),
           ),
         UserSubscriptionStatusModel() => SubscriptionStatus(
-            caption: lang.manuallyManaged('ubuntu.com/pro/dashboard'),
+            caption: lang.manuallyManaged(
+              'ubuntu.com/pro/dashboard',
+              'https://ubuntu.com/pro/dashboard',
+            ),
             actionButton: FilledButton(
               style: FilledButton.styleFrom(
-                backgroundColor: const Color(0xFFE86581),
+                backgroundColor: YaruColors.red,
               ),
               onPressed: () async {
                 context.read<ValueNotifier<SubscriptionInfo>>().value =

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
@@ -15,7 +15,6 @@ import 'subscription_status_widgets.dart';
 class SubscriptionStatusPage extends StatelessWidget {
   const SubscriptionStatusPage({super.key});
 
-  // TODO: Replace the constants below with YaruColors.dark.link and YaruColors.dark.error once we release yaru v0.9 or v1.0.0.
   @override
   Widget build(BuildContext context) {
     final model = context.watch<SubscriptionStatusModel>();
@@ -33,8 +32,7 @@ class SubscriptionStatusPage extends StatelessWidget {
           ),
         UserSubscriptionStatusModel() => SubscriptionStatus(
             caption: lang.manuallyManaged(
-              'ubuntu.com/pro/dashboard',
-              'https://ubuntu.com/pro/dashboard',
+              '[ubuntu.com/pro/dashboard](https://ubuntu.com/pro/dashboard)',
             ),
             actionButton: FilledButton(
               style: FilledButton.styleFrom(

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 import '../widgets/page_widgets.dart';
 
@@ -22,12 +24,24 @@ class SubscriptionStatus extends StatelessWidget {
   Widget build(BuildContext context) {
     final lang = AppLocalizations.of(context);
 
+    final linkStyle = MarkdownStyleSheet.fromTheme(
+      Theme.of(context).copyWith(
+        textTheme: DarkStyledLandingPage.textTheme.copyWith(
+          bodyMedium: DarkStyledLandingPage.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w100,
+            color: YaruColors.warmGrey,
+          ),
+        ),
+      ),
+    );
+
     return DarkStyledLandingPage(
       children: [
         Row(
           children: [
-            const Icon(
+            Icon(
               Icons.check_circle,
+              color: YaruColors.dark.success,
             ),
             const SizedBox(width: 8.0),
             Text(
@@ -38,12 +52,10 @@ class SubscriptionStatus extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 16.0),
-        Text(
-          caption,
-          style: DarkStyledLandingPage.textTheme.bodyMedium!.copyWith(
-            fontWeight: FontWeight.w100,
-            color: YaruColors.warmGrey,
-          ),
+        MarkdownBody(
+          data: caption,
+          onTapLink: (_, href, __) => launchUrlString(href!),
+          styleSheet: linkStyle,
         ),
         if (actionButton != null)
           Padding(

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -29,38 +29,67 @@ class SubscriptionStatus extends StatelessWidget {
         textTheme: DarkStyledLandingPage.textTheme.copyWith(
           bodyMedium: DarkStyledLandingPage.textTheme.bodyMedium?.copyWith(
             fontWeight: FontWeight.w100,
-            color: YaruColors.warmGrey,
+            color: YaruColors.jet,
           ),
         ),
+      ),
+    ).copyWith(
+      a: const TextStyle(
+        decoration: TextDecoration.underline,
+        color: YaruColors.jet,
       ),
     );
 
     return DarkStyledLandingPage(
+      centered: true,
       children: [
-        Row(
-          children: [
-            Icon(
-              Icons.check_circle,
-              color: YaruColors.dark.success,
-            ),
-            const SizedBox(width: 8.0),
-            Text(
-              lang.subscriptionIsActive,
-              style: DarkStyledLandingPage.textTheme.bodyLarge!
-                  .copyWith(fontWeight: FontWeight.w100),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16.0),
-        MarkdownBody(
-          data: caption,
-          onTapLink: (_, href, __) => launchUrlString(href!),
-          styleSheet: linkStyle,
+        Container(
+          padding: const EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFF0E8420), width: 1.0),
+            color: const Color(0xFFE6F8E8),
+            borderRadius: const BorderRadius.all(Radius.circular(4.0)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(
+                Icons.check_circle_outline_outlined,
+                color: Color(0xFF0E8420),
+                size: 24.0,
+              ),
+              const SizedBox(width: 8.0),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      lang.subscriptionIsActive,
+                      style:
+                          DarkStyledLandingPage.textTheme.bodyLarge!.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: YaruColors.darkJet,
+                      ),
+                    ),
+                    const SizedBox(height: 4.0),
+                    MarkdownBody(
+                      data: caption,
+                      onTapLink: (_, href, __) => launchUrlString(href!),
+                      styleSheet: linkStyle,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
         if (actionButton != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 32.0),
-            child: actionButton!,
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 32.0),
+              child: actionButton!,
+            ),
           ),
       ],
     );

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -122,7 +122,6 @@ class DarkStyledLandingPage extends StatelessWidget {
 
 class _PageContent extends StatelessWidget {
   const _PageContent({
-    super.key,
     required this.svgAsset,
     required this.title,
     required ThemeData data,

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -70,10 +70,12 @@ class DarkStyledLandingPage extends StatelessWidget {
     required this.children,
     this.svgAsset = 'assets/Ubuntu-tag.svg',
     this.title = 'Ubuntu Pro',
+    this.centered = false,
   });
   final List<Widget> children;
   final String svgAsset;
   final String title;
+  final bool centered;
   // TODO: Remove those getters once we have a background image suitable for the light mode theme.
   static ThemeData get _data => yaruDark;
   static TextTheme get textTheme => _data.textTheme;
@@ -82,6 +84,7 @@ class DarkStyledLandingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Pro4WSLPage(
       body: Stack(
+        fit: StackFit.expand,
         children: [
           Positioned.fill(
             child: Image.asset(
@@ -91,40 +94,83 @@ class DarkStyledLandingPage extends StatelessWidget {
           ),
           Padding(
             padding: const EdgeInsets.all(48.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                RichText(
-                  text: TextSpan(
-                    children: [
-                      WidgetSpan(
-                        child: SvgPicture.asset(
-                          svgAsset,
-                          height: 70,
-                        ),
+            child: centered
+                ? Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 480.0),
+                      child: _PageContent(
+                        svgAsset: svgAsset,
+                        title: title,
+                        data: _data,
+                        centered: true,
+                        children: children,
                       ),
-                      const WidgetSpan(
-                        child: SizedBox(
-                          width: 8,
-                        ),
-                      ),
-                      TextSpan(
-                        text: title,
-                        style: _data.textTheme.displaySmall
-                            ?.copyWith(fontWeight: FontWeight.w100),
-                      ),
-                    ],
+                    ),
+                  )
+                : _PageContent(
+                    svgAsset: svgAsset,
+                    title: title,
+                    data: _data,
+                    children: children,
                   ),
-                ),
-                const SizedBox(
-                  height: 24,
-                ),
-                ...children,
-              ],
-            ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PageContent extends StatelessWidget {
+  const _PageContent({
+    super.key,
+    required this.svgAsset,
+    required this.title,
+    required ThemeData data,
+    required this.children,
+    this.centered = false,
+  }) : _data = data;
+
+  final String svgAsset;
+  final String title;
+  final ThemeData _data;
+  final List<Widget> children;
+  final bool centered;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment:
+          centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+      mainAxisAlignment:
+          centered ? MainAxisAlignment.center : MainAxisAlignment.start,
+      children: [
+        RichText(
+          text: TextSpan(
+            children: [
+              WidgetSpan(
+                child: SvgPicture.asset(
+                  svgAsset,
+                  height: 70,
+                ),
+              ),
+              const WidgetSpan(
+                child: SizedBox(
+                  width: 8,
+                ),
+              ),
+              TextSpan(
+                text: title,
+                style: _data.textTheme.displaySmall
+                    ?.copyWith(fontWeight: FontWeight.w100),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(
+          height: 24,
+        ),
+        ...children,
+      ],
     );
   }
 }

--- a/gui/packages/ubuntupro/pubspec.lock
+++ b/gui/packages/ubuntupro/pubspec.lock
@@ -265,6 +265,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "21b085a1c185e46701373866144ced56cfb7a0c33f63c916bb8fe2d0c1491278"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.19"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -429,6 +437,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.1"
   matcher:
     dependency: transitive
     description:

--- a/gui/packages/ubuntupro/pubspec.yaml
+++ b/gui/packages/ubuntupro/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  flutter_markdown: ^0.6.19
   flutter_svg: ^2.0.9
   grpc: ^3.2.4
   intl: ^0.18.1


### PR DESCRIPTION
This PR redesigns the subscription status page to be more consistent with the designs for Provisioning. It includes having clickable text links, centering the title, text, and buttons, and outlining the text with a green background box.

This required changing the flow of the main layout and adding a `centered` option, so it may be more changes than you might suspect. This same layout will likely be used for the Landscape status page as well.

**New design**

![image](https://github.com/canonical/ubuntu-pro-for-wsl/assets/101582426/78e79aa2-b851-4d8f-84f7-cc06097779e7)

**Old design (but with color changes and clickable link)**

![Screenshot 2024-02-15 134408](https://github.com/canonical/ubuntu-pro-for-wsl/assets/101582426/47cd3796-afc8-499c-80b9-18541ac9b78c)

---

UDENG-1786