### PR TITLE
feat(Landscape): Do not cancel commands in progress, and ping the server back on completion

### DIFF
--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -218,7 +218,10 @@ func (conn *connection) receiveCommands(e executor) error {
 			return fmt.Errorf("could not receive commands: %v", err)
 		}
 
-		if err := e.exec(conn.ctx, command); err != nil {
+		// Removing the cancel context so that the command is executed even if the connection is lost.
+		ctx := context.WithoutCancel(conn.ctx)
+
+		if err := e.exec(ctx, command); err != nil {
 			log.Errorf(conn.ctx, "Landscape: %v", err)
 		}
 

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -234,6 +234,8 @@ func (conn *connection) receiveCommands(e executor) error {
 		if err := conn.sendInfo(info); err != nil {
 			log.Warningf(conn.ctx, "Landscape: after completing command: %v", err)
 		}
+
+		log.Infof(conn.ctx, "Landscape: replied to command %s ", commandString(command))
 	}
 }
 

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -221,6 +221,16 @@ func (conn *connection) receiveCommands(e executor) error {
 		if err := e.exec(conn.ctx, command); err != nil {
 			log.Errorf(conn.ctx, "Landscape: %v", err)
 		}
+
+		// Ping back the server with the updated info
+		info, err := newHostAgentInfo(conn.ctx, e.serviceData)
+		if err != nil {
+			log.Warningf(conn.ctx, "Landscape: after completing command: %v", err)
+		}
+
+		if err := conn.sendInfo(info); err != nil {
+			log.Warningf(conn.ctx, "Landscape: after completing command: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
The connection dropping should not stop a distro registration, for instance.
And for the server to know that a command worked, we should ping them when it has completed.

---

UDENG-2422
UDENG-2425
