### PR TITLE
fix(msix): Port numbers must be quoted

### DIFF
--- a/msix/UbuntuProForWSL/Package.appxmanifest
+++ b/msix/UbuntuProForWSL/Package.appxmanifest
@@ -76,8 +76,8 @@
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules" Executable="agent\ubuntu-pro-agent.exe" EntryPoint="Windows.FullTrustApplication">
       <desktop2:FirewallRules Executable="agent\ubuntu-pro-agent.exe">
-        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="in" LocalPortMin=49152 LocalPortMax=65535 ></desktop2:Rule>
-        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="out" LocalPortMin=49152 LocalPortMax=65535 ></desktop2:Rule>
+        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="in" LocalPortMin="49152" LocalPortMax="65535" ></desktop2:Rule>
+        <desktop2:Rule Profile="all" IPProtocol="TCP" Direction="out" LocalPortMin="49152" LocalPortMax="65535" ></desktop2:Rule>
       </desktop2:FirewallRules>
     </desktop2:Extension>
   </Extensions>


### PR DESCRIPTION
inside the .appxmanifest file.

ref: https://github.com/canonical/ubuntu-pro-for-wsl/pull/600#issuecomment-1964206066 and https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/8049768246/job/21984022791?pr=599#step:9:257