### PR TITLE
feat: Implement clean verb for the agent

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -228,7 +228,7 @@ func (a *App) publicDir(opts options) (string, error) {
 		opts.publicDir = filepath.Join(homeDir, common.UserProfileDir)
 	}
 
-	if err := os.MkdirAll(opts.publicDir, 0600); err != nil {
+	if err := os.MkdirAll(opts.publicDir, 0700); err != nil {
 		return "", fmt.Errorf("could not create public dir %s: %v", opts.publicDir, err)
 	}
 
@@ -246,7 +246,7 @@ func (a *App) privateDir(opts options) (string, error) {
 		opts.privateDir = filepath.Join(localAppData, common.LocalAppDataDir)
 	}
 
-	if err := os.MkdirAll(opts.privateDir, 0600); err != nil {
+	if err := os.MkdirAll(opts.privateDir, 0700); err != nil {
 		return "", fmt.Errorf("could not create private dir %s: %v", opts.privateDir, err)
 	}
 

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -97,6 +97,7 @@ func New(o ...option) *App {
 
 	// subcommands
 	a.installVersion()
+	a.installClean()
 
 	return &a
 }

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/clean.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/clean.go
@@ -52,7 +52,7 @@ func stopAgent() error {
 		"/FI", filterPID, // Filter out the current process.
 	).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("could not list stop process %s: %v. %s", cmdName(), err, out)
+		return fmt.Errorf("could not stop process %s: %v. %s", cmdName(), err, out)
 	}
 
 	return nil

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/clean.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/clean.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func (a *App) installClean() {
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: i18n.G("Removes all the agent's data and exits"),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			defer log.Debug("clean command finished")
+
+			// Stop the agent so that it doesn't interfere with file removal.
+			if err := stopAgent(); err != nil {
+				log.Warningf("could not stop agent: %v", err)
+			}
+
+			// Clean up the agent's data.
+			return errors.Join(
+				cleanLocation("LocalAppData", common.LocalAppDataDir),
+				cleanLocation("UserProfile", common.UserProfileDir),
+			)
+		},
+	}
+	a.rootCmd.AddCommand(cmd)
+}
+
+// stopAgent stops all other ubuntu-pro-agent instances (but not itself!).
+func stopAgent() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filterPID := fmt.Sprintf("PID ne %d", os.Getpid())
+
+	//nolint:gosec // The return value of cmdName() is not user input.
+	out, err := exec.CommandContext(ctx, "taskkill.exe",
+		"/F",             // Force-stop the process
+		"/IM", cmdName(), // Match the process name
+		"/FI", filterPID, // Filter out the current process.
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not list stop process %s: %v. %s", cmdName(), err, out)
+	}
+
+	return nil
+}
+
+func cleanLocation(rootEnv, relpath string) error {
+	root := os.Getenv(rootEnv)
+	if root == "" {
+		return fmt.Errorf("could not clean up location: environment variable %q is not set", rootEnv)
+	}
+
+	path := filepath.Join(root, relpath)
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("could not clean up location %s: %v", path, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
ubuntu-pro-agent.exe clean
```
This command removes directories `~/.ubuntupro` and `$LocalAppData\Ubuntu Pro`.

Eventually the MSIX uninstaller should call this command so as to clean up after itself. It's also useful for local testing.

---

UDENG-2231