### PR TITLE
fix(windows-agent): Fix clean-up of tasks when the distro is invalidated.

### DIFF
--- a/windows-agent/internal/distros/worker/worker.go
+++ b/windows-agent/internal/distros/worker/worker.go
@@ -202,7 +202,7 @@ func (w *Worker) processTasks(ctx context.Context) {
 		resultErr := w.processSingleTask(ctx, t)
 
 		var target unreachableDistroError
-		if errors.Is(resultErr, &target) {
+		if errors.As(resultErr, &target) {
 			log.Errorf(ctx, "Distro %q: task %q: distro not reachable: %v", w.distro.Name(), t, target.sourceErr)
 			w.distro.Invalidate(ctx)
 			continue


### PR DESCRIPTION
Closes #674 
^ The test was not flaky but rather the behaviour!

---

UDENG-2457