### PR TITLE
feat(windows-agent): Obfuscate pro token when logged

### DIFF
--- a/windows-agent/internal/proservices/ui/ui.go
+++ b/windows-agent/internal/proservices/ui/ui.go
@@ -62,12 +62,12 @@ func (s *Service) ApplyProToken(ctx context.Context, info *agentapi.ProAttachInf
 		return nil, fmt.Errorf("some distros could not pro-attach: %v", err)
 	}
 
-	subs, err := s.getSubscriptionInfo()
+	subs, err := s.getSubscriptionSource()
 	if err != nil {
 		return subs, fmt.Errorf("could not assemble response: %v", err)
 	}
 
-	log.Debugf(ctx, "UI service: responding ApplyProToken with info: %v", info)
+	log.Debugf(ctx, "UI service: responding ApplyProToken with following info: %v", subs)
 	return subs, nil
 }
 
@@ -93,7 +93,7 @@ func (s *Service) Ping(ctx context.Context, request *agentapi.Empty) (*agentapi.
 func (s *Service) GetSubscriptionInfo(ctx context.Context, empty *agentapi.Empty) (_ *agentapi.SubscriptionInfo, err error) {
 	log.Info(ctx, "UI service: received GetSubscriptionInfo message")
 
-	info, err := s.getSubscriptionInfo()
+	info, err := s.getSubscriptionSource()
 	if err != nil {
 		err = fmt.Errorf("UI service: GetSubscriptionInfo: %v", err)
 		log.Warningf(ctx, "%v", err)
@@ -104,7 +104,7 @@ func (s *Service) GetSubscriptionInfo(ctx context.Context, empty *agentapi.Empty
 	return info, nil
 }
 
-func (s *Service) getSubscriptionInfo() (*agentapi.SubscriptionInfo, error) {
+func (s *Service) getSubscriptionSource() (*agentapi.SubscriptionInfo, error) {
 	info := &agentapi.SubscriptionInfo{}
 
 	_, source, err := s.config.Subscription()
@@ -137,7 +137,7 @@ func (s *Service) NotifyPurchase(ctx context.Context, empty *agentapi.Empty) (in
 		errs = errors.Join(errs, err)
 	}
 
-	info, err := s.getSubscriptionInfo()
+	info, err := s.getSubscriptionSource()
 	if err != nil {
 		log.Warningf(ctx, "UI service: NotifyPurchase: %v", err)
 		errs = errors.Join(errs, err)

--- a/windows-agent/internal/tasks/pro_attachment.go
+++ b/windows-agent/internal/tasks/pro_attachment.go
@@ -3,7 +3,9 @@ package tasks
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/task"
 	"github.com/canonical/ubuntu-pro-for-wsl/wslserviceapi"
 )
@@ -30,7 +32,7 @@ func (t ProAttachment) Execute(ctx context.Context, client wslserviceapi.WSLClie
 
 // String is needed to fulfil Task.
 func (t ProAttachment) String() string {
-	return "AttachPro"
+	return fmt.Sprintf("%T task with token: %s", t, common.Obfuscate(t.Token))
 }
 
 // Is is a custom comparator. All AttachPro tasks are considered equivalent.


### PR DESCRIPTION
Previously, the pro token was being logged fully when applied. This PR obfuscates that token so that only the first and last 2 characters are visible.

---

UDENG-2354