### PR TITLE
deps(wsl-pro-service): update the package name for ubuntu-advantage-tools

### DIFF
--- a/wsl-pro-service/debian/control
+++ b/wsl-pro-service/debian/control
@@ -25,7 +25,7 @@ Architecture: any
 Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         ubuntu-advantage-tools,
+         ubuntu-pro-client,
 Recommends: landscape-client,
 Description: ${source:Synopsis} - WSL service
  ${source:Extended-Description}


### PR DESCRIPTION
From v31, ubuntu-advantage-tools has been renamed to ubuntu-pro-client. The ubuntu-advantage-tools package name is now a transitional package. Noble currently has ubuntu-advantage-tools v31.