### PR TITLE
fix(end-to-end): Increase timeouts in pro attachment check

### DIFF
--- a/end-to-end/manual_token_input_test.go
+++ b/end-to-end/manual_token_input_test.go
@@ -74,7 +74,7 @@ func TestManualTokenInput(t *testing.T) {
 				require.NoErrorf(t, err, "Setup: could not wake distro up: %v. %s", err, out)
 			}
 
-			const maxTimeout = 30 * time.Second
+			const maxTimeout = time.Minute
 
 			if !tc.wantAttached {
 				time.Sleep(maxTimeout)

--- a/end-to-end/organization_token_test.go
+++ b/end-to-end/organization_token_test.go
@@ -79,7 +79,7 @@ func TestOrganizationProvidedToken(t *testing.T) {
 				require.NoErrorf(t, err, "Setup: could not wake distro up: %v. %s", err, out)
 			}
 
-			const maxTimeout = 30 * time.Second
+			const maxTimeout = time.Minute
 
 			if !tc.wantAttached {
 				time.Sleep(maxTimeout)


### PR DESCRIPTION
sometimes pro attach is very slow