### PR TITLE
fix(windows-agent): Truncate log files

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -66,6 +66,13 @@ func setLoggerOutput(a app) (func(), error) {
 
 	logFile := filepath.Join(publicDir, "log")
 
+	// Move old log file
+	fileInfo, err := os.Stat(logFile)
+	if err == nil && fileInfo.Size() > 0 {
+		oldLogFile := filepath.Join(publicDir, "log.old")
+		_ = os.Rename(logFile, oldLogFile)
+	}
+
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("could not open log file: %v", err)

--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -70,7 +70,10 @@ func setLoggerOutput(a app) (func(), error) {
 	fileInfo, err := os.Stat(logFile)
 	if err == nil && fileInfo.Size() > 0 {
 		oldLogFile := filepath.Join(publicDir, "log.old")
-		_ = os.Rename(logFile, oldLogFile)
+		err = os.Rename(logFile, oldLogFile)
+		if err != nil {
+			log.Warnf("Could not archive previous log file: %v", err)
+		}
 	}
 
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)


### PR DESCRIPTION
This PR renames any existing log to `log.old` when the program starts, overwriting the file if it already exists. It also tests that if a log exists a log.old is successfully created.

---

UDENG-2355