### PR TITLE
maint(ci): Allows that one percent coverage reduction

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        threshold: 1%
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  range: 85..100
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,10 @@ coverage:
   status:
     project:
       default:
+        # Some tests are causing coverage fluctuation (race condition or flakyness)
+        # TODO: Investigate and fix, then reduce this threshold.
         threshold: 1%
     patch:
+      # TODO: Consider relaxing the patch target vs range for the global project in the long term, being more lenient on the patches themselves.
       default:
         threshold: 1%
-


### PR DESCRIPTION
Should allow CI to be happier with racy tests
Until we figure out the source of fluctuations I guess.

All cases in CI which we could forgive coverage drop reports were well under 0.80%, so 1% seems not too tight.

Let see how this goes.

Ref: 
- https://docs.codecov.com/docs/commit-status
- https://docs.codecov.com/docs/codecov-yaml