### PR TITLE
fix(windows-agent): Use the almost-default logrus formatter

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
@@ -77,7 +76,6 @@ func setLoggerOutput(a app) (func(), error) {
 	log.SetOutput(w)
 
 	fmt.Fprintf(f, "\n======= STARTUP =======\n")
-	log.Infof("Time: %s", time.Now().Format(time.RFC3339))
 	log.Infof("Version: %s", common.Version)
 
 	return func() { _ = f.Close() }, nil

--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -36,15 +36,6 @@ type app interface {
 func run(a app) int {
 	defer installSignalHandler(a)()
 
-	log.SetFormatter(&log.TextFormatter{
-		DisableLevelTruncation: true,
-		DisableTimestamp:       true,
-
-		// ForceColors is necessary on Windows, not only to have colors but to
-		// prevent logrus from falling back to structured logs.
-		ForceColors: true,
-	})
-
 	cleanup, err := setLoggerOutput(a)
 	if err != nil {
 		log.Warningf("could not set logger output: %v", err)

--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -36,6 +36,10 @@ type app interface {
 func run(a app) int {
 	defer installSignalHandler(a)()
 
+	log.SetFormatter(&log.TextFormatter{
+		DisableQuote: true,
+	})
+
 	cleanup, err := setLoggerOutput(a)
 	if err != nil {
 		log.Warningf("could not set logger output: %v", err)


### PR DESCRIPTION
This formatter is for consoles so it looks ugly in logfiles. The default logger produces structured logging so it works well enough, but I removed the quotes because windows\\\\paths\\\\are\\\\annoying\\\\to\\\\copy\\\\and\\\\paste.

Before:

```
======= STARTUP =======
[36mINFO[0m Time: 2024-02-23T15:01:40+01:00              
[36mINFO[0m Version: Dev                                 
[37mDEBUG[0m Debug mode is enabled                        
[37mDEBUG[0m Agent public directory: C:\Users\edu19\.ubuntupro 
[37mDEBUG[0m Agent private directory: C:\Users\edu19\AppData\Local\Ubuntu Pro 
```

After
```
======= STARTUP =======
time=2024-02-23T17:21:45+01:00 level=info msg=Version: Dev
time=2024-02-23T17:21:45+01:00 level=debug msg=Debug mode is enabled
time=2024-02-23T17:21:45+01:00 level=debug msg=Agent public directory: C:\Users\edu19\.ubuntupro
time=2024-02-23T17:21:45+01:00 level=debug msg=Agent private directory: C:\Users\edu19\AppData\Local\Ubuntu Pro
```