### PR TITLE
fix(landscape): Restrict landscape config file from 0604 to 0640

### DIFF
--- a/wsl-pro-service/internal/system/backend.go
+++ b/wsl-pro-service/internal/system/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 )
 
@@ -49,4 +50,8 @@ func (b realBackend) CmdExe(ctx context.Context, path string, args ...string) *e
 	cmd.Dir = filepath.Dir(path)
 
 	return cmd
+}
+
+func (b realBackend) LookupGroup(name string) (*user.Group, error) {
+	return user.LookupGroup("landscape")
 }

--- a/wsl-pro-service/internal/system/landscape.go
+++ b/wsl-pro-service/internal/system/landscape.go
@@ -56,7 +56,7 @@ func (s *System) writeConfig(landscapeConfig string) (err error) {
 		return err
 	}
 
-	groupID, err := s.lookupGroup("landscape")
+	groupID, err := s.groupToGUID("landscape")
 	if err != nil {
 		return err
 	}

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -279,8 +279,8 @@ func (s *System) findCmdExe() (cmdExe string, err error) {
 	return "", fmt.Errorf("none of the mounted drives contains subpath %s", subPath)
 }
 
-// lookupGroup searches the group with the specified name and returns its GID.
-func (s *System) lookupGroup(name string) (int, error) {
+// groupToGUID searches the group with the specified name and returns its GID.
+func (s *System) groupToGUID(name string) (int, error) {
 	group, err := s.backend.LookupGroup(name)
 	if err != nil {
 		return 0, err

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -6,9 +6,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
+	"strconv"
 	"strings"
 
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
@@ -34,6 +37,7 @@ type Backend interface {
 	Path(p ...string) string
 	Hostname() (string, error)
 	GetenvWslDistroName() string
+	LookupGroup(string) (*user.Group, error)
 
 	ProExecutable(ctx context.Context, args ...string) *exec.Cmd
 	LandscapeConfigExecutable(ctx context.Context, args ...string) *exec.Cmd
@@ -273,4 +277,34 @@ func (s *System) findCmdExe() (cmdExe string, err error) {
 	}
 
 	return "", fmt.Errorf("none of the mounted drives contains subpath %s", subPath)
+}
+
+// lookupGroup searches the group with the specified name and returns its GID.
+func (s *System) lookupGroup(name string) (int, error) {
+	group, err := s.backend.LookupGroup(name)
+	if err != nil {
+		return 0, err
+	}
+
+	guid, err := strconv.ParseInt(group.Gid, 10, 32)
+	if err != nil {
+		return 0, errors.New("could not parse %s as an integer")
+	}
+
+	return int(guid), nil
+}
+
+// currentUser returns the UID of the current user.
+func (s *System) currentUser() (int, error) {
+	user, err := user.Current()
+	if err != nil {
+		return 0, err
+	}
+
+	userID, err := strconv.ParseInt(user.Uid, 10, 32)
+	if err != nil {
+		return 0, errors.New("could not parse %s as an integer")
+	}
+
+	return int(userID), nil
 }

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -393,6 +393,7 @@ func TestLandscapeEnable(t *testing.T) {
 		breakWriteConfig     bool
 		breakLandscapeConfig bool
 		breakWSLPath         bool
+		noLandscapeGroup     bool
 
 		wantErr bool
 	}{
@@ -406,6 +407,7 @@ func TestLandscapeEnable(t *testing.T) {
 		"Error when the config file cannot be written":           {breakWriteConfig: true, wantErr: true},
 		"Error when the landscape-config command fails":          {breakLandscapeConfig: true, wantErr: true},
 		"Error when failing to override the SSL certficate path": {breakWSLPath: true, wantErr: true},
+		"Error when the Landscape user does not exist":           {noLandscapeGroup: true, wantErr: true},
 	}
 
 	for name, tc := range testCases {
@@ -426,6 +428,10 @@ func TestLandscapeEnable(t *testing.T) {
 
 			if tc.breakWSLPath {
 				mock.SetControlArg(testutils.WslpathErr)
+			}
+
+			if tc.noLandscapeGroup {
+				mock.LandscapeGroupGID = ""
 			}
 
 			config, err := os.ReadFile(filepath.Join(commontestutils.TestFixturePath(t), "landscape.conf"))

--- a/wsl-pro-service/internal/system/testdata/TestLandscapeEnable/error_when_the_landscape_user_does_not_exist/landscape.conf
+++ b/wsl-pro-service/internal/system/testdata/TestLandscapeEnable/error_when_the_landscape_user_does_not_exist/landscape.conf
@@ -1,0 +1,5 @@
+[host]
+url = www.example.com
+
+[client]
+hello = world


### PR DESCRIPTION
The landscape group needs read-access to the /etc/landscape/client.conf file. However, we do not want any user to be able to read it as it may contain confidential details such as the registration key. The solution is to restrict its visibility to its owner and group, and to add it to landscape's group

Thanks @iosifache for spotting this vulnerability.

---

UDENG-2540