### PR TITLE
fix(gui): Regression: not checking subscription status on startup

### DIFF
--- a/gui/packages/ubuntupro/lib/app.dart
+++ b/gui/packages/ubuntupro/lib/app.dart
@@ -36,26 +36,29 @@ class Pro4WSLApp extends StatelessWidget {
             builder: (context, child) {
               return Wizard(
                 routes: {
-                  Routes.startup: const WizardRoute(builder: buildStartup),
+                  Routes.startup: WizardRoute(
+                    builder: buildStartup,
+                    onNext: (_) async {
+                      final subscriptionInfo =
+                          context.read<ValueNotifier<SubscriptionInfo>>();
+                      final client = getService<AgentApiClient>();
+                      subscriptionInfo.value = await client.subscriptionInfo();
+
+                      if (subscriptionInfo.value.whichSubscriptionType() !=
+                          SubscriptionType.none) {
+                        return Routes.subscriptionStatus;
+                      }
+                      return null;
+                    },
+                  ),
                   Routes.subscribeNow:
                       const WizardRoute(builder: SubscribeNowPage.create),
                   Routes.configureLandscape:
                       const WizardRoute(builder: LandscapePage.create),
                   Routes.subscriptionStatus: WizardRoute(
                     builder: SubscriptionStatusPage.create,
-                    onLoad: (_) async {
-                      final client = getService<AgentApiClient>();
-                      final subscriptionInfo =
-                          context.read<ValueNotifier<SubscriptionInfo>>();
-
-                      subscriptionInfo.value = await client.subscriptionInfo();
-
-                      // never skip this page.
-                      return true;
-                    },
-                    onBack: (settings) {
-                      return Routes.subscribeNow;
-                    },
+                    onReplace: (_) => Routes.subscribeNow,
+                    onBack: (_) => Routes.subscribeNow,
                   ),
                   Routes.configureLandscapeLate: WizardRoute(
                     builder: (context) => LandscapePage.create(

--- a/gui/packages/ubuntupro/lib/app.dart
+++ b/gui/packages/ubuntupro/lib/app.dart
@@ -38,7 +38,7 @@ class Pro4WSLApp extends StatelessWidget {
                 routes: {
                   Routes.startup: WizardRoute(
                     builder: buildStartup,
-                    onNext: (_) async {
+                    onReplace: (_) async {
                       final subscriptionInfo =
                           context.read<ValueNotifier<SubscriptionInfo>>();
                       final client = getService<AgentApiClient>();

--- a/gui/packages/ubuntupro/lib/pages/startup/startup_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/startup/startup_page.dart
@@ -47,7 +47,7 @@ class _StartupAnimatedChildState extends State<StartupAnimatedChild> {
     model.init();
     model.addListener(() async {
       if (model.view == ViewState.ok) {
-        await Wizard.of(context).next();
+        await Wizard.of(context).replace();
       }
       if (model.view == ViewState.retry) {
         await model.resetAgent();

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
@@ -66,8 +66,16 @@ class SubscriptionStatusPage extends StatelessWidget {
                 onPressed: () async {
                   await model.detachPro();
                   if (context.mounted) {
-                    Wizard.of(context).home();
-                    await Wizard.of(context).next();
+                    // TODO: Find a way to place this logic upwards.
+                    final countOfLoadedPages =
+                        Wizard.of(context).controller.state.length;
+                    // If more than just Startup and this one, we can go back.
+                    if (countOfLoadedPages > 2) {
+                      Wizard.of(context).back();
+                    } else {
+                      // otherwise we need .replace() or .jump(). [small detail of the wizard_router package]
+                      await Wizard.of(context).replace();
+                    }
                   }
                 },
                 child: Text(lang.detachPro),

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
@@ -66,11 +66,9 @@ class SubscriptionStatusPage extends StatelessWidget {
                 onPressed: () async {
                   await model.detachPro();
                   if (context.mounted) {
-                    // TODO: Find a way to place this logic upwards.
-                    final countOfLoadedPages =
-                        Wizard.of(context).controller.state.length;
-                    // If more than just Startup and this one, we can go back.
-                    if (countOfLoadedPages > 2) {
+                    final wizard = Wizard.of(context);
+                    // If more than just this one, we can go back.
+                    if (wizard.hasPrevious) {
                       Wizard.of(context).back();
                     } else {
                       // otherwise we need .replace() or .jump(). [small detail of the wizard_router package]


### PR DESCRIPTION
For users it looks like the app forgotten the Pro token previously supplied. The current state is always starting in the subscribe now page. When refactoring the app code, we mistakenly placed the call to get the current subscription status in the last screen, it should be on the first.

Added an integration test to assert that behavior.

Also, notice the usage of `Wizard.of(context).replace()` instead of `.next()` or `.jump()`. It has the benefit of removing the current page from the navigator, thus allowing the `SubscriptionStatusPage` to consider itself the only one if the apps starts with a pre-existing subscription as well as prevents undesired back navigations (such as going back from the `SubscribeNowPage` to the `SubscriptionStatusPage` or the `StartupPage`).