### PR TITLE
fix(windows-agent): Fix race in ubuntupro tests

### DIFF
--- a/windows-agent/internal/ubuntupro/ubuntupro_test.go
+++ b/windows-agent/internal/ubuntupro/ubuntupro_test.go
@@ -51,6 +51,7 @@ func TestDistribute(t *testing.T) {
 
 			dist, err := db.GetDistroAndUpdateProperties(ctx, distroName, distro.Properties{})
 			require.NoError(t, err, "Setup: GetDistroAndUpdateProperties should return no error")
+			defer dist.Cleanup(ctx)
 
 			if tc.distroIsDead {
 				dist.Invalidate(ctx)


### PR DESCRIPTION
We were leaking the distro task processing. This caused a race in the removal of the distro's working dir.

See race here: https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/8097649091/job/22129174184#step:7:72