### PR TITLE
fix(wsl-pro-service): Fix bug where IPv6 addresses where badly concatenated with port

### DIFF
--- a/wsl-pro-service/internal/controlstream/controlstream.go
+++ b/wsl-pro-service/internal/controlstream/controlstream.go
@@ -138,7 +138,7 @@ func (cs ControlStream) address(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("could not parse port from %q: %v", addr, err)
 	}
 
-	return fmt.Sprintf("%s:%s", windowsLocalhost, port), nil
+	return net.JoinHostPort(windowsLocalhost.String(), port), nil
 }
 
 // ReservedPort returns the port assigned to this distro.


### PR DESCRIPTION
Thanks @iosifache for noticing!

Co-authored-by: Didier Roche-Tolomelli <didrocks@ubuntu.com>
