### PR TITLE
deps(windows-agent): Update GoWSL dependency

### DIFF
--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c
-	github.com/ubuntu/gowsl v0.0.0-20231004124730-8fd8df02f394
+	github.com/ubuntu/gowsl v0.0.0-20240213160838-c27a23d27d12
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sys v0.17.0
 	google.golang.org/grpc v1.62.0

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -84,8 +84,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c h1:jO41xNLddTDkrfz4w4RCMWCmX8Y+ZHz5jSbJWNLDvqU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c/go.mod h1:edGgz97NOqS2oqzbKrZqO9YU9neosRrkEZbVJVQynAA=
-github.com/ubuntu/gowsl v0.0.0-20231004124730-8fd8df02f394 h1:DS9wb53gTUxFCPYnhAqOhfdRLsHTL9NpzT+F/D8NwIg=
-github.com/ubuntu/gowsl v0.0.0-20231004124730-8fd8df02f394/go.mod h1:gu6CgOaqMFFz1h96UocQwXvRvF6CePIqQnI58DzIg2Q=
+github.com/ubuntu/gowsl v0.0.0-20240213160838-c27a23d27d12 h1:LrBQDPvsK4Pqluy05iw8w51F6XWndIfyssL4g/fLAzo=
+github.com/ubuntu/gowsl v0.0.0-20240213160838-c27a23d27d12/go.mod h1:7hcEt67BNrsJHVZtWBCU0tJG0JQEvoMSi+TN1hFZHHg=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=


### PR DESCRIPTION
We were currently pinned at a four-month-old commit. The only changes are dependabot things, but those may contain security fixes