### PR TITLE
feat(windows-agent): Notify landscape when SetUserLandscapeConfig is used

### DIFF
--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -199,7 +199,7 @@ void main() {
         expect(tester.widget<FilledButton>(continueButton).enabled, isFalse);
 
         // check that valid input enabled continue, and continue
-        await tester.enterText(fqdnInput, 'example.com');
+        await tester.enterText(fqdnInput, 'localhost');
         await tester.pump();
         expect(tester.widget<FilledButton>(continueButton).enabled, isTrue);
         await tester.tap(continueButton);

--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -179,8 +179,13 @@ func (c *Config) SetUserLandscapeConfig(ctx context.Context, landscapeConfig str
 		return errors.New("attempted to set a user-provided landscape configuration when there already is a higher priority one")
 	}
 
-	if _, err := c.set(&c.Landscape.UserConfig, landscapeConfig); err != nil {
+	isNew, err := c.set(&c.Landscape.UserConfig, landscapeConfig)
+	if err != nil {
 		return errors.New("config: could not set Landscape configuration")
+	}
+
+	if isNew {
+		c.notifyLandsape(ctx, landscapeConfig, c.Landscape.UID)
 	}
 
 	return nil

--- a/windows-agent/internal/config/config_test.go
+++ b/windows-agent/internal/config/config_test.go
@@ -461,6 +461,15 @@ func TestSetUserLandscapeConfig(t *testing.T) {
 
 			landscapeConfig := "LANDSCAPE CONFIG"
 
+			var calledLandscapeNotifier int
+			conf.SetUbuntuProNotifier(func(context.Context, string) {
+				require.Fail(t, "UbuntuPro should not be called")
+			})
+
+			conf.SetLandscapeNotifier(func(context.Context, string, string) {
+				calledLandscapeNotifier++
+			})
+
 			err = conf.SetUserLandscapeConfig(ctx, landscapeConfig)
 			if tc.wantError {
 				require.Error(t, err, "SetUserLandscapeConfig should return an error")
@@ -472,6 +481,7 @@ func TestSetUserLandscapeConfig(t *testing.T) {
 			require.NoError(t, err, "LandscapeClientConfig should return no errors")
 			require.Equal(t, landscapeConfig, got, "Did not get the same value for landscape config as we set")
 			require.Equal(t, config.SourceUser, src, "Did not get the same value for landscape config as we set")
+			require.Equal(t, 1, calledLandscapeNotifier, "LandscapeNotifier should have been called once")
 		})
 	}
 }


### PR DESCRIPTION
This function is called when the UI reports a new Landscape config

---

UDENG-2421