### PR TITLE
docs: Improve style consistency everywhere, improve flow in setup prerequisites

### DIFF
--- a/docs/dev/howto/02-install.md
+++ b/docs/dev/howto/02-install.md
@@ -1,10 +1,10 @@
-# How to install Ubuntu Pro for WSL
+# How to install UP4W
 
-This guide will show you how to install Ubuntu Pro for WSL for local development and testing.
+This guide will show you how to install UP4W for local development and testing.
 
-## Install Ubuntu Pro for WSL from scratch
+<br/>
 
-### Requirements
+**Requirements:**
 
 - A Windows machine with access to the internet
 - Appx from the Microsoft Store:
@@ -12,7 +12,7 @@ This guide will show you how to install Ubuntu Pro for WSL for local development
   - Either Ubuntu, Ubuntu 22.04, or Ubuntu (Preview)
 - The Windows Subsystem for Windows optional feature enabled
 
-### Download
+## 1. Download the Windows Agent and the  WSL Pro Service
 <!-- TODO: Update when we change were artifacts are hosted -->
 1. Go to the [repository actions page](https://github.com/canonical/ubuntu-pro-for-wsl/actions/workflows/qa-azure.yaml?query=branch%3Amain+).
 2. Click the latest successful workflow run.
@@ -24,7 +24,7 @@ This guide will show you how to install Ubuntu Pro for WSL for local development
 Notice that, for the step above, there is also an alternative version of the MSIX bundle enabled for end-to-end testing. Most likely, that's not what you want to download.
 
 (dev::install::agent)=
-### Install the Windows agent
+## 2. Install the Windows Agent
 
 This is the Windows-side agent that manages the distros.
 
@@ -41,7 +41,7 @@ This is the Windows-side agent that manages the distros.
 6. The Firewall may ask for an exception. Allow it.
 7. The GUI should show up. You’re done.
 
-### Install the WSL Pro Service
+## 2. Install the WSL Pro Service
 
 This is the Linux-side component that talks to the agent. Choose one or more distros Jammy or greater, and follow the instructions.
 

--- a/docs/dev/howto/02-install.md
+++ b/docs/dev/howto/02-install.md
@@ -41,7 +41,7 @@ This is the Windows-side agent that manages the distros.
 6. The Firewall may ask for an exception. Allow it.
 7. The GUI should show up. You’re done.
 
-## 2. Install the WSL Pro Service
+## 3. Install the WSL Pro Service
 
 This is the Linux-side component that talks to the agent. Choose one or more distros Jammy or greater, and follow the instructions.
 

--- a/docs/dev/howto/03-restart.md
+++ b/docs/dev/howto/03-restart.md
@@ -1,12 +1,12 @@
-# How to restart Ubuntu Pro for WSL
+# How to restart UP4W
 
-Some configuration changes only apply when you restart Ubuntu Pro for WSL. Here is a guide on how to restart it.
+Some configuration changes only apply when you restart UP4W. Here is a guide on how to restart it. There are two options.
 
-## Option 1: Restart your machine
+## Option 1: Restart your UP4W host machine
 
 This is the simple one. If you're not in a hurry to see the configuration updated, just wait until next time you boot your machine.
 
-## Option 2: Restart only Ubuntu Pro for WSL
+## Option 2: Restart only UP4W
 
 1. Stop the agent:
 

--- a/docs/dev/howto/06-access-the-logs.md
+++ b/docs/dev/howto/06-access-the-logs.md
@@ -1,8 +1,8 @@
-# How to access the logs
+# How to access UP4W logs
 
-At some point you may want to read the logs of Ubuntu Pro for WSL, most likely for debugging purposes. The agent and the service store their logs separately. This guide shows you where to find each of the logs.
+At some point you may want to read the UP4W logs, most likely for debugging purposes. The agent and the service store their logs separately. This guide shows you where to find each of the logs.
 
-## WSL Pro service
+## Access the logs for the WSL Pro service
 
 To access the logs of a specific distribution's WSL-Pro-Service, you must first launch the distribution and then query the journal:
 
@@ -14,9 +14,9 @@ For more information on using the journal, you can check out its man page with `
 
 These logs may be insufficient for proper debugging, so you may be interested in looking at the agent's logs as well.
 
-## Windows agent
+## Access the logs for the Windows Agent
 
-Follow these steps to access the logs for the Windows agent.
+To access the logs for the Windows Agent:
 
 1. Go to your home directory
    - Open the file explorer

--- a/docs/dev/howto/index.md
+++ b/docs/dev/howto/index.md
@@ -7,8 +7,8 @@ These how-to guides cover key operations and processes in Ubuntu Pro for WSL.
 ```{toctree}
 :titlesonly:
 
-02-install
-03-restart
-06-access-the-logs
-reset-factory
+Install UP4W <02-install>
+Restart UP4W <03-restart>
+Access UP4W logs <06-access-the-logs>
+Reset UP4W <reset-factory>
 ```

--- a/docs/dev/reference/07-windows-agent-command-line-reference.md
+++ b/docs/dev/reference/07-windows-agent-command-line-reference.md
@@ -1,6 +1,7 @@
-# Windows Agent command-line reference
+# Windows Agent CLI
 
-The Windows Agent is the component that runs on the host Windows machine.
+> See first: [UP4W - Windows Agent](ref::up4w-windows-agent)
+
 
 ## Usage
 

--- a/docs/dev/reference/08-wsl-pro-service-command-line-reference.md
+++ b/docs/dev/reference/08-wsl-pro-service-command-line-reference.md
@@ -1,6 +1,6 @@
-# WSL-Pro-Service command-line reference
+# WSL Pro Service CLI
 
-The WSL Pro Service is the component that runs on each guest Ubuntu distro.
+> See first: [UP4W - WSL Pro Service](ref::up4w-wsl-pro-service)
 
 ## Usage
 

--- a/docs/dev/reference/index.md
+++ b/docs/dev/reference/index.md
@@ -8,7 +8,7 @@ The reference material in this section provides technical descriptions of Ubuntu
 :titlesonly:
 
 
-Windows Agent command line interface <07-windows-agent-command-line-reference>
-WSL Pro Service command line interface <08-wsl-pro-service-command-line-reference>
-QA process reference <09-qa-process-reference>
+Windows Agent CLI <07-windows-agent-command-line-reference>
+WSL Pro Service CLI <08-wsl-pro-service-command-line-reference>
+QA process <09-qa-process-reference>
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -2,10 +2,10 @@
 
 # How-to guides
 
-These how-to guides cover key operations and processes in Ubuntu Pro for WSL.
+These how-to guides cover key operations and processes in UP4W.
 
 ```{toctree}
 :titlesonly:
 
-set-up-up4w
+Install and configure UP4W <set-up-up4w>
 ```

--- a/docs/howto/set-up-up4w.md
+++ b/docs/howto/set-up-up4w.md
@@ -1,61 +1,45 @@
-# How to set up Ubuntu Pro For WSL
+# How to install and configure UP4W
 
-## Prerequisites
-### Prepare a compatible Ubuntu WSL distro
+## 1. Check that you meet UP4W prerequisites
 
-<details><summary> Expand to see how to make a pre-existing WSL distro UP4W-compatible </summary>
+To install and configure UP4W you will need:
 
-> Note: You can make more than one distro compatible, and UP4W will manage all of them.
-1.	Check the version of your distro with `cat /etc/os-release`.
-	- If the `NAME` is not `Ubuntu`, the distro cannot be made compatible. You'll need to create a new one.
-	- If the `VERSION_ID` is not `24.04`, the distro cannot be made compatible. You'll need to create a new one.
-	<!-- Once Noble is released, there will also be the option to upgrade the distro -->
-
-2.	Check if package `wsl-pro-service` is installed by running this command in your distro:
-	```bash
-	pkg -s wsl-pro-service | grep Status
-	```
-
-	- If the output says `Status: install ok installed`: Congratulations, your WSL instance is already compatible with UP4W.
-	- Otherwise: Install it by running: `sudo apt update && sudo apt install -y wsl-pro-service`
-</details>
-
-<details><summary> Expand to see how to create a new UP4W-compatible distro </summary>
-
-1.	Verify that you have WSL installed: In your Windows terminal, run `wsl --version` and see that there is no error. Otherwise, install it with `wsl --install`.
-2.	Ensure that you don't have an _Ubuntu (Preview)_ distro registered by running `wsl --list --quiet` on your Windows terminal.
-	- If the output contains _Ubuntu-Preview_, you already have an instance of Ubuntu (Preview).
-		- You can make it compatible with UP4W
- 		- You can remove it and continue installing a new instance.
-			- To **irreversibly** remove the distro, run: `wsl --unregister Ubuntu-Preview`.
-3.	Ensure that you have the latest _Ubuntu (Preview)_ app installed:
-On your Windows host, go to the Microsoft Store, search for _Ubuntu (Preview)_, click on the result and look at the options:
-	- If you see a button `Install`, click it.
-	- If you see a button `Update`, click it.
-
-	On the same Microsoft Store page, there should be an `Open` button. Click it. _Ubuntu (Preview)_ will start and guide you through the installation steps.
-</details>
+- A Windows host
+- An Ubuntu Pro token
 
 
-### Obtain an Ubuntu Pro token
+<details><summary> How do I get an Ubuntu Pro token? </summary> 
 
-<details><summary> Expand to see how </summary>
+1. Visit the Ubuntu Pro page to get a subscription.
+    
+> See more: [Ubuntu | Ubuntu Pro > Subscribe](https://ubuntu.com/pro/subscribe). If you choose the personal subscription option (`Myself`), the subscription is free for up to 5 machines. 
 
-Get the Ubuntu Pro token associated with your subscription (it's free for up to 5 machines).
-> See more: [Ubuntu Pro dashboard](https://ubuntu.com/pro)
+2. Visit your Ubuntu Pro Dashboard to retrieve your subscription token.
+    
+> See more: [Ubuntu | Ubuntu Pro > Dashboard](https://ubuntu.com/pro/dashboard)
 
 </details>
 
-### Set up a Landscape server
 
-<details><summary> Expand to see how </summary>
+
+- (*Only if you want to use UP4W with Landscape:*) <br>A UP4W-compatible Landscape server
+    - i.e., Landscape beta
+
+
+
+<details><summary> How do I set up a  Landscape beta server?</summary> 
+
+> See: [Landscape | Quickstart deployment](https://ubuntu.com/landscape/docs/quickstart-deployment)
+
+</details>
+
+<details><summary>Can you help me set up a Landscape beta server locally, just for testing?</summary>
+
+Sure: 
 
 1. Set up an Ubuntu WSL to act as the server:
-	> Note: you can skip step 1 if you already have a Landscape Beta server running.
 
-	> Note: The usual setup calls for the Landscape server to run on another machine (a server). For demonstration purposes, we explain how to set up a Landscape server in one of your WSL distros.
-
-   1. Install a new Ubuntu WSL distro
+   1. Install a new Ubuntu WSL distro:
 	```shell
 	wsl --install Ubuntu-22.04
    	```
@@ -67,7 +51,7 @@ Get the Ubuntu Pro token associated with your subscription (it's free for up to 
         - Otherwise, open file `/etc/resolv.conf` in the WSL instance named _Ubuntu-22.04_. Find the line starting with `nameserver` followed by an IP address.
            - If the IP address does not start with `127`, take note of this address.
            - Otherwise, run the command `ip route | grep ^default` and take note of the IP address that is printed.
-   3. Set up a Landscape Beta server. 
+   3. Set up a Landscape Beta server: 
       1. Start a shell in your _Ubuntu-22.04_ distro.
       2. Install the Landscape (beta) following the steps in the Landscape Quickstart deployment with the following considerations:
          - Make sure you install the beta version.
@@ -91,18 +75,162 @@ Get the Ubuntu Pro token associated with your subscription (it's free for up to 
 	```
 </details>
 
-## 1. Install Ubuntu Pro for WSL
-On your Windows host, go to the Microsoft Store, search for _Ubuntu Pro for WSL_ and click on the result. Find the _Install_ button. Click on it.
+
+- (*Only for the verify step:*) <br> One or more UP4W-compatible Ubuntu WSL instances
+    - i.e., from an `Ubuntu`, `Ubuntu-Preview`, or `Ubuntu-22.04`+ distro and with `wsl-pro-service` installed 
+	    - note: with a freshly installed or updated `Ubuntu-Preview` or `Ubuntu-22.04`+, `wsl-pro-service` comes automatically pre-installed
+
+<details><summary> I already have an Ubuntu WSL instance. Can I make it UP4W-compatible? </summary>
+
+It depends:
+
+1.	Open a shell into your instance and check its distro version:
+    ```bash
+	cat /etc/os-release
+	```
+	If the distro is *not* `Ubuntu`, `Ubuntu-Preview`, or `Ubuntu-22.04`+: Your instance cannot be made UP4W-compatible. Please create a new one that is compatible. Otherwise:
+
+2.	Open a shell into your distro and  check if package `wsl-pro-service` is installed:
+	```bash
+	pkg -s wsl-pro-service | grep Status
+	```
+
+	If the status is *not* `Status: install ok installed`: Install it by running: `sudo apt update && sudo apt install -y wsl-pro-service`.
+
+</details>
+
+
+<details><summary> How do I create a new Ubuntu WSL instance that is UP4W-compatible? </summary>
+
+```{note}
+Here we assume you already have WSL installed. Run `wsl --version` to verify; if there you get an error because it is not there, install it: `wsl --install`.
+```
+
+```{warning}
+Here we assume you do not have any existing `Ubuntu-Preview` or `Ubuntu-22.04`+ instances or you have them but do not mind overwriting them. 
+- To view your current registered instances, run `wsl --list --quiet`. 
+- To export, delete, and re-import an instance, see `wsl --export`, `wsl --unregister`, and `wsl --import`. 
+> See more: [Microsoft | WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/basic-commands).
+```
+
+
+On your Windows host, in the Microsoft Store, search for the `Ubuntu-Preview` or `Ubuntu-22.04`+ distro app, click **Install** / **Update**, then **Open**. Follow the instructions to set up the instance. Note: The instance will come with `wsl-pro-service` pre-installed.
+
+</details>
+
+
+
+<!-- ## Prerequisites -->
+<!-- ### Prepare a compatible Ubuntu WSL distro -->
+
+<!-- <details><summary> Expand to see how to make a pre-existing WSL distro UP4W-compatible </summary> -->
+
+<!-- > Note: You can make more than one distro compatible, and UP4W will manage all of them. -->
+<!-- 1.	Check the version of your distro with `cat /etc/os-release`. -->
+<!-- 	- If the `NAME` is not `Ubuntu`, the distro cannot be made compatible. You'll need to create a new one. -->
+<!-- 	- If the `VERSION_ID` is not `24.04`, the distro cannot be made compatible. You'll need to create a new one. -->
+<!-- 	<\!-- Once Noble is released, there will also be the option to upgrade the distro -\-> -->
+
+<!-- 2.	Check if package `wsl-pro-service` is installed by running this command in your distro: -->
+<!-- 	```bash -->
+<!-- 	pkg -s wsl-pro-service | grep Status -->
+<!-- 	``` -->
+
+<!-- 	- If the output says `Status: install ok installed`: Congratulations, your WSL instance is already compatible with UP4W. -->
+<!-- 	- Otherwise: Install it by running: `sudo apt update && sudo apt install -y wsl-pro-service` -->
+<!-- </details> -->
+
+<!-- <details><summary> Expand to see how to create a new UP4W-compatible distro </summary> -->
+
+<!-- 1.	Verify that you have WSL installed: In your Windows terminal, run `wsl --version` and see that there is no error. Otherwise, install it with `wsl --install`. -->
+<!-- 2.	Ensure that you don't have an _Ubuntu (Preview)_ distro registered by running `wsl --list --quiet` on your Windows terminal. -->
+<!-- 	- If the output contains _Ubuntu-Preview_, you already have an instance of Ubuntu (Preview). -->
+<!-- 		- You can make it compatible with UP4W -->
+<!--  		- You can remove it and continue installing a new instance. -->
+<!-- 			- To **irreversibly** remove the distro, run: `wsl --unregister Ubuntu-Preview`. -->
+<!-- 3.	Ensure that you have the latest _Ubuntu (Preview)_ app installed: -->
+<!-- On your Windows host, go to the Microsoft Store, search for _Ubuntu (Preview)_, click on the result and look at the options: -->
+<!-- 	- If you see a button `Install`, click it. -->
+<!-- 	- If you see a button `Update`, click it. -->
+
+<!-- 	On the same Microsoft Store page, there should be an `Open` button. Click it. _Ubuntu (Preview)_ will start and guide you through the installation steps. -->
+<!-- </details> -->
+
+
+<!-- ### Obtain an Ubuntu Pro token -->
+
+<!-- <details><summary> Expand to see how </summary> -->
+
+<!-- Get the Ubuntu Pro token associated with your subscription (it's free for up to 5 machines). -->
+<!-- > See more: [Ubuntu Pro dashboard](https://ubuntu.com/pro) -->
+
+<!-- </details> -->
+
+<!-- ### Set up a Landscape server -->
+
+<!-- <details><summary> Expand to see how </summary> -->
+
+<!-- 1. Set up an Ubuntu WSL to act as the server: -->
+<!-- 	> Note: you can skip step 1 if you already have a Landscape Beta server running. -->
+
+<!-- 	> Note: The usual setup calls for the Landscape server to run on another machine (a server). For demonstration purposes, we explain how to set up a Landscape server in one of your WSL distros. -->
+
+<!--    1. Install a new Ubuntu WSL distro -->
+<!-- 	```shell -->
+<!-- 	wsl --install Ubuntu-22.04 -->
+<!--    	``` -->
+<!--    2. Find out the Windows host IP: In the WSL distro named _Ubuntu-22.04_, run: -->
+<!--       ```bash -->
+<!-- 	  wslinfo --networking-mode -->
+<!-- 	  ``` -->
+<!--         - If it says `mirrored`, the relevant IP is `127.0.0.1`. Take note of this address. -->
+<!--         - Otherwise, open file `/etc/resolv.conf` in the WSL instance named _Ubuntu-22.04_. Find the line starting with `nameserver` followed by an IP address. -->
+<!--            - If the IP address does not start with `127`, take note of this address. -->
+<!--            - Otherwise, run the command `ip route | grep ^default` and take note of the IP address that is printed. -->
+<!--    3. Set up a Landscape Beta server.  -->
+<!--       1. Start a shell in your _Ubuntu-22.04_ distro. -->
+<!--       2. Install the Landscape (beta) following the steps in the Landscape Quickstart deployment with the following considerations: -->
+<!--          - Make sure you install the beta version. -->
+<!--          - Your FQDN is the address you took note of in the previous step. -->
+<!--    		> See more: [Landscape | Quickstart deployment](https://ubuntu.com/landscape/docs/quickstart-deployment) -->
+<!--    4. Take note of the following addresses: -->
+<!--       	- Hostagent API endpoint: `${WINDOWS_HOST_IP}:6554` -->
+<!--       	- Message API endpoint: `${WINDOWS_HOST_IP}/message-system` -->
+<!--       	- Ping API endpoint: `${WINDOWS_HOST_IP}/ping` -->
+<!--    5. Open a `Ubuntu-22.04` terminal and keep it open during the rest of the guide. -->
+<!--       	- This ensures this distro keeps running in the background. See also: [Microsoft's FAQ](https://learn.microsoft.com/en-us/windows/wsl/faq#can-i-use-wsl-for-production-scenarios--). -->
+<!-- 2. Store the following file somewhere in your Windows system. Name it `landscape-client.conf`. Replace the variables in the file with the relevant values for your server. -->
+<!-- 	```ini -->
+<!-- 	[host] -->
+<!-- 	url = ${HOSTAGENT_API_ENDPOINT} -->
+
+<!-- 	[client] -->
+<!-- 	url = ${MESSAGE_API_ENDPOINT} -->
+<!-- 	ping_url = ${PING_API_ENDPOINT} -->
+<!-- 	account_name = standalone -->
+<!-- 	``` -->
+<!-- </details> -->
+
+## 2. Install UP4W
+On your Windows host, go to the Microsoft Store, search for _Ubuntu Pro for WSL_ and click on the result. Find the _Install_ button. Click. Done.
 
 (howto::configure-up4w)=
 
-## 2. Configure Ubuntu Pro for WSL
-You have two ways of setting up UP4W. You can use the graphical interface (GUI), which is recommended for users managing a single Windows machine. Alternatively, you can use the registry which we recommend for users who want to deploy at scale.
+## 3. Configure UP4W for Ubuntu Pro and Landscape
+
+> See also: [Ubuntu Pro](ref::ubuntu-pro), [Landscape](ref::landscape)
+
+There are two ways in which you can configure UP4W for Ubuntu Pro and Landscape -- using the UP4W GUI or using the Windows Registry.
 
 ### Using the GUI
-> See also: [Ubuntu Pro for WSL GUI](ref::up4w-gui)
-1. Open the Windows menu, search and click on Ubuntu Pro for WSL.
-2. Input your Ubuntu Pro Token:
+
+```{note}
+With this method you can only configure UP4W on a single Windows host at a time.
+```
+
+> See also: [UP4W GUI](ref::up4w-gui)
+1. Open the Windows menu, search for "Ubuntu Pro for WSL", click.
+2. Input your Ubuntu Pro token:
 	1. Click on **Already have a token?**.
 	2. Write your Ubuntu Pro token and click **Confirm**.
 3. Input your Landscape configuration:
@@ -113,6 +241,12 @@ You have two ways of setting up UP4W. You can use the graphical interface (GUI),
 
 (howto::configure::registry)=
 ### Using the registry
+
+```{note}
+This method can be adapted to configure UP4W on multiple Windows hosts at a time.
+```
+
+
 > See also: [Windows registry](windows-registry)
 1. Press Win+R, type `regedit.exe`, and click OK.
 2. Navigate the tree to `HKEY_CURRENT_USER\Software\Canonical\UbuntuPro`.
@@ -125,7 +259,7 @@ You have two ways of setting up UP4W. You can use the graphical interface (GUI),
 	- Right-click `LandscapeConfig` > Modify > Write the Landscape config.
 	  > See more: [UP4W Landscape config reference](ref::landscape-config).
 
-## 3. Verify that UP4W is working
+## 4. Verify that UP4W is working
 > If either verification step fails, wait for a few seconds and try again. This should not take longer than a minute.
 1. Start the UP4W GUI and check that your subscription is active.
    - To open the GUI, search _Ubuntu Pro for WSL_ in the Windows menu and click on it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,21 +15,21 @@ When you install UP4W on your Windows host:
 
 Pro-attaching and Landscape-enrolling an Ubuntu instance is not difficult, but when your Ubuntu instance fleet is large it can get tedious.  UP4W takes advantage of the WSL setting to make it a breeze -- regardless of the size of your fleet.
 
-Ubuntu Pro for WSL is of value to system administrators, corporate security teams, and desktop users.
+UP4W is of value to system administrators, corporate security teams, and desktop users.
 
 ## Project and community
 
-Ubuntu Pro for WSL is a member of the Ubuntu family. It’s an open-source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback. Check out our [contribution page](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/CONTRIBUTING.md) on GitHub in order to bring ideas, report bugs, participate in discussions, and much more!
+UP4W is a member of the Ubuntu family. It’s an open-source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback. Check out our [contribution page](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/CONTRIBUTING.md) on GitHub in order to bring ideas, report bugs, participate in discussions, and much more!
 
-Thinking about using Ubuntu Pro for WSL for your next project? Get in touch!
+Thinking about using UP4W for your next project? Get in touch!
 
 ```{toctree}
 :hidden:
 :titlesonly:
 
-self
+UP4W <self>
 Tutorial </tutorial/index>
 How-to guides </howto/index>
 Reference </reference/index>
-Developer documentation </dev/index>
+UP4W Dev </dev/index>
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,7 +12,7 @@ ubuntu_pro
 ubuntu_pro_client
 ubuntu_wsl
 UP4W <up4w>
-up4w-gui
+UP4W - GUI <up4w-gui>
 up4w-windows_agent
 up4w-wsl_pro_service
 windows_registry

--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -2,15 +2,21 @@
 # Landscape
 
 Landscape is a systems management tool designed to help you manage and monitor your Ubuntu systems from a unified platform.
-> See more: [Landscape | Documentation ](https://ubuntu.com/landscape/docs).
+> See more: [Landscape | Documentation ](https://ubuntu.com/landscape/docs)
 
-In UP4W, Landscape consists of a remote server and two clients, (1) the usual Ubuntu-side client, in this case a [Landscape client](ref::landscape-client) that comes automatically with any Ubuntu WSL instance, and (2) a Windows-side client, a Landscape client that is built into the [UP4W Windows Agent](ref::up4w-windows-agent). The latter offers advantages unique to Ubuntu WSL – the ability to create new instances through Landscape and the ability to configure all your instances at scale (when you configure the Windows-side client, the UP4W agent forwards the configuration to the client on each instance).
+In UP4W, Landscape consists of a remote server and two clients:
+
+1. the usual Ubuntu-side client, in this case a [Landscape client](ref::landscape-client) that comes automatically with any Ubuntu WSL instance, and 
+
+2. a Windows-side client, a Landscape client that is built into the [UP4W Windows Agent](ref::up4w-windows-agent). 
+
+The latter offers advantages unique to Ubuntu WSL – the ability to create new instances through Landscape and the ability to configure all your instances at scale (when you configure the Windows-side client, the UP4W agent forwards the configuration to the client on each instance).
 
 (ref::landscape-config)=
 ## Landscape configuration schema
 
 Both Landscape clients are configured via a single `.ini` file. This file is provided to the Windows host.
-> See more: [How to configure UP4W](howto::configure-up4w)
+> See more: [How to configure UP4W for Ubuntu Pro and Landscape](howto::configure-up4w)
 
 The schema for this file is the same as Landscape for Ubuntu desktop or server, with a few additional keys specific to the WSL settings, which can be grouped into keys that affect just the Windows-side client and keys that affect both the Windows-side client and the Ubuntu WSL-side client(s). These additions are documented below.
 
@@ -31,7 +37,7 @@ ssl_public_key = C:\Users\user\Downloads\landscape_server.pem
 
 ### Host
 
-This section contains settings unique to the Windows-side client. It contains a single key:
+This section contains settings unique to the Windows-side client. Currently these consist of a single key:
 - `url`: The URL of your Landscape account followed by a colon (`:`) and the port number. Port 6554 is the default for Landscape Quickstart installations.
 
 ### Client

--- a/docs/reference/landscape_client.md
+++ b/docs/reference/landscape_client.md
@@ -1,8 +1,7 @@
 (ref::landscape-client)=
 # Landscape (client)
-> See more: [Landscape](ref::landscape)
 
-The Landscape client is a `systemd` unit running on Landscape-managed Ubuntu machines. It sends information about the system to the Landscape server. The server, in turn, sends instructions that the client executes.
+The Landscape client is a `systemd` unit running on [Landscape](ref::landscape)-managed Ubuntu machines. It sends information about the system to the Landscape server. The server, in turn, sends instructions that the client executes.
 
 In WSL, there is one Landscape client inside every Ubuntu WSL distro. The Landscape client comes pre-installed in your distro as part of the package `landscape-client`, but it must be configured before it can start running.
 
@@ -10,7 +9,7 @@ In WSL, there is one Landscape client inside every Ubuntu WSL distro. The Landsc
 
 UP4W will configure all Ubuntu WSL distros for you, so you don't need to configure each WSL instance separately; you specify the configuration once and UP4W will distribute it to every distro.
 
-> See more: [How to set up Ubuntu Pro for WSL](howto::configure-up4w)
+> See more: [How to install and configure UP4W](howto::configure-up4w)
 
 You can see the status of the Landscape client in any particular Ubuntu WSL instance by starting a shell in that instance and running:
 ```bash

--- a/docs/reference/ubuntu_pro.md
+++ b/docs/reference/ubuntu_pro.md
@@ -1,22 +1,22 @@
 (ref::ubuntu-pro)=
 # Ubuntu Pro
 
-Ubuntu Pro is a product offered by Canonical on top of the Long Term Support (LTS) releases of Ubuntu. It provides access to the following offerings:
+Ubuntu Pro is a subscription service offered by Canonical on top of the Long Term Support (LTS) releases of Ubuntu. It provides access to the following offerings:
 - Landscape
 - Center for Internet Security (CIS) compliance
 - Expanded Security Maintenance (ESM)
 - Canonical Support line
 
-> See more: [Ubuntu Pro](https://ubuntu.com/pro)
+> See more: [Ubuntu | Ubuntu Pro](https://ubuntu.com/pro)
 
-The [Ubuntu Pro client](ref::ubuntu-pro-client) is in charge of managing the services provided for Ubuntu Pro.
+Ubuntu Pro services are managed by the [Ubuntu Pro client](ref::ubuntu-pro-client).
 
 (ref::ubuntu-pro-token)=
 ## Ubuntu Pro token
 
-An Ubuntu pro token is a secret string of numbers and letters that acts as proof of purchase. Services provided by the Ubuntu Pro subscription will require a token to run.
+An Ubuntu pro token is a secret string of numbers and letters that acts as proof of purchase for your Ubuntu Pro subscription. Services provided by the Ubuntu Pro subscription will require a token to run.
 > See more: [Pro-attach](ref::pro-attach)
 
 You can find out what your Ubuntu Pro token is by visiting your Ubuntu Pro dashboard and logging in.
-> See more: [Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard)
+> See more: [Ubuntu | Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard)
 

--- a/docs/reference/ubuntu_pro_client.md
+++ b/docs/reference/ubuntu_pro_client.md
@@ -4,9 +4,8 @@
 The Ubuntu Pro client is a command-line utility (a CLI) that manages the different offerings of your Ubuntu Pro subscription. In UP4W, this executable is used within each of the managed WSL distros to enable [Ubuntu Pro](ref::ubuntu-pro) services within that distro.
 
 This executable is provided as part of the `ubuntu-advantage-tools` package, which comes pre-installed in your Ubuntu WSL distros.
-> See more: [Ubuntu manuals | Ubuntu advantage tools](https://manpages.ubuntu.com/manpages/noble/en/man1/ubuntu-advantage.1.html).
+> See more: [Ubuntu manuals | Ubuntu advantage tools](https://manpages.ubuntu.com/manpages/noble/en/man1/ubuntu-advantage.1.html)
 
 (ref::pro-attach)=
 ## Pro-attach
-_Pro-attaching_ a machine (e.g. a desktop computer, a WSL distro, a server, a virtual machine, etc.) means to provide your Ubuntu Pro token to the Ubuntu Pro client, so that it can enable Ubuntu Pro services.
-> See more: [Ubuntu Pro token](ref::ubuntu-pro-token)
+_Pro-attaching_ a machine (e.g. a desktop computer, a WSL distro, a server, a virtual machine, etc.) means to provide your [Ubuntu Pro token](ref::ubuntu-pro-token) to the Ubuntu Pro client, so that it can enable Ubuntu Pro services.

--- a/docs/reference/up4w-windows_agent.md
+++ b/docs/reference/up4w-windows_agent.md
@@ -1,9 +1,9 @@
 (ref::up4w-windows-agent)=
 # UP4W - Windows Agent
 
-The Windows agent is a Windows application running in the background. It is started when the user first logs in to Windows. The GUI will also start it if it stops for some reason.
+UP4W's Windows Agent is a Windows application running in the background. It starts automatically when the user logs in to Windows. If it stops for some reason, it can also be started by launching the UP4W GUI.
 
-The Windows agent communicates with the different components to coordinate them:
+The Windows agent is UP4W's central hub that communicates with all the components to coordinate them.
 
 
 ![Diagram displaying the Windows agent communicating with the GUI, the Landscape server and the WSL-Pro-Service. It also reads the registry.](./assets/up4w-c4-windows-agent.png)

--- a/docs/reference/up4w-wsl_pro_service.md
+++ b/docs/reference/up4w-wsl_pro_service.md
@@ -1,8 +1,8 @@
 (ref::up4w-wsl-pro-service)=
 # UP4W - WSL Pro service
 
-A `systemd` unit running inside every Ubuntu WSL instance. The [Windows Agent](ref::up4w-windows-agent) running on the Windows host sends commands that the WSL Pro Service executes, such as pro-attaching or configuring the Landscape client.
-> See more: [Pro-attaching](ref::pro-attach) and [Landscape](ref::landscape).
+A `systemd` unit running inside every Ubuntu WSL instance. The [Windows Agent](ref::up4w-windows-agent) running on the Windows host sends commands that the WSL Pro Service executes, such as [pro-attaching](ref::pro-attach) pro-attaching or configuring the [Landscape client](ref::landscape-client).
+
 
 You can check the current status of the WSL Pro Service in any particular distro with:
 ```bash

--- a/docs/reference/up4w-wsl_pro_service.md
+++ b/docs/reference/up4w-wsl_pro_service.md
@@ -1,7 +1,7 @@
 (ref::up4w-wsl-pro-service)=
 # UP4W - WSL Pro service
 
-A `systemd` unit running inside every Ubuntu WSL instance. The [Windows Agent](ref::up4w-windows-agent) running on the Windows host sends commands that the WSL Pro Service executes, such as [pro-attaching](ref::pro-attach) pro-attaching or configuring the [Landscape client](ref::landscape-client).
+A `systemd` unit running inside every Ubuntu WSL instance. The [Windows Agent](ref::up4w-windows-agent) running on the Windows host sends commands that the WSL Pro Service executes, such as [pro-attaching](ref::pro-attach) or configuring the [Landscape client](ref::landscape-client).
 
 
 You can check the current status of the WSL Pro Service in any particular distro with:

--- a/docs/reference/up4w.md
+++ b/docs/reference/up4w.md
@@ -1,6 +1,8 @@
 # Ubuntu Pro for WSL (UP4W)
 
-Ubuntu Pro for WSL is an automation tool running on Windows hosts to manage Ubuntu WSL instances, providing them with compliance by attaching them to Ubuntu Pro and enrolling them into Landscape. Some Ubuntu Pro for WSL components run on the Windows host:
+Ubuntu Pro for WSL (UP4W) is an automation tool running on Windows hosts to manage Ubuntu WSL instances, providing them with compliance by attaching them to your Ubuntu Pro subscription and enrolling them into Landscape. 
+
+Some Ubuntu Pro for WSL components run on the Windows host:
 - the [UP4W Windows Agent](ref::up4w-windows-agent) providing automation services.
 - the [UP4W GUI](ref::up4w-gui) for end users to manage their Ubuntu Pro subscription and Landscape configuration.
 


### PR DESCRIPTION
Touched up titles in Navigation to remove "How to" or to include just the abbreviation.

Restyled "Ubuntu Pro for WSL" everywhere *except for first occurrence on the website, in the home, and the install page) as just "UP4W".

Touched up See, See first, See more, See also style in all the docs
- See: used when we link to something else for the entire content of a point
- See also: used at the top of a HTG section to link to the immediately relevant reference
- See more: used in HTGs to link to reference bits used in the HTG or in Reference to link to external pages for more info
- See first: used in the UP4W Dev docs to link to the bits that the dev doc is adding to.

In the setup HTG, turned Prerequisites into a Check that you meet requirements section. Also touched up the content to improve flow.