### PR TITLE
maint(windows-agent): No TLS from agent to Landscape

### DIFF
--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -83,10 +83,13 @@ func TestConnect(t *testing.T) {
 		wantErr           bool
 		wantDistroSkipped bool
 	}{
-		"Success":                         {},
-		"Success in non-first contact":    {uid: "123"},
-		"Success with an SSL certificate": {requireCertificate: true},
+		"Success":                      {},
+		"Success in non-first contact": {uid: "123"},
+		// TODO: Re-enable this test case when Landscape server start supporting gRPC over TLS.
+		// "Success with an SSL certificate": {requireCertificate: true},
 
+		//"Error when the SSL certificate cannot be read":        {wantErr: true},
+		//"Error when the SSL certificate is not valid":          {wantErr: true},
 		"Error when the context is cancelled before Connected": {precancelContext: true, wantErr: true},
 		"Error when the config is empty":                       {wantErr: true},
 		"Error when the landscape URL cannot be retrieved":     {wantErr: true},
@@ -96,8 +99,6 @@ func TestConnect(t *testing.T) {
 		"Error when the first-contact SendUpdatedInfo fails":   {tokenErr: true, wantErr: true},
 		"Error when the config cannot be accessed":             {breakLandscapeClientConfig: true, wantErr: true},
 		"Error when the config cannot be parsed":               {wantErr: true},
-		"Error when the SSL certificate cannot be read":        {wantErr: true},
-		"Error when the SSL certificate is not valid":          {wantErr: true},
 		"Error when there is no Ubuntu Pro token":              {emptyToken: true, wantErr: true},
 	}
 
@@ -611,6 +612,8 @@ func TestReconnect(t *testing.T) {
 
 		c.triggerNotifications()
 	}
+	// TODO:Remove this silly assignment when Landscape server start supporting gRPC over TLS.
+	_ = changeCertificate
 
 	changeIrrelevant := func(ctx context.Context, s *landscape.Service, c *mockConfig) {
 		c.mu.Lock()
@@ -629,8 +632,9 @@ func TestReconnect(t *testing.T) {
 	}{
 		"Reconnect when explicitly requesting a reconnection": {trigger: requestReconnect, wantImmediateRconnect: true},
 		"Reconnect when changing the URL":                     {trigger: changeAddress},
-		"Reconnect when changing the certificate path":        {trigger: changeCertificate, useCertificate: true},
-		"Don't reconnect when changing irrelevant config":     {trigger: changeIrrelevant, wantNoReconnect: true},
+		// TODO: Re-enable this test case when Landscape server start supporting gRPC over TLS.
+		// "Reconnect when changing the certificate path":        {trigger: changeCertificate, useCertificate: true},
+		"Don't reconnect when changing irrelevant config": {trigger: changeIrrelevant, wantNoReconnect: true},
 	}
 
 	for name, tc := range testCases {

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -131,12 +131,13 @@ func newLandscapeHostConf(config Config) (conf landscapeHostConf, err error) {
 
 	sec, err := ini.GetSection("client")
 	if err == nil {
-		k, err := sec.GetKey("ssl_public_key")
-		if err == nil {
-			conf.sslPublicKey = k.String()
-		}
+		// TODO: Re-enable this code path when Landscape server start supporting gRPC over TLS.
+		// k, err := sec.GetKey("ssl_public_key")
+		// if err == nil {
+		// 	conf.sslPublicKey = k.String()
+		// }
 
-		k, err = sec.GetKey("account_name")
+		k, err := sec.GetKey("account_name")
 		if err == nil {
 			conf.accountName = k.String()
 		}


### PR DESCRIPTION
Landscape quick setup for now at least is not talking to the agent over TLS. The team was advised and they are working to enable such feature. In the meanwhile let's use insecure credentials on the connection to Landscape. I'm doing this in a ugly but easy to revert way.