### PR TITLE
fix(msix): Attempt to prevent firewall popus

### DIFF
--- a/msix/UbuntuProForWSL/Package.appxmanifest
+++ b/msix/UbuntuProForWSL/Package.appxmanifest
@@ -76,8 +76,8 @@
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules" Executable="agent\ubuntu-pro-agent.exe" EntryPoint="Windows.FullTrustApplication">
       <desktop2:FirewallRules Executable="agent\ubuntu-pro-agent.exe">
-        <desktop2:Rule Profile="private" IPProtocol="TCP" Direction="in"></desktop2:Rule>
-        <desktop2:Rule Profile="private" IPProtocol="TCP" Direction="out"></desktop2:Rule>
+        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="in" LocalPortMin=49152 LocalPortMax=65535 ></desktop2:Rule>
+        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="out" LocalPortMin=49152 LocalPortMax=65535 ></desktop2:Rule>
       </desktop2:FirewallRules>
     </desktop2:Extension>
   </Extensions>


### PR DESCRIPTION
By deploying firewall rules for all network profiles. I had success with this testing in VMs. I'd like to have others testing the build to make sure the firewall popups won't show up before merging.