### PR TITLE
maint(windows-agent): Revert "No TLS from agent to Landscape (#601)"

### DIFF
--- a/end-to-end/landscape_utils_test.go
+++ b/end-to-end/landscape_utils_test.go
@@ -3,20 +3,23 @@ package endtoend_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"log/slog"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
 	landscapeapi "github.com/canonical/landscape-hostagent-api"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/testutils"
 	"github.com/canonical/ubuntu-pro-for-wsl/mocks/landscape/landscapemockservice"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/gowsl"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 // landscape manages all the aspects necessary to hosting a Landscape mock server.
@@ -37,28 +40,45 @@ type landscape struct {
 //
 //nolint:revive // Context goes after testing.T
 func NewLandscape(t *testing.T, ctx context.Context) (l landscape) {
-	// TODO: Restore TLS when the agent supports it.
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(ctx)
 	l.stop = cancel
 	t.Cleanup(cancel)
 
+	certPath := t.TempDir()
+	testutils.GenerateTempCertificate(t, certPath)
+
+	certificatePath := filepath.Join(certPath, "cert.pem")
+	privateKeyPath := filepath.Join(certPath, "key.pem")
+
+	serverCert, err := tls.LoadX509KeyPair(certificatePath, privateKeyPath)
+	require.NoError(t, err, "Setup: could not load Landscape mock server credentials")
+
 	var cfg net.ListenConfig
 	lis, err := cfg.Listen(ctx, "tcp", "localhost:")
 	require.NoError(t, err, "Setup: can't listen")
 	l.lis = lis
 
+	config := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.NoClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}
+
 	h := slog.NewTextHandler(&l.logs, &slog.HandlerOptions{Level: slog.LevelDebug})
 	l.service = landscapemockservice.New(landscapemockservice.WithLogger(slog.New(h)))
 
-	l.server = grpc.NewServer(grpc.Creds(insecure.NewCredentials()))
+	l.server = grpc.NewServer(grpc.Creds(credentials.NewTLS(config)))
 	landscapeapi.RegisterLandscapeHostAgentServer(l.server, l.service)
 
 	l.ClientConfig = fmt.Sprintf(`
 	[host]
 	url = %s
-	`, lis.Addr())
+	
+	[client]
+	ssl_public_key = %s
+	`, lis.Addr(), certificatePath)
 
 	return l
 }

--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -85,10 +85,9 @@ func TestConnect(t *testing.T) {
 		wantDistroSkipped bool
 		wantSingleMessage bool
 	}{
-		"Success":                      {},
-		"Success in non-first contact": {uid: "123", wantSingleMessage: true},
-		// TODO: Re-enable this test case when Landscape server start supporting gRPC over TLS.
-		// "Success with an SSL certificate": {requireCertificate: true},
+		"Success":                         {},
+		"Success in non-first contact":    {uid: "123", wantSingleMessage: true},
+		"Success with an SSL certificate": {requireCertificate: true},
 
 		// These tests are for the error cases when the error is logged but not returned
 		"Silent error when the config is empty":                   {wantNotConnected: true},
@@ -103,8 +102,8 @@ func TestConnect(t *testing.T) {
 		"Error when the first-contact SendUpdatedInfo fails":   {tokenErr: true, wantErr: true},
 		"Error when the config cannot be accessed":             {breakLandscapeClientConfig: true, wantErr: true},
 		"Error when the config cannot be parsed":               {wantErr: true},
-		// "Error when the SSL certificate cannot be read":        {wantErr: true},
-		// "Error when the SSL certificate is not valid":          {wantErr: true},
+		"Error when the SSL certificate cannot be read":        {wantErr: true},
+		"Error when the SSL certificate is not valid":          {wantErr: true},
 	}
 
 	for name, tc := range testCases {
@@ -657,8 +656,6 @@ func TestReconnect(t *testing.T) {
 
 		s.NotifyUbuntuProUpdate(ctx, c.proToken)
 	}
-	// TODO:Remove this silly assignment when Landscape server start supporting gRPC over TLS.
-	_ = changeCertificate
 
 	changeIrrelevant := func(ctx context.Context, s *landscape.Service, c *mockConfig) {
 		c.mu.Lock()
@@ -686,8 +683,7 @@ func TestReconnect(t *testing.T) {
 	}{
 		"Reconnect when explicitly requesting a reconnection": {trigger: requestReconnect, wantImmediateReconnect: true},
 		"Reconnect when changing the URL":                     {trigger: changeAddress},
-		// TODO: Re-enable this test case when Landscape server start supporting gRPC over TLS.
-		// "Reconnect when changing the certificate path":        {trigger: changeCertificate, useCertificate: true},
+		"Reconnect when changing the certificate path":        {trigger: changeCertificate, useCertificate: true},
 
 		"Don't disconnect when changing irrelevant config": {trigger: changeIrrelevant, wantNoDisconnect: true},
 

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -151,13 +151,12 @@ func newLandscapeHostConf(config Config) (conf landscapeHostConf, err error) {
 
 	sec, err := ini.GetSection("client")
 	if err == nil {
-		// TODO: Re-enable this code path when Landscape server start supporting gRPC over TLS.
-		// k, err := sec.GetKey("ssl_public_key")
-		// if err == nil {
-		// 	conf.sslPublicKey = k.String()
-		// }
+		k, err := sec.GetKey("ssl_public_key")
+		if err == nil {
+			conf.sslPublicKey = k.String()
+		}
 
-		k, err := sec.GetKey("account_name")
+		k, err = sec.GetKey("account_name")
 		if err == nil {
 			conf.accountName = k.String()
 		}


### PR DESCRIPTION
This reverts commit 1b7275d345b1bf7125b17bb1fd0f9b3190a424c6, reversing changes made to 63bb25988bcc9e92f916f525a950f59f449d383e.

Merge once @wck0 pings us.

---

UDENG-2424