### PR TITLE
feat(windows-agent): Daemon listens at the hyper-V adapter

### DIFF
--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -1,6 +1,3 @@
-/// The address where the Agent gRPC service is hosted.
-const kDefaultHost = '127.0.0.1';
-
 /// The name of the file where the Agent's drop its service connection information.
 const kAddrFileName = '.ubuntupro/.address';
 

--- a/gui/packages/ubuntupro/lib/core/agent_monitor.dart
+++ b/gui/packages/ubuntupro/lib/core/agent_monitor.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'package:path/path.dart' as p;
 
-import '/constants.dart';
 import 'agent_api_client.dart';
 import 'agent_api_paths.dart';
 
@@ -131,7 +130,7 @@ class AgentStartupMonitor {
       final portResult = await readAgentPortFromFile(_addrFilePath!);
       st = await portResult.fold(
         ifLeft: _onAddrError,
-        ifRight: _onPort,
+        ifRight: _onAddress,
       );
       yield st;
     }
@@ -167,13 +166,15 @@ class AgentStartupMonitor {
     }
   }
 
-  Future<AgentState> _onPort(int port) async {
+  Future<AgentState> _onAddress((String, int) address) async {
+    final (host, port) = address;
+
     if (_agentApiClient != null) {
-      await _agentApiClient!.connectTo(host: kDefaultHost, port: port);
+      await _agentApiClient!.connectTo(host: host, port: port);
       return AgentState.ok;
     }
 
-    final client = clientFactory(kDefaultHost, port);
+    final client = clientFactory(host, port);
     if (await client.ping()) {
       _agentApiClient = client;
       for (final cb in _onClient) {

--- a/gui/packages/ubuntupro/test/core/agent_api_paths_test.dart
+++ b/gui/packages/ubuntupro/test/core/agent_api_paths_test.dart
@@ -7,14 +7,37 @@ import 'package:ubuntupro/core/agent_api_paths.dart';
 void main() {
   tearDownAll(() => File('./.address').deleteSync());
 
-  test('read port from line', () {
+  test('read ipv4 host and port from line', () {
+    const host = '127.0.0.1';
     const port = 56768;
-    const line = '[::]:$port';
+    const line = '$host:$port';
 
     // Exercises the parsing algorithm.
-    final res = readAgentPortFromLine(line);
+    final res = parseAddress(line);
 
-    expect(res, port);
+    expect(res, (host, port));
+  });
+
+  test('read ipv6 host and port from line', () {
+    const host = '[::]';
+    const port = 56768;
+    const line = '$host:$port';
+
+    // Exercises the parsing algorithm.
+    final res = parseAddress(line);
+
+    expect(res, (host, port));
+  });
+
+  test('read localhost and port from line', () {
+    const host = 'localhost';
+    const port = 56768;
+    const line = '$host:$port';
+
+    // Exercises the parsing algorithm.
+    final res = parseAddress(line);
+
+    expect(res, (host, port));
   });
 
   test('line parsing error', () {
@@ -22,22 +45,41 @@ void main() {
     const line = '[::]-$port';
 
     // Exercises the parsing algorithm.
-    final res = readAgentPortFromLine(line);
+    final res = parseAddress(line);
 
     expect(res, isNull);
   });
 
-  test('read port from addr file', () async {
+  test('Negative port error', () {
+    const line = '[::]:-56768';
+
+    // Exercises the parsing algorithm.
+    final res = parseAddress(line);
+
+    expect(res, isNull);
+  });
+
+  test('Zero port parsing error', () {
+    const line = '[::]:0';
+
+    // Exercises the parsing algorithm.
+    final res = parseAddress(line);
+
+    expect(res, isNull);
+  });
+
+  test('read host and port from addr file', () async {
     const filePath = './.address';
+    const host = '[::]';
     const port = 56768;
-    const line = '[::]:$port';
+    const line = '$host:$port';
     final addr = File(filePath);
     addr.writeAsStringSync(line);
 
     // Exercises the expected usage: reading from a file
     final res = await readAgentPortFromFile(filePath);
 
-    expect(res.orNull(), port);
+    expect(res.orNull(), (host, port));
   });
 
   test('invalid file name', () async {

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -47,9 +47,14 @@ func (d Daemon) Serve(ctx context.Context) (err error) {
 
 	log.Debug(ctx, "Daemon: starting to serve requests")
 
-	// TODO: get a local port only, please :)
+	wslIP, err := getWslIP()
+	if err != nil {
+		log.Warningf(ctx, "Daemon: serving on all interfaces because we could not get the WSL adapter IP: %v", err)
+		wslIP = net.IPv4zero
+	}
+
 	var cfg net.ListenConfig
-	lis, err := cfg.Listen(ctx, "tcp", "")
+	lis, err := cfg.Listen(ctx, "tcp", fmt.Sprintf("%s:0", wslIP))
 	if err != nil {
 		return fmt.Errorf("can't listen: %v", err)
 	}

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -49,8 +49,7 @@ func (d Daemon) Serve(ctx context.Context) (err error) {
 
 	wslIP, err := getWslIP()
 	if err != nil {
-		log.Warningf(ctx, "Daemon: serving on all interfaces because we could not get the WSL adapter IP: %v", err)
-		wslIP = net.IPv4zero
+		return fmt.Errorf("could not get the WSL adapter IP: %v", err)
 	}
 
 	var cfg net.ListenConfig

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"testing"
+
+	wsl "github.com/ubuntu/gowsl"
+)
+
+// SetWslIPErr sets the WslIPErr variable to true, causing getWslIP to return an error.
+// This only works when the build tag is "linux" or "gowslmock".
+func SetWslIPErr(t *testing.T) {
+	if !wsl.MockAvailable() {
+		t.Skip("gowslmock not available")
+	}
+
+	wslIPErr = true
+	t.Cleanup(func() { wslIPErr = false })
+}

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -9,6 +9,8 @@ import (
 // SetWslIPErr sets the WslIPErr variable to true, causing getWslIP to return an error.
 // This only works when the build tag is "linux" or "gowslmock".
 func SetWslIPErr(t *testing.T) {
+	t.Helper()
+
 	if !wsl.MockAvailable() {
 		t.Skip("gowslmock not available")
 	}

--- a/windows-agent/internal/daemon/networking_mock.go
+++ b/windows-agent/internal/daemon/networking_mock.go
@@ -3,9 +3,16 @@
 package daemon
 
 import (
+	"errors"
 	"net"
 )
 
+var wslIPErr bool
+
 func getWslIP() (net.IP, error) {
+	if wslIPErr {
+		return nil, errors.New("mock error")
+	}
+
 	return net.IP([]byte{127, 0, 0, 1}), nil
 }

--- a/windows-agent/internal/daemon/networking_mock.go
+++ b/windows-agent/internal/daemon/networking_mock.go
@@ -1,0 +1,11 @@
+//go:build linux || (windows && gowslmock)
+
+package daemon
+
+import (
+	"net"
+)
+
+func getWslIP() (net.IP, error) {
+	return net.IP([]byte{127, 0, 0, 1}), nil
+}

--- a/windows-agent/internal/daemon/networking_windows.go
+++ b/windows-agent/internal/daemon/networking_windows.go
@@ -11,6 +11,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Does nothing, exists so we can compile the tests without mocks.
+var wslIPErr bool
+
 func getWslIP() (net.IP, error) {
 	const targetName = "Hyper-V Virtual Ethernet Adapter"
 

--- a/windows-agent/internal/daemon/networking_windows.go
+++ b/windows-agent/internal/daemon/networking_windows.go
@@ -1,0 +1,84 @@
+//go:build !gowslmock
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func getWslIP() (net.IP, error) {
+	const targetName = "Hyper-V Virtual Ethernet Adapter"
+
+	head, err := getAdaptersAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	for addr := head; addr != nil; addr = addr.Next {
+		desc := safeUTF16ToString(addr.Description, len(targetName)+1)
+		if desc != targetName {
+			continue
+		}
+
+		return addr.FirstUnicastAddress.Address.IP(), nil
+	}
+
+	return nil, fmt.Errorf("could not find WSL adapter")
+}
+
+// getAdaptersAddresses returns the head of a linked list of network adapters.
+func getAdaptersAddresses() (*windows.IpAdapterAddresses, error) {
+	// Flags from the Windows API.
+	// https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
+	//
+	//nolint:revive // Windows API constants are in shout case.
+	const (
+		GAA_FLAG_SKIP_ANYCAST       uint32 = 0x0002
+		GAA_FLAG_SKIP_MULTICAST     uint32 = 0x0004
+		GAA_FLAG_SKIP_DNS_SERVER    uint32 = 0x0008
+		GAA_FLAG_SKIP_FRIENDLY_NAME uint32 = 0x0010
+	)
+
+	// Return only IPv4 unicast addresses
+	const (
+		family uint32 = windows.AF_INET
+		flags  uint32 = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_SKIP_FRIENDLY_NAME
+	)
+
+	buf := make([]windows.IpAdapterAddresses, 1)
+	for i := 0; i < 100; i++ {
+		size := uint32(len(buf))
+
+		err := windows.GetAdaptersAddresses(family, flags, 0, &buf[0], &size)
+		if errors.Is(err, windows.ERROR_BUFFER_OVERFLOW) {
+			// Buffer too small, try again with the returned size.
+			buf = make([]windows.IpAdapterAddresses, size)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		break
+	}
+
+	// Returning the buffer would be confusing to the caller, as it is a fake slice.
+	// Only the first element is valid, accessing any other element causes a panic.
+	return &buf[0], nil
+}
+
+// safeUTF16ToString is equivalent to windows.UTF16ToString, but it takes a maximum length
+// to avoid reading past the end of the buffer.
+func safeUTF16ToString(ptr *uint16, maxLen int) string {
+	//nolint:gosec // This is safe because:
+	// 1. This slice does not escape the function.
+	// 2. windows.UTF16ToString checks for null-termination.
+	s := unsafe.Slice(ptr, maxLen)
+
+	return windows.UTF16ToString(s)
+}


### PR DESCRIPTION
Up until now we listened to all interfaces, this of course exposed us to the outside world.

With this change, we stay in our network, and we hope we'll also avoid ugly Windows Defender firewall pop-ups.

You can get this address in Powershell with:
```
Get-NetIPAddress -InterfaceAlias 'vEthernet (WSL (Hyper-V firewall))' -AddressFamily "IPv4" | Select-Object -ExpandProperty IPAddress
```

I prefered to avoid unnecessary subprocessing, so we instead use the Win32 API:

https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses

---

UDENG-2320