### PR TITLE
fix(windows-agent): Fix deadlock in config Stop

### DIFF
--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -63,10 +63,6 @@ func New(ctx context.Context, cachePath string) (m *Config) {
 // Stop releases all resources associated with the config.
 func (c *Config) Stop() {
 	c.cancel()
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.wg.Wait()
 }
 


### PR DESCRIPTION
This commit fixes a deadlock between config.Stop and any config notifaction callback that uses a config Mutex.

Scenario:

1. A config notification is triggered: the waitgroup count is increased by one and a single callback is called and starts executing. Waitgroup count decrease is deferred until the callback returns.

2. config.Stop is called, the config's ctx is cancelled but it is too late: the callback has already started. Then the config mutex is locked and it waits on the config waitgroup. This blocks until the waitgroup count reached 0.

3. during its execution, the callback calls some getter in the config. The mutex is already locked, so the getter cannot proceed, hence it cannot return. The deferred waitgroup count decrease never happens.

This is a deadlock! config.Stop is waiting on all callbacks to exit before releasing the mutex, but the callback cannot exit until the mutex is released.

Since waitgroups are thread-safe, we can simply remove the mutex from config.Stop.


---

This is not speculation, it happened here:

https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/7961210145/job/21731894552?pr=506