### PR TITLE
fix(windows-agent): Truncate log files

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,13 +68,10 @@ func setLoggerOutput(a app) (func(), error) {
 	logFile := filepath.Join(publicDir, "log")
 
 	// Move old log file
-	fileInfo, err := os.Stat(logFile)
-	if err == nil && fileInfo.Size() > 0 {
-		oldLogFile := filepath.Join(publicDir, "log.old")
-		err = os.Rename(logFile, oldLogFile)
-		if err != nil {
-			log.Warnf("Could not archive previous log file: %v", err)
-		}
+	oldLogFile := filepath.Join(publicDir, "log.old")
+	err = os.Rename(logFile, oldLogFile)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Warnf("Could not archive previous log file: %v", err)
 	}
 
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)

--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -66,6 +66,13 @@ func setLoggerOutput(a app) (func(), error) {
 
 	logFile := filepath.Join(publicDir, "log")
 
+	// Move old log file
+	fileInfo, err := os.Stat(logFile)
+	if err == nil && fileInfo.Size() > 0 {
+		oldLogFile := filepath.Join(publicDir, "log.old")
+		_ = os.Rename(logFile, oldLogFile)
+	}
+
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("could not open log file: %v", err)

--- a/windows-agent/cmd/ubuntu-pro-agent/main.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main.go
@@ -70,7 +70,10 @@ func setLoggerOutput(a app) (func(), error) {
 	fileInfo, err := os.Stat(logFile)
 	if err == nil && fileInfo.Size() > 0 {
 		oldLogFile := filepath.Join(publicDir, "log.old")
-		_ = os.Rename(logFile, oldLogFile)
+		err = os.Rename(logFile, oldLogFile)
+		if err != nil {
+			log.Warnf("Could not archive previous log file: %v", err)
+		}
 	}
 
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)

--- a/windows-agent/cmd/ubuntu-pro-agent/main_linux_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_linux_test.go
@@ -26,7 +26,8 @@ func TestRunSignal(t *testing.T) {
 			// Signal handlers tests: can’t be parallel
 
 			a := myApp{
-				done: make(chan struct{}),
+				done:   make(chan struct{}),
+				tmpDir: t.TempDir(),
 			}
 
 			var rc int

--- a/windows-agent/cmd/ubuntu-pro-agent/main_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_test.go
@@ -45,17 +45,23 @@ func TestRun(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		createLog        bool
+		existingLogContent string
+
 		runError         bool
 		usageErrorReturn bool
 		logDirError      bool
 
 		wantReturnCode int
+		wantOldLogFile bool
 	}{
 		"Run and exit successfully":                                {},
 		"Run and exit successfully despite logs not being written": {logDirError: true},
-		"Run and exit successfully when logs already exist":        {createLog: true},
 
+		// Log file handling
+		"Existing log file has been renamed to old": {existingLogContent: "foo", wantOldLogFile: true},
+		"Empty existing log file is overwritten":    {existingLogContent: "-", wantOldLogFile: false},
+
+		// Error cases
 		"Run and return error":                   {runError: true, wantReturnCode: 1},
 		"Run and return usage error":             {usageErrorReturn: true, runError: true, wantReturnCode: 2},
 		"Run and usage error only does not fail": {usageErrorReturn: true, runError: false, wantReturnCode: 0},
@@ -75,11 +81,14 @@ func TestRun(t *testing.T) {
 				a.tmpDir = "PUBLIC_DIR_ERROR"
 			}
 
-			if tc.createLog {
+			if tc.existingLogContent != "" {
+				if tc.existingLogContent == "-" {
+					tc.existingLogContent = ""
+				}
 				publicDir, _ := a.PublicDir()
 				logFile := filepath.Join(publicDir, "log")
-				err := os.WriteFile(logFile, []byte("test log"), 0600)
-				require.NoError(t, err, "")
+				err := os.WriteFile(logFile, []byte(tc.existingLogContent), 0600)
+				require.NoError(t, err, "Setup: creating pre-existing log file")
 			}
 
 			var rc int
@@ -95,13 +104,11 @@ func TestRun(t *testing.T) {
 			<-wait
 
 			publicDir, _ := a.PublicDir()
-			oldLogfile := filepath.Join(publicDir, "log.old")
-			_, err := os.Stat(oldLogfile)
-
-			if tc.createLog {
-				require.NoError(t, err, "Old log file should be created")
+			oldLogFile := filepath.Join(publicDir, "log.old")
+			if tc.wantOldLogFile {
+				require.FileExists(t, oldLogFile, "Old log file should exist")
 			} else {
-				require.Error(t, err, "Old log file should not be created")
+				require.NoFileExists(t, oldLogFile, "Old log file should not exist")
 			}
 
 			require.Equal(t, tc.wantReturnCode, rc, "Return expected code")

--- a/windows-agent/cmd/ubuntu-pro-agent/main_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_test.go
@@ -45,6 +45,7 @@ func TestRun(t *testing.T) {
 	t.Parallel()
 
 	fooContent := "foo"
+	emptyContent := ""
 
 	tests := map[string]struct {
 		existingLogContent string
@@ -60,8 +61,9 @@ func TestRun(t *testing.T) {
 		"Run and exit successfully despite logs not being written": {logDirError: true},
 
 		// Log file handling
-		"Existing log file has been renamed to old": {existingLogContent: "foo", wantOldLogFileContent: &fooContent},
-		"Ignore when failing to archive log file":   {existingLogContent: "OLD_IS_DIRECTORY", wantReturnCode: 0},
+		"Existing log file has been renamed to old":       {existingLogContent: "foo", wantOldLogFileContent: &fooContent},
+		"Existing empty log file has been renamed to old": {existingLogContent: "-", wantOldLogFileContent: &emptyContent},
+		"Ignore when failing to archive log file":         {existingLogContent: "OLD_IS_DIRECTORY", wantReturnCode: 0},
 
 		// Error cases
 		"Run and return error":                   {runError: true, wantReturnCode: 1},
@@ -94,6 +96,9 @@ func TestRun(t *testing.T) {
 					require.NoError(t, err, "Setup: create invalid log.old file")
 					err = os.WriteFile(logFile, []byte("Old log content"), 0600)
 					require.NoError(t, err, "Setup: creating pre-existing log file")
+				case "-":
+					tc.existingLogContent = ""
+					fallthrough
 				default:
 					err := os.WriteFile(logFile, []byte(tc.existingLogContent), 0600)
 					require.NoError(t, err, "Setup: creating pre-existing log file")

--- a/windows-agent/cmd/ubuntu-pro-agent/main_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_test.go
@@ -83,19 +83,21 @@ func TestRun(t *testing.T) {
 				a.tmpDir = "PUBLIC_DIR_ERROR"
 			}
 
-			publicDir, _ := a.PublicDir()
+			publicDir, err := a.PublicDir()
 			logFile := filepath.Join(publicDir, "log")
 			oldLogFile := logFile + ".old"
-			switch tc.existingLogContent {
-			case "":
-			case "OLD_IS_DIRECTORY":
-				err := os.Mkdir(oldLogFile, 0700)
-				require.NoError(t, err, "Setup: create invalid log.old file")
-				err = os.WriteFile(logFile, []byte("Old log content"), 0600)
-				require.NoError(t, err, "Setup: creating pre-existing log file")
-			default:
-				err := os.WriteFile(logFile, []byte(tc.existingLogContent), 0600)
-				require.NoError(t, err, "Setup: creating pre-existing log file")
+			if err == nil {
+				switch tc.existingLogContent {
+				case "":
+				case "OLD_IS_DIRECTORY":
+					err := os.Mkdir(oldLogFile, 0700)
+					require.NoError(t, err, "Setup: create invalid log.old file")
+					err = os.WriteFile(logFile, []byte("Old log content"), 0600)
+					require.NoError(t, err, "Setup: creating pre-existing log file")
+				default:
+					err := os.WriteFile(logFile, []byte(tc.existingLogContent), 0600)
+					require.NoError(t, err, "Setup: creating pre-existing log file")
+				}
 			}
 
 			var rc int

--- a/windows-agent/cmd/ubuntu-pro-agent/main_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -43,6 +45,7 @@ func TestRun(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
+		createLog        bool
 		runError         bool
 		usageErrorReturn bool
 		logDirError      bool
@@ -51,6 +54,7 @@ func TestRun(t *testing.T) {
 	}{
 		"Run and exit successfully":                                {},
 		"Run and exit successfully despite logs not being written": {logDirError: true},
+		"Run and exit successfully when logs already exist":        {createLog: true},
 
 		"Run and return error":                   {runError: true, wantReturnCode: 1},
 		"Run and return usage error":             {usageErrorReturn: true, runError: true, wantReturnCode: 2},
@@ -71,6 +75,13 @@ func TestRun(t *testing.T) {
 				a.tmpDir = "PUBLIC_DIR_ERROR"
 			}
 
+			if tc.createLog {
+				publicDir, _ := a.PublicDir()
+				logFile := filepath.Join(publicDir, "log")
+				err := os.WriteFile(logFile, []byte("test log"), 0600)
+				require.NoError(t, err, "")
+			}
+
 			var rc int
 			wait := make(chan struct{})
 			go func() {
@@ -82,6 +93,16 @@ func TestRun(t *testing.T) {
 
 			a.Quit()
 			<-wait
+
+			publicDir, _ := a.PublicDir()
+			oldLogfile := filepath.Join(publicDir, "log.old")
+			_, err := os.Stat(oldLogfile)
+
+			if tc.createLog {
+				require.NoError(t, err, "Old log file should be created")
+			} else {
+				require.Error(t, err, "Old log file should not be created")
+			}
 
 			require.Equal(t, tc.wantReturnCode, rc, "Return expected code")
 		})

--- a/windows-agent/cmd/ubuntu-pro-agent/main_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/main_test.go
@@ -85,10 +85,11 @@ func TestRun(t *testing.T) {
 				a.tmpDir = "PUBLIC_DIR_ERROR"
 			}
 
+			var logFile, oldLogFile string
 			publicDir, err := a.PublicDir()
-			logFile := filepath.Join(publicDir, "log")
-			oldLogFile := logFile + ".old"
 			if err == nil {
+				logFile = filepath.Join(publicDir, "log")
+				oldLogFile = logFile + ".old"
 				switch tc.existingLogContent {
 				case "":
 				case "OLD_IS_DIRECTORY":
@@ -119,6 +120,10 @@ func TestRun(t *testing.T) {
 
 			require.Equal(t, tc.wantReturnCode, rc, "Return expected code")
 
+			// Don't check for log files if the directory was not writable
+			if logFile == "" {
+				return
+			}
 			if tc.wantOldLogFileContent != nil {
 				require.FileExists(t, oldLogFile, "Old log file should exist")
 				content, err := os.ReadFile(oldLogFile)


### PR DESCRIPTION
This PR renames any existing log to `log.old` when the program starts, overwriting the file if it already exists. It also tests that if a log exists a log.old is successfully created.

---

UDENG-2355