### PR TITLE
fix(windows-agent): Fix race in Landscape tests

### DIFF
--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -515,7 +515,7 @@ func TestAutoReconnection(t *testing.T) {
 
 			// Detecting reconnection
 			require.Eventually(t, func() bool {
-				return service.Connected()
+				return mockService.IsConnected(uid)
 			}, 10*time.Second, 100*time.Millisecond, "Client should have reconnected after the stream is dropped")
 
 			ok = monitorDisconnection(t, mockService, uid, func() error {


### PR DESCRIPTION
The diff is quite subtle, here is the explanation. This part of the test does the following:
  1. Wait until we connect to the Landscape server.
  2. Stop the server and detect the disconnection.

We validate that we connected to the server by querying the client -> client.Connected().

Step 2 has three sub-steps:
  - 2.1 Ensure we are connected
  - 2.2 Stop the server
  - 2.3 Wait for disconnection

We perforn the step 2.1 by querying the server ->
server.IsConnected(clientUID)

There is a race between 1. and 2.1! There is a brief window of time where the gRPC connection has been made, but the server has not yet added the client to its internal database. Hence, check 1. succeeds but check 2.1 fails (as the UID is not yet recognized).

Changing step 1. to query the server is the easiest fix.