### PR TITLE
fix(msix): Restart automatically after receiving updates

### DIFF
--- a/msix/ubuntu-pro-agent-launcher/main.cpp
+++ b/msix/ubuntu-pro-agent-launcher/main.cpp
@@ -32,7 +32,7 @@ std::filesystem::path thisBinaryDir() {
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR pCmdLine, int) try {
   // Request to restart if closed for installing updates.
   RegisterApplicationRestart(
-      NULL, RESTART_NO_CRASH | RESTART_NO_HANG | RESTART_NO_REBOOT);
+      pCmdLine, RESTART_NO_CRASH | RESTART_NO_HANG | RESTART_NO_REBOOT);
   // setup the app: pipes and console
   up4w::PseudoConsole console{{.X = 80, .Y = 80}};
 

--- a/msix/ubuntu-pro-agent-launcher/main.cpp
+++ b/msix/ubuntu-pro-agent-launcher/main.cpp
@@ -30,6 +30,9 @@ std::filesystem::path thisBinaryDir() {
 }
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR pCmdLine, int) try {
+  // Request to restart if closed for installing updates.
+  RegisterApplicationRestart(
+      NULL, RESTART_NO_CRASH | RESTART_NO_HANG | RESTART_NO_REBOOT);
   // setup the app: pipes and console
   up4w::PseudoConsole console{{.X = 80, .Y = 80}};
 


### PR DESCRIPTION
I played with this in different scenarios and ended up with the most obvious one: doing the call to register the application restart the earliest possible in `main`. I'd like to defer that registration to the last moment possible (when the message `WM_QUERYENDSESSION` arrives to the queue), but that would only work if I create a window, something we don't do in the agent, which is a true console application, nor in the agent launcher, which is a fake window app, since it does not create a window.

This does what it promisses: once a build containing this patch is asked to close to install updates, the OS is tasked to restart the new version of the agent launcher (and consequently the agent). Notice that the restart is ignored if the app gets closed due hang, crash or reboot (`RESTART_NO_CRASH | RESTART_NO_HANG | RESTART_NO_REBOOT`). The reboot case is already handled by the startup task.

For more information about this topic, see:

- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart and
- https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#restart-automatically-after-receiving-an-update-from-the-microsoft-store