### PR TITLE
fix(wsl-pro-service): Don't break when processes print to Stderr

### DIFF
--- a/wsl-pro-service/internal/system/backend.go
+++ b/wsl-pro-service/internal/system/backend.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -22,24 +24,29 @@ func (b realBackend) GetenvWslDistroName() string {
 }
 
 // ProExecutable returns the full command to run the pro executable with the provided arguments.
-func (b realBackend) ProExecutable(args ...string) (string, []string) {
-	return "pro", args
+func (b realBackend) ProExecutable(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "pro", args...)
 }
 
-func (b realBackend) LandscapeConfigExecutable(args ...string) (string, []string) {
-	return "landscape-config", args
+func (b realBackend) LandscapeConfigExecutable(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "landscape-config", args...)
 }
 
 // ProExecutable returns the full command to run the wslpath executable with the provided arguments.
-func (b realBackend) WslpathExecutable(args ...string) (string, []string) {
-	return "wslpath", args
+func (b realBackend) WslpathExecutable(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "wslpath", args...)
 }
 
 // WslinfoExecutable returns the full command to run the wslinfo executable with the provided arguments.
-func (b realBackend) WslinfoExecutable(args ...string) (string, []string) {
-	return "wslinfo", args
+func (b realBackend) WslinfoExecutable(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "wslinfo", args...)
 }
 
-func (b realBackend) CmdExe(path string, args ...string) (string, []string) {
-	return path, args
+func (b realBackend) CmdExe(ctx context.Context, path string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, path, args...)
+
+	// cmd.exe must run within the Windows filesystem to avoid warnings.
+	cmd.Dir = filepath.Dir(path)
+
+	return cmd
 }

--- a/wsl-pro-service/internal/system/export_test.go
+++ b/wsl-pro-service/internal/system/export_test.go
@@ -5,3 +5,5 @@ const LandscapeConfigPath = landscapeConfigPath
 func (s *System) CmdExeCache() *string {
 	return &s.cmdExe
 }
+
+type RealBackend = realBackend

--- a/wsl-pro-service/internal/system/networking.go
+++ b/wsl-pro-service/internal/system/networking.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -41,12 +40,11 @@ func (s *System) WindowsHostAddress(ctx context.Context) (ip net.IP, err error) 
 }
 
 func (s *System) networkingMode(ctx context.Context) (string, error) {
-	exe, argv := s.backend.WslinfoExecutable("--networking-mode", "-n")
+	cmd := s.backend.WslinfoExecutable(ctx, "--networking-mode", "-n")
 
-	//nolint:gosec // In production code, these variables are hard-coded.
-	out, err := exec.CommandContext(ctx, exe, argv...).CombinedOutput()
+	out, err := runCommand(cmd)
 	if err != nil {
-		return "", fmt.Errorf("failed call to wslinfo: %v. Output: %s", err, out)
+		return "", err
 	}
 
 	return strings.TrimSpace(string(out)), nil

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -203,6 +203,24 @@ func (s *System) UserProfileDir(ctx context.Context) (wslPath string, err error)
 	return wslPath, nil
 }
 
+// runCommand is a helper that runs a command and returns stdout.
+// The first return value is the always trimmed stdout, even in case of error.
+// In case of error, both Stdout and Stderr are included in the error message.
+func runCommand(cmd *exec.Cmd) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	out := bytes.TrimSpace(stdout.Bytes())
+	if err != nil {
+		return out, fmt.Errorf("%s: error: %v.\n    Stdout: %s\n    Stderr: %s", cmd.Path, err, out, stderr.String())
+	}
+
+	return out, nil
+}
+
 // Path converts an absolute path into one inside the mocked filesystem.
 func (s System) Path(path ...string) string {
 	return s.backend.Path(path...)

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -590,6 +590,46 @@ func TestLandscapeDisable(t *testing.T) {
 	}
 }
 
+func TestRealBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := system.RealBackend{}
+
+	// Asserting generated commands
+	//
+	// Note that we cannot test the cmd.Path directly as it will depend on the install location,
+	// so we only test the base of the path.
+
+	pro := b.ProExecutable(ctx, "arg1", "arg2")
+	assertBasePath(t, "pro", pro.Path, "ProExecutable did not return the expected command")
+	assert.Equal(t, []string{"pro", "arg1", "arg2"}, pro.Args, "ProExecutable did not return the expected arguments")
+
+	lpe := b.LandscapeConfigExecutable(ctx, "arg1", "arg2")
+	assertBasePath(t, "landscape-config", lpe.Path, "LandscapeConfigExecutable did not return the expected command")
+	assert.Equal(t, []string{"landscape-config", "arg1", "arg2"}, lpe.Args, "LandscapeConfigExecutable did not return the expected arguments")
+
+	wpath := b.WslpathExecutable(ctx, "arg1", "arg2")
+	assertBasePath(t, "wslpath", wpath.Path, "WslpathExecutable did not return the expected command")
+	assert.Equal(t, []string{"wslpath", "arg1", "arg2"}, wpath.Args, "WslpathExecutable did not return the expected arguments")
+
+	winfo := b.WslinfoExecutable(ctx, "arg1", "arg2")
+	assertBasePath(t, "wslinfo", winfo.Path, "WslinfoExecutable did not return the expected command")
+	assert.Equal(t, []string{"wslinfo", "arg1", "arg2"}, winfo.Args, "WslinfoExecutable did not return the expected arguments")
+
+	cmd := b.CmdExe(ctx, "/mnt/c/WINDOWS/whatever/cmd.exe", "arg1", "arg2")
+	assert.Equal(t, "/mnt/c/WINDOWS/whatever", cmd.Dir, "CmdExe did not set the expected directory")
+	assert.Equal(t, "/mnt/c/WINDOWS/whatever/cmd.exe", cmd.Path, "CmdExe did not return the expected command")
+	assert.Equal(t, []string{"/mnt/c/WINDOWS/whatever/cmd.exe", "arg1", "arg2"}, cmd.Args, "CmdExe did not return the expected arguments")
+}
+
+// Asserts that the base of got is equal to wantBase, and if not, it fails the test with a message.
+func assertBasePath(t *testing.T, wantBase, got, msg string) {
+	t.Helper()
+	base := filepath.Base(got)
+	assert.Equalf(t, wantBase, base, "Mismatch in base path.\n%s", msg)
+}
+
 func TestWithProMock(t *testing.T)             { testutils.ProMock(t) }
 func TestWithLandscapeConfigMock(t *testing.T) { testutils.LandscapeConfigMock(t) }
 func TestWithWslPathMock(t *testing.T)         { testutils.WslPathMock(t) }

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -3,14 +3,17 @@
 package testutils
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/system"
@@ -582,6 +585,10 @@ func mockMain(t *testing.T, f func(argv []string) exitCode) {
 		argv = os.Args[begin+1:]
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go fuzzStderr(ctx)
+
 	exit := int(f(argv))
 	if exit == 0 {
 		// testing library only prints this line when it fails
@@ -589,6 +596,27 @@ func mockMain(t *testing.T, f func(argv []string) exitCode) {
 		fmt.Fprintln(os.Stdout, "exit status 0")
 	}
 	syscall.Exit(exit)
+}
+
+// fuzzStderr prints a message to stderr approximately every second.
+// This ensures that tested subprocesses separate their stderr from their stdout.
+func fuzzStderr(ctx context.Context) {
+	fmt.Fprintln(os.Stderr, "MOCK STDERR FUZZING")
+
+	go func() {
+		for {
+			//nolint:gosec // No need for a secure random number
+			randMs := time.Duration(rand.Int()%200) * time.Millisecond
+
+			select {
+			case <-time.After(time.Second + randMs):
+				return
+			case <-ctx.Done():
+			}
+
+			fmt.Fprintln(os.Stderr, "MOCK STDERR FUZZING")
+		}
+	}()
 }
 
 // mockFilesystemRoot sets up a skelleton filesystem with files used by the wsl-pro-service and returns


### PR DESCRIPTION
cmd.exe prints random stuff to stderr. When attempting to parse the output of `cmd.exe`, Stderr gets in the way and we fail.

Regression introduced in 373a97d

---

UDENG-2476