### PR TITLE
feat(windows-agent): Add support for configuration files

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -102,7 +102,7 @@ func New(o ...option) *App {
 	a.viper = viper.New()
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
-	installConfigFlag(&a.rootCmd, a.viper)
+	installConfigFlag(&a.rootCmd)
 
 	// subcommands
 	a.installVersion()
@@ -186,6 +186,13 @@ func (a App) RootCmd() cobra.Command {
 // SetArgs changes the root command args. Shouldn't be in general necessary apart for tests.
 func (a *App) SetArgs(args ...string) {
 	a.rootCmd.SetArgs(args)
+}
+
+// Config returns the DaemonConfig for test purposes.
+//
+//nolint:revive
+func (a App) Config() daemonConfig {
+	return a.config
 }
 
 // PublicDir creates a directory to store public data in.

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
@@ -72,9 +73,9 @@ func New(o ...option) *App {
 			// command parsing has been successful. Returns to not print usage anymore.
 			a.rootCmd.SilenceUsage = true
 
-			// Parse environment veriables
-			a.viper.SetEnvPrefix("UP4W")
-			a.viper.AutomaticEnv()
+			if err := initViperConfig(strings.ReplaceAll(cmdName(), ".exe", ""), &a.rootCmd, a.viper); err != nil {
+				return err
+			}
 
 			if err := a.viper.Unmarshal(&a.config); err != nil {
 				return fmt.Errorf("unable to decode configuration into struct: %w", err)
@@ -101,6 +102,7 @@ func New(o ...option) *App {
 	a.viper = viper.New()
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
+	installConfigFlag(&a.rootCmd, a.viper)
 
 	// subcommands
 	a.installVersion()
@@ -148,32 +150,6 @@ func (a *App) serve(ctx context.Context, args ...option) error {
 	close(a.ready)
 
 	return a.daemon.Serve(ctx)
-}
-
-// installVerbosityFlag adds the -v and -vv options and returns the reference to it.
-func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
-	r := cmd.PersistentFlags().CountP("verbosity", "v", i18n.G("issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"))
-	if err := viper.BindPFlag("verbosity", cmd.PersistentFlags().Lookup("verbosity")); err != nil {
-		log.Warning(context.Background(), err)
-	}
-	return r
-}
-
-// SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
-func setVerboseMode(level int) {
-	var reportCaller bool
-	switch level {
-	case 0:
-		logrus.SetLevel(consts.DefaultLogLevel)
-	case 1:
-		logrus.SetLevel(logrus.InfoLevel)
-	case 3:
-		reportCaller = true
-		fallthrough
-	default:
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-	log.SetReportCaller(reportCaller)
 }
 
 // Run executes the command and associated process. It returns an error on syntax/usage error.

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -188,13 +188,6 @@ func (a *App) SetArgs(args ...string) {
 	a.rootCmd.SetArgs(args)
 }
 
-// Config returns the DaemonConfig for test purposes.
-//
-//nolint:revive
-func (a App) Config() daemonConfig {
-	return a.config
-}
-
 // PublicDir creates a directory to store public data in.
 func (a *App) PublicDir() (string, error) {
 	// This wrapper is used to have a cleaner public API.

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
@@ -102,7 +102,7 @@ func TestConfigArg(t *testing.T) {
 
 	filename := "ubuntu-pro-agent.yaml"
 	configPath := filepath.Join(t.TempDir(), filename)
-	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0644), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
 
 	a := agent.New()
 	a.SetArgs("version", "--config", configPath)
@@ -121,7 +121,7 @@ func TestConfigAutoDetect(t *testing.T) {
 
 	filename := "ubuntu-pro-agent.yaml"
 	configPath := filepath.Join(".", filename)
-	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0644), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
 	defer os.Remove(configPath)
 
 	err := a.Run()

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
@@ -102,7 +102,7 @@ func TestConfigArg(t *testing.T) {
 
 	filename := "ubuntu-pro-agent.yaml"
 	configPath := filepath.Join(t.TempDir(), filename)
-	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 1"), 0600), "Setup: couldn't write config file")
 
 	a := agent.New()
 	a.SetArgs("version", "--config", configPath)
@@ -110,7 +110,7 @@ func TestConfigArg(t *testing.T) {
 	err := a.Run()
 	out := getStdout()
 	require.NoError(t, err, "Run should not return an error, stdout: %v", out)
-	require.Equal(t, 3, a.Config().Verbosity)
+	require.Equal(t, 1, a.Config().Verbosity)
 }
 
 func TestConfigAutoDetect(t *testing.T) {

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
@@ -35,11 +33,6 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 		vip.AddConfigPath("./")
 		vip.AddConfigPath("$HOME")
 		vip.AddConfigPath(fmt.Sprintf("$HOME/%s", common.UserProfileDir))
-		if binPath, err := os.Executable(); err != nil {
-			log.Warningf(context.Background(), "Failed to get the current executable path, not adding it as a config dir: %v", err)
-		} else {
-			vip.AddConfigPath(filepath.Dir(binPath))
-		}
 	}
 
 	// Load the config

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/consts"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/ubuntu/decorate"
+)
+
+func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err error) {
+	defer decorate.OnError(&err, "can't load configuration")
+
+	// Use command-line flag for verbosity until configuration is parsed
+	v, err := cmd.Flags().GetCount("verbosity")
+	if err != nil {
+		return fmt.Errorf("internal error: no persistent verbosity flags installed on cmd: %w", err)
+	}
+	setVerboseMode(v)
+
+	// Find a valid configuration file
+	if v, err := cmd.Flags().GetString("config"); err == nil && v != "" {
+		vip.SetConfigFile(v)
+	} else {
+		vip.SetConfigName(name)
+		vip.AddConfigPath("./")
+		vip.AddConfigPath("$HOME")
+		vip.AddConfigPath(fmt.Sprintf("$HOME/%s", common.UserProfileDir))
+		if binPath, err := os.Executable(); err != nil {
+			log.Warningf(context.Background(), "Failed to get the current executable path, not adding it as a config dir: %v", err)
+		} else {
+			vip.AddConfigPath(filepath.Dir(binPath))
+		}
+	}
+
+	// Load the config
+	if err := vip.ReadInConfig(); err != nil {
+		if e, ok := err.(viper.ConfigFileNotFoundError); ok {
+			log.Infof(context.Background(), "No configuration file: %v", e)
+		} else {
+			log.Errorf(context.Background(), "invalid configuration file: %v", err)
+		}
+	} else {
+		log.Infof(context.Background(), "Using configuration file: %v", vip.ConfigFileUsed())
+	}
+
+	// Parse environment variables
+	vip.SetEnvPrefix("UP4W")
+	vip.AutomaticEnv()
+
+	return nil
+}
+
+// installVerbosityFlag adds the -v and -vv options and returns the reference to it.
+func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
+	r := cmd.PersistentFlags().CountP("verbosity", "v", i18n.G("issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"))
+	if err := viper.BindPFlag("verbosity", cmd.PersistentFlags().Lookup("verbosity")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
+}
+
+// installConfigFlag adds the --config flag to allow for custom config paths.
+func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
+	r := cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
+	if err := viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
+}
+
+// SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
+func setVerboseMode(level int) {
+	var reportCaller bool
+	switch level {
+	case 0:
+		logrus.SetLevel(consts.DefaultLogLevel)
+	case 1:
+		logrus.SetLevel(logrus.InfoLevel)
+	case 3:
+		reportCaller = true
+		fallthrough
+	default:
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	log.SetReportCaller(reportCaller)
+}

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -72,11 +72,7 @@ func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
 
 // installConfigFlag adds the --config flag to allow for custom config paths.
 func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
-	r := cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
-	if err := viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config")); err != nil {
-		log.Warning(context.Background(), err)
-	}
-	return r
+	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
 }
 
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,10 +44,11 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 
 	// Load the config
 	if err := vip.ReadInConfig(); err != nil {
-		if e, ok := err.(viper.ConfigFileNotFoundError); ok {
+		var e viper.ConfigFileNotFoundError
+		if errors.As(err, &e) {
 			log.Infof(context.Background(), "No configuration file: %v", e)
 		} else {
-			log.Errorf(context.Background(), "invalid configuration file: %v", err)
+			return fmt.Errorf("invalid configuration file: %v", err)
 		}
 	} else {
 		log.Infof(context.Background(), "Using configuration file: %v", vip.ConfigFileUsed())

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -64,7 +64,7 @@ func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
 }
 
 // installConfigFlag adds the --config flag to allow for custom config paths.
-func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
+func installConfigFlag(cmd *cobra.Command) *string {
 	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
 }
 

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
@@ -39,3 +39,10 @@ func NewForTesting(t *testing.T, publicDir, privateDir string) *App {
 
 	return New(WithPrivateDir(privateDir), WithPublicDir(publicDir), WithRegistry(registry.NewMock()))
 }
+
+// Config returns the DaemonConfig for test purposes.
+//
+//nolint:revive
+func (a App) Config() daemonConfig {
+	return a.config
+}


### PR DESCRIPTION
This adds support for a configuration file to be read and used. Currently, the only options available are verbosity level.

Config files can be located in the current working directory, alongside the binary, in the user's home directory, or in `%UserProfile%/.ubuntupro`. The file must be named `ubuntu-pro-agent.<type>` where `<type>` is one of the file types [supported by Viper](https://github.com/spf13/viper?tab=readme-ov-file#reading-config-files), e.g. `ubuntu-pro-agent.yaml`.

A custom configuration path can be specified by passing the new `--config` flag, which should point to a file that meets the same requirements of Viper described above.

Largely the same as #732.

---

UDENG-2369