### PR TITLE
maint(wsl-pro-service): Better logging of subprocess errors in WSL-Pro-Service

### DIFF
--- a/wsl-pro-service/internal/system/landscape.go
+++ b/wsl-pro-service/internal/system/landscape.go
@@ -33,7 +33,7 @@ func (s *System) LandscapeEnable(ctx context.Context, landscapeConfig string, ho
 
 	exe, args := s.backend.LandscapeConfigExecutable("--config", landscapeConfigPath, "--silent")
 	//nolint:gosec // In production code, these variables are hard-coded.
-	if out, err := exec.CommandContext(ctx, exe, args...).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("%s returned an error: %v. Output: %s", exe, err, strings.TrimSpace(string(out)))
 	}
 
@@ -45,7 +45,7 @@ func (s *System) LandscapeDisable(ctx context.Context) (err error) {
 	exe, args := s.backend.LandscapeConfigExecutable("--disable")
 
 	//nolint:gosec // In production code, these variables are hard-coded (except for the URLs).
-	if out, err := exec.CommandContext(ctx, exe, args...).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("could not disable Landscape: %s returned an error: %v\nOutput:%s", exe, err, string(out))
 	}
 

--- a/wsl-pro-service/internal/system/pro.go
+++ b/wsl-pro-service/internal/system/pro.go
@@ -15,16 +15,16 @@ func (s System) ProStatus(ctx context.Context) (attached bool, err error) {
 
 	exe, args := s.backend.ProExecutable("status", "--format=json")
 	//nolint:gosec // In production code, these variables are hard-coded (except for the token).
-	out, err := exec.CommandContext(ctx, exe, args...).Output()
+	out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput()
 	if err != nil {
-		return false, fmt.Errorf("command returned error: %v\nStdout:%s", err, string(out))
+		return false, fmt.Errorf("command returned error: %v. Output:%s", err, string(out))
 	}
 
 	var attachedStatus struct {
 		Attached bool
 	}
 	if err = json.Unmarshal(out, &attachedStatus); err != nil {
-		return false, fmt.Errorf("could not parse output: %v\nOutput: %s", err, string(out))
+		return false, fmt.Errorf("could not parse output: %v. Output: %s", err, string(out))
 	}
 
 	return attachedStatus.Attached, nil
@@ -43,7 +43,7 @@ func (s *System) ProAttach(ctx context.Context, token string) (err error) {
 
 	exe, args := s.backend.ProExecutable("attach", token, "--format=json")
 	//nolint:gosec // In production code, these variables are hard-coded (except for the token).
-	out, err := exec.CommandContext(ctx, exe, args...).Output()
+	out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("command returned error: %v\nOutput:%s", err, string(out))
 	}
@@ -72,7 +72,7 @@ func (s *System) ProDetach(ctx context.Context) (err error) {
 		}
 
 		if len(detachedError.Errors) == 0 {
-			return fmt.Errorf("command returned error: %v.\nOutput: %s", detachErr, string(out))
+			return fmt.Errorf("command returned error: %v. Output: %s", detachErr, string(out))
 		}
 
 		if detachedError.Errors[0].MessageCode == "unattached" {

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -144,9 +144,9 @@ func (s *System) WslDistroName(ctx context.Context) (name string, err error) {
 
 	exe, args := s.backend.WslpathExecutable("-w", "/")
 	//nolint:gosec //outside of tests, this function simply prepends "wslpath" to the args.
-	out, err := exec.CommandContext(ctx, exe, args...).Output()
+	out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("could not get distro root path: %v. Stdout: %s", err, string(out))
+		return "", fmt.Errorf("could not get distro root path: %v. Output: %s", err, string(out))
 	}
 
 	// Example output for Windows 11: "\\wsl.localhost\Ubuntu-Preview\"
@@ -173,9 +173,9 @@ func (s *System) UserProfileDir(ctx context.Context) (wslPath string, err error)
 
 	exe, args := s.backend.CmdExe(cmdExe, "/C", "echo %UserProfile%")
 	//nolint:gosec //this function simply prepends the WSL path to "cmd.exe" to the args.
-	out, err := exec.CommandContext(ctx, exe, args...).Output()
+	out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput()
 	if err != nil {
-		return wslPath, fmt.Errorf("%s: error: %v, stdout: %s", exe, err, string(out))
+		return wslPath, fmt.Errorf("%s: error: %v. Output: %s", exe, err, string(out))
 	}
 
 	// Path from Windows' perspective ( C:\Users\... )
@@ -184,9 +184,9 @@ func (s *System) UserProfileDir(ctx context.Context) (wslPath string, err error)
 
 	exe, args = s.backend.WslpathExecutable("-ua", winHome)
 	//nolint:gosec //outside of tests, this function simply prepends "wslpath" to the args.
-	out, err = exec.CommandContext(ctx, exe, args...).Output()
+	out, err = exec.CommandContext(ctx, exe, args...).CombinedOutput()
 	if err != nil {
-		return wslPath, fmt.Errorf("%s: error: %v, stdout: %s", exe, err, string(out))
+		return wslPath, fmt.Errorf("%s: error: %v. Output: %s", exe, err, string(out))
 	}
 
 	winHomeLinux := strings.TrimSpace(string(out))


### PR DESCRIPTION
We were not printing Stderr when something failed, meaning that we lost most of the error message.