### PR TITLE
fix(Landscape): fix bad time staircase

### DIFF
--- a/windows-agent/internal/proservices/landscape/controller.go
+++ b/windows-agent/internal/proservices/landscape/controller.go
@@ -52,18 +52,12 @@ func (c Controller) forceReconnect(ctx context.Context) bool {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		case <-c.hasStopped():
-			return false
-		case <-ticker.C:
-		}
-
-		if !c.connected() {
-			break
-		}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-c.hasStopped():
+		return false
+	case <-c.connDone():
 	}
 
 	// Waiting until re-connection

--- a/windows-agent/internal/proservices/landscape/interfaces.go
+++ b/windows-agent/internal/proservices/landscape/interfaces.go
@@ -20,5 +20,6 @@ type serviceData interface {
 type serviceConn interface {
 	connected() bool
 	reconnect()
+	connDone() <-chan struct{}
 	sendInfo(*landscapeapi.HostAgentInfo) error
 }

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -312,6 +312,19 @@ func (s *Service) reconnect() {
 	s.connRetrier.Request()
 }
 
+func (s *Service) connDone() <-chan struct{} {
+	s.connMu.RLock()
+	defer s.connMu.RUnlock()
+
+	if s.conn == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+
+	return s.conn.ctx.Done()
+}
+
 func (s *Service) hasStopped() <-chan struct{} {
 	return s.ctx.Done()
 }


### PR DESCRIPTION
The "if error -> increase wait" logic did not work.

It now does work, and we also consider short-lived connections as errors (to avoid spamming 1-second connections that the server rejects for whatever reason, or spamming with flaky connections, etc).

This also fixes the recently flaky Landscape tests.

---

UDENG-2261