### PR TITLE
fix(windows-agent): Avoid panic in distro properties

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2
 	github.com/stretchr/testify v1.9.0
-	github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa
+	github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.33.0

--- a/common/go.sum
+++ b/common/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c h1:jO41xNLddTDkrfz4w4RCMWCmX8Y+ZHz5jSbJWNLDvqU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c/go.mod h1:edGgz97NOqS2oqzbKrZqO9YU9neosRrkEZbVJVQynAA=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa h1:kKgqEuEgZ3yOCKNFZ6Bvn0/Xuzlf/yxeN2eEIotGKms=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa/go.mod h1:1BBypuxD3Q91vOqv4Du+9o3YIWJbwhML6I1PuPm1+e4=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0 h1:GBrsd49DdWFkpmwzGoDBdQKg3Jei8BTaKRp+dRhoveg=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0/go.mod h1:vRsZU/rh424dLup5eIYmLM0xf0EPVeYxFvh47iI5o3s=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/end-to-end/go.mod
+++ b/end-to-end/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240306140056-b2552aec01d2
 	github.com/canonical/ubuntu-pro-for-wsl/mocks v0.0.0-20240306142331-92bc29c88c71
 	github.com/stretchr/testify v1.9.0
-	github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa
+	github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/sys v0.18.0
 	google.golang.org/grpc v1.62.1

--- a/end-to-end/go.sum
+++ b/end-to-end/go.sum
@@ -45,8 +45,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c h1:jO41xNLddTDkrfz4w4RCMWCmX8Y+ZHz5jSbJWNLDvqU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c/go.mod h1:edGgz97NOqS2oqzbKrZqO9YU9neosRrkEZbVJVQynAA=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa h1:kKgqEuEgZ3yOCKNFZ6Bvn0/Xuzlf/yxeN2eEIotGKms=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa/go.mod h1:1BBypuxD3Q91vOqv4Du+9o3YIWJbwhML6I1PuPm1+e4=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0 h1:GBrsd49DdWFkpmwzGoDBdQKg3Jei8BTaKRp+dRhoveg=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0/go.mod h1:vRsZU/rh424dLup5eIYmLM0xf0EPVeYxFvh47iI5o3s=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/tomarrell/wrapcheck/v2 v2.8.1 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
 	github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c // indirect
-	github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa // indirect
+	github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0 // indirect
 	github.com/ultraware/funlen v0.1.0 // indirect
 	github.com/ultraware/whitespace v0.1.0 // indirect
 	github.com/uudashr/gocognit v1.1.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -573,8 +573,8 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c h1:jO41xNLddTDkrfz4w4RCMWCmX8Y+ZHz5jSbJWNLDvqU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c/go.mod h1:edGgz97NOqS2oqzbKrZqO9YU9neosRrkEZbVJVQynAA=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa h1:kKgqEuEgZ3yOCKNFZ6Bvn0/Xuzlf/yxeN2eEIotGKms=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa/go.mod h1:1BBypuxD3Q91vOqv4Du+9o3YIWJbwhML6I1PuPm1+e4=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0 h1:GBrsd49DdWFkpmwzGoDBdQKg3Jei8BTaKRp+dRhoveg=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0/go.mod h1:vRsZU/rh424dLup5eIYmLM0xf0EPVeYxFvh47iI5o3s=
 github.com/ultraware/funlen v0.1.0 h1:BuqclbkY6pO+cvxoq7OsktIXZpgBSkYTQtmwhAK81vI=
 github.com/ultraware/funlen v0.1.0/go.mod h1:XJqmOQja6DpxarLj6Jj1U7JuoS8PvL4nEqDaQhy22p4=
 github.com/ultraware/whitespace v0.1.0 h1:O1HKYoh0kIeqE8sFqZf1o0qbORXUCOQFrlaQyZsczZw=

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 	github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c
-	github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa
+	github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/sys v0.18.0
 	google.golang.org/grpc v1.62.1

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -85,8 +85,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c h1:jO41xNLddTDkrfz4w4RCMWCmX8Y+ZHz5jSbJWNLDvqU=
 github.com/ubuntu/decorate v0.0.0-20230905131025-e968fa48a85c/go.mod h1:edGgz97NOqS2oqzbKrZqO9YU9neosRrkEZbVJVQynAA=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa h1:kKgqEuEgZ3yOCKNFZ6Bvn0/Xuzlf/yxeN2eEIotGKms=
-github.com/ubuntu/gowsl v0.0.0-20240311113207-ef97500f04fa/go.mod h1:1BBypuxD3Q91vOqv4Du+9o3YIWJbwhML6I1PuPm1+e4=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0 h1:GBrsd49DdWFkpmwzGoDBdQKg3Jei8BTaKRp+dRhoveg=
+github.com/ubuntu/gowsl v0.0.0-20240313091109-66e05bce56e0/go.mod h1:vRsZU/rh424dLup5eIYmLM0xf0EPVeYxFvh47iI5o3s=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/windows-agent/internal/distros/distro/properties.go
+++ b/windows-agent/internal/distros/distro/properties.go
@@ -33,7 +33,6 @@ type Properties struct {
 }
 
 // isValid checks that the properties against the registry.
-// TODO: check all calls for isValid(), and if when !ok -> return error in the caller, just returns an error.
 func (id identity) isValid() (ok bool) {
 	distro := wsl.NewDistro(id.ctx, id.Name)
 


### PR DESCRIPTION
This PR fixes a race where unregistering a distro at a very unfortunate time would cause a panic.

From [LBYL](https://docs.python.org/3.5/glossary.html#term-lbyl) to [EAFP](https://docs.python.org/3.5/glossary.html#term-eafp) 😃

---

UDENG-2385