### PR TITLE
feat(wsl-pro-service): Add support for using configuration file

### DIFF
--- a/wsl-pro-service/cmd/wsl-pro-service/service/config.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/config.go
@@ -70,7 +70,7 @@ func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
 }
 
 // installConfigFlag adds the --config flag to allow for custom config paths.
-func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
+func installConfigFlag(cmd *cobra.Command) *string {
 	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
 }
 

--- a/wsl-pro-service/cmd/wsl-pro-service/service/config.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/config.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
+	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/consts"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/ubuntu/decorate"
+)
+
+func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err error) {
+	defer decorate.OnError(&err, "can't load configuration")
+
+	// Use command-line flag for verbosity until configuration is parsed
+	v, err := cmd.Flags().GetCount("verbosity")
+	if err != nil {
+		return fmt.Errorf("internal error: no persistent verbosity flags installed on cmd: %w", err)
+	}
+	setVerboseMode(v)
+
+	// Find a valid configuration file
+	if v, err := cmd.Flags().GetString("config"); err == nil && v != "" {
+		vip.SetConfigFile(v)
+	} else {
+		vip.SetConfigName(name)
+		vip.AddConfigPath("./")
+		vip.AddConfigPath("$HOME/")
+		vip.AddConfigPath("/etc/")
+		if binPath, err := os.Executable(); err != nil {
+			log.Warningf(context.Background(), "Failed to get the current executable path, not adding it as a config dir: %v", err)
+		} else {
+			vip.AddConfigPath(filepath.Dir(binPath))
+		}
+	}
+
+	// Load the config
+	if err := vip.ReadInConfig(); err != nil {
+		var e viper.ConfigFileNotFoundError
+		if errors.As(err, &e) {
+			log.Infof(context.Background(), "No configuration file: %v", e)
+		} else {
+			return fmt.Errorf("invalid configuration file: %v", err)
+		}
+	} else {
+		log.Infof(context.Background(), "Using configuration file: %v", vip.ConfigFileUsed())
+	}
+
+	// Parse environment variables
+	vip.SetEnvPrefix("UP4W")
+	vip.AutomaticEnv()
+
+	return nil
+}
+
+// installVerbosityFlag adds the -v and -vv options and returns the reference to it.
+func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
+	r := cmd.PersistentFlags().CountP("verbosity", "v", i18n.G("issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"))
+	if err := viper.BindPFlag("verbosity", cmd.PersistentFlags().Lookup("verbosity")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
+}
+
+// installConfigFlag adds the --config flag to allow for custom config paths.
+func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
+	r := cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
+	if err := viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
+}
+
+// SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
+func setVerboseMode(level int) {
+	var reportCaller bool
+	switch level {
+	case 0:
+		logrus.SetLevel(consts.DefaultLogLevel)
+	case 1:
+		logrus.SetLevel(logrus.InfoLevel)
+	case 3:
+		reportCaller = true
+		fallthrough
+	default:
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	log.SetReportCaller(reportCaller)
+}

--- a/wsl-pro-service/cmd/wsl-pro-service/service/config.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/config.go
@@ -71,11 +71,7 @@ func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
 
 // installConfigFlag adds the --config flag to allow for custom config paths.
 func installConfigFlag(cmd *cobra.Command, viper *viper.Viper) *string {
-	r := cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
-	if err := viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config")); err != nil {
-		log.Warning(context.Background(), err)
-	}
-	return r
+	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
 }
 
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.

--- a/wsl-pro-service/cmd/wsl-pro-service/service/export_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/export_test.go
@@ -7,3 +7,10 @@ func WithSystem(s *system.System) func(*options) {
 		o.system = s
 	}
 }
+
+// Config returns the daemonConfig for test purposes.
+//
+//nolint:revive
+func (a App) Config() daemonConfig {
+	return a.config
+}

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service.go
@@ -137,10 +137,3 @@ func (a App) RootCmd() cobra.Command {
 func (a *App) SetArgs(args ...string) {
 	a.rootCmd.SetArgs(args)
 }
-
-// Config returns the daemonConfig for test purposes.
-//
-//nolint:revive
-func (a App) Config() daemonConfig {
-	return a.config
-}

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service.go
@@ -137,3 +137,7 @@ func (a App) RootCmd() cobra.Command {
 func (a *App) SetArgs(args ...string) {
 	a.rootCmd.SetArgs(args)
 }
+
+func (a App) Config() daemonConfig {
+	return a.config
+}

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service.go
@@ -74,7 +74,7 @@ func New(o ...option) *App {
 	a.viper = viper.New()
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
-	installConfigFlag(&a.rootCmd, a.viper)
+	installConfigFlag(&a.rootCmd)
 
 	// subcommands
 	a.installVersion()
@@ -138,6 +138,9 @@ func (a *App) SetArgs(args ...string) {
 	a.rootCmd.SetArgs(args)
 }
 
+// Config returns the daemonConfig for test purposes.
+//
+//nolint:revive
 func (a App) Config() daemonConfig {
 	return a.config
 }

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service.go
@@ -8,10 +8,8 @@ import (
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
 	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/commandservice"
-	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/consts"
 	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/daemon"
 	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/system"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,9 +52,9 @@ func New(o ...option) *App {
 			// command parsing has been successful. Returns to not print usage anymore.
 			a.rootCmd.SilenceUsage = true
 
-			// Parse environment veriables
-			a.viper.SetEnvPrefix("UP4W")
-			a.viper.AutomaticEnv()
+			if err := initViperConfig(cmdName, &a.rootCmd, a.viper); err != nil {
+				return err
+			}
 
 			if err := a.viper.Unmarshal(&a.config); err != nil {
 				return fmt.Errorf("unable to decode configuration into struct: %w", err)
@@ -76,6 +74,7 @@ func New(o ...option) *App {
 	a.viper = viper.New()
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
+	installConfigFlag(&a.rootCmd, a.viper)
 
 	// subcommands
 	a.installVersion()
@@ -105,32 +104,6 @@ func (a *App) serve(args ...option) (err error) {
 	close(a.ready)
 
 	return a.daemon.Serve(service)
-}
-
-// installVerbosityFlag adds the -v and -vv options and returns the reference to it.
-func installVerbosityFlag(cmd *cobra.Command, viper *viper.Viper) *int {
-	r := cmd.PersistentFlags().CountP("verbosity", "v", i18n.G("issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"))
-	if err := viper.BindPFlag("verbosity", cmd.PersistentFlags().Lookup("verbosity")); err != nil {
-		log.Warning(context.Background(), err)
-	}
-	return r
-}
-
-// SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
-func setVerboseMode(level int) {
-	var reportCaller bool
-	switch level {
-	case 0:
-		logrus.SetLevel(consts.DefaultLogLevel)
-	case 1:
-		logrus.SetLevel(logrus.InfoLevel)
-	case 3:
-		reportCaller = true
-		fallthrough
-	default:
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-	log.SetReportCaller(reportCaller)
 }
 
 // Run executes the command and associated process. It returns an error on syntax/usage error.

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
@@ -91,7 +91,7 @@ func TestConfigArg(t *testing.T) {
 
 	filename := "wsl-pro-service.yaml"
 	configPath := filepath.Join(t.TempDir(), filename)
-	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0644), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
 
 	sys, _ := testutils.MockSystem(t)
 	a := service.New(service.WithSystem(sys))
@@ -112,7 +112,7 @@ func TestConfigAutoDetect(t *testing.T) {
 
 	filename := "wsl-pro-service.yaml"
 	configNextToBinaryPath := filepath.Join(filepath.Dir(os.Args[0]), filename)
-	require.NoError(t, os.WriteFile(configNextToBinaryPath, []byte("verbosity: 3"), 0644), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configNextToBinaryPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
 
 	err := a.Run()
 	out := getStdout()

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
@@ -91,7 +91,7 @@ func TestConfigArg(t *testing.T) {
 
 	filename := "wsl-pro-service.yaml"
 	configPath := filepath.Join(t.TempDir(), filename)
-	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 3"), 0600), "Setup: couldn't write config file")
+	require.NoError(t, os.WriteFile(configPath, []byte("verbosity: 1"), 0600), "Setup: couldn't write config file")
 
 	sys, _ := testutils.MockSystem(t)
 	a := service.New(service.WithSystem(sys))
@@ -100,7 +100,7 @@ func TestConfigArg(t *testing.T) {
 	err := a.Run()
 	out := getStdout()
 	require.NoError(t, err, "Run should not return an error, stdout: %v", out)
-	require.Equal(t, 3, a.Config().Verbosity)
+	require.Equal(t, 1, a.Config().Verbosity)
 }
 
 func TestConfigAutoDetect(t *testing.T) {

--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -4,7 +4,7 @@ ConditionVirtualization=wsl
 
 [Service]
 Type=notify
-ExecStart=/usr/libexec/wsl-pro-service -vv
+ExecStart=/usr/libexec/wsl-pro-service
 Restart=always
 RestartSec=2s
 


### PR DESCRIPTION
This adds support for a configuration file to be read and used. Currently, the only options available are verbosity level.

Config files can be located in the current working directory, alongside the binary, in the user's home directory, or in `/etc/`. The file must be named `wsl-pro-service.<type>` where `<type>` is one of the file types [supported by Viper](https://github.com/spf13/viper?tab=readme-ov-file#reading-config-files), e.g. `wsl-pro-service.yaml`.

A custom configuration path can be specified by passing the new `--config` flag, which should point to a file that meets the same requirements of Viper described above.

This also removes the default `-vv` flags passed to the service.

Largely the same as #721.

---

UDENG-2371