### PR TITLE
feat(gui-ubuntupro): Make version text selectable for copying

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/widgets/status_bar.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/status_bar.dart
@@ -26,7 +26,7 @@ class StatusBar extends StatelessWidget {
     return Row(
       children: <Widget>[
         const SizedBox(width: 8.0),
-        Text(
+        SelectableText(
           constants.kVersion,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: YaruColors.warmGrey,


### PR DESCRIPTION
Very small change that just allows the version text in the status bar of the GUI to be selected for copying.

---

UDENG-2749