### PR TITLE
feat(windows-agent): Add Windows Event Logger support

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 // cmdName is the binary name for the agent.
@@ -44,7 +45,9 @@ type App struct {
 }
 
 type daemonConfig struct {
-	Verbosity int
+	Verbosity       int
+	EventLogEnabled bool
+	FileLogEnabled  bool
 }
 
 type options struct {
@@ -103,6 +106,8 @@ func New(o ...option) *App {
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
 	installConfigFlag(&a.rootCmd)
+	installFileLogEnabledFlag(&a.rootCmd)
+	installEventLogEnabledFlag(&a.rootCmd)
 
 	// subcommands
 	a.installVersion()
@@ -251,18 +256,78 @@ func (a *App) setUpLogger(ctx context.Context) (func(), error) {
 		log.Warningf(ctx, "Could not archive previous log file: %v", err)
 	}
 
-	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)
-	if err != nil {
-		return noop, fmt.Errorf("could not open log file: %v", err)
+	// Always write to stdout, which is useful for local development.
+	w := io.MultiWriter(os.Stdout)
+
+	var f *os.File
+	if a.config.FileLogEnabled {
+		f, err = os.OpenFile(logFile, os.O_APPEND|os.O_CREATE, 0600)
+		if err != nil {
+			return noop, fmt.Errorf("could not open log file: %v", err)
+		}
+		w = io.MultiWriter(w, f)
 	}
 
-	// Write both to file and to Stdout. The latter is useful for local development.
-	w := io.MultiWriter(f, os.Stdout)
+	var eventLogger *eventlog.Log
+	if a.config.EventLogEnabled {
+		eventLogger, err = eventlog.Open(cmdName())
+		if err != nil {
+			return noop, err
+		}
+		logrus.AddHook(&eventLogHook{Writer: &EventLogWriter{eventLogger}})
+	}
+
 	logrus.SetOutput(w)
 
 	fmt.Fprintf(f, "\n======= STARTUP =======\n")
 	log.Infof(ctx, "Version: %s", consts.Version)
 	log.Debug(ctx, "Debug mode is enabled")
 
-	return func() { _ = f.Close() }, nil
+	return func() {
+		if f != nil {
+			_ = f.Close()
+		}
+		if eventLogger != nil {
+			_ = eventLogger.Close()
+		}
+	}, nil
+}
+
+type EventLogWriter struct {
+	*eventlog.Log
+}
+
+func (writer *EventLogWriter) Write(p []byte) (n int, err error) {
+	err = writer.Info(0, string(p))
+	if err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+}
+
+type eventLogHook struct {
+	Writer *EventLogWriter
+}
+
+// Fire sends the log entry to the specified EventLog if the log level matches
+func (hook *eventLogHook) Fire(entry *logrus.Entry) error {
+	switch entry.Level {
+	case logrus.DebugLevel:
+		// EventLogWriter has no Debug function as of now, so use Info instead
+		return hook.Writer.Info(0, entry.Message)
+	case logrus.InfoLevel:
+		return hook.Writer.Info(0, entry.Message)
+	case logrus.WarnLevel:
+		return hook.Writer.Warning(0, entry.Message)
+	case logrus.ErrorLevel:
+		return hook.Writer.Error(0, entry.Message)
+	}
+
+	return fmt.Errorf("invalid log level %v", entry.Level)
+}
+
+// Levels returns the log levels that this hook should be registered with
+func (hook *eventLogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
 }

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -44,12 +44,6 @@ type App struct {
 	ready chan struct{}
 }
 
-type daemonConfig struct {
-	Verbosity       int
-	EventLogEnabled bool
-	FileLogEnabled  bool
-}
-
 type options struct {
 	// publicDir is the directory where public data goes. Other components need access to it.
 	publicDir string
@@ -106,8 +100,8 @@ func New(o ...option) *App {
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
 	installConfigFlag(&a.rootCmd)
-	installFileLogEnabledFlag(&a.rootCmd)
-	installEventLogEnabledFlag(&a.rootCmd)
+	installFileLogEnabledFlag(&a.rootCmd, a.viper)
+	installEventLogEnabledFlag(&a.rootCmd, a.viper)
 
 	// subcommands
 	a.installVersion()

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -68,6 +68,16 @@ func installConfigFlag(cmd *cobra.Command) *string {
 	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("configuration file path"))
 }
 
+// installEventLogEnabledFlag adds the --event-log-enabled flag to allow for disabling event logging.
+func installEventLogEnabledFlag(cmd *cobra.Command) *bool {
+	return cmd.PersistentFlags().BoolP("event-log-enabled", "e", false, i18n.G("whether to enable logging to the Windows event logger"))
+}
+
+// installFileLogEnabledFlag adds the --file-log-enabled flag to allow for enabling file logging.
+func installFileLogEnabledFlag(cmd *cobra.Command) *bool {
+	return cmd.PersistentFlags().BoolP("file-log-enabled", "f", false, i18n.G("whether to enable logging to a log file"))
+}
+
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
 func setVerboseMode(level int) {
 	var reportCaller bool

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -15,6 +15,12 @@ import (
 	"github.com/ubuntu/decorate"
 )
 
+type daemonConfig struct {
+	Verbosity       int
+	EventLogEnabled bool `mapstructure:"event-log-enabled"`
+	FileLogEnabled  bool `mapstructure:"file-log-enabled"`
+}
+
 func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err error) {
 	defer decorate.OnError(&err, "can't load configuration")
 
@@ -69,13 +75,23 @@ func installConfigFlag(cmd *cobra.Command) *string {
 }
 
 // installEventLogEnabledFlag adds the --event-log-enabled flag to allow for disabling event logging.
-func installEventLogEnabledFlag(cmd *cobra.Command) *bool {
-	return cmd.PersistentFlags().BoolP("event-log-enabled", "e", false, i18n.G("whether to enable logging to the Windows event logger"))
+// Event logging is enabled by default.
+func installEventLogEnabledFlag(cmd *cobra.Command, viper *viper.Viper) *bool {
+	r := cmd.PersistentFlags().BoolP("event-log-enabled", "e", true, i18n.G("whether to enable logging to the Windows event logger"))
+	if err := viper.BindPFlag("event-log-enabled", cmd.PersistentFlags().Lookup("event-log-enabled")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
 }
 
 // installFileLogEnabledFlag adds the --file-log-enabled flag to allow for enabling file logging.
-func installFileLogEnabledFlag(cmd *cobra.Command) *bool {
-	return cmd.PersistentFlags().BoolP("file-log-enabled", "f", false, i18n.G("whether to enable logging to a log file"))
+// File logging is disabled by default.
+func installFileLogEnabledFlag(cmd *cobra.Command, viper *viper.Viper) *bool {
+	r := cmd.PersistentFlags().BoolP("file-log-enabled", "f", false, i18n.G("whether to enable logging to a log file"))
+	if err := viper.BindPFlag("file-log-enabled", cmd.PersistentFlags().Lookup("file-log-enabled")); err != nil {
+		log.Warning(context.Background(), err)
+	}
+	return r
 }
 
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.


### PR DESCRIPTION
This changes the default logging method from file logging to using the Windows Event Logger. File logging is still available through the use of the new `--file-log-enabled` flag (and its accompanying `--event-log-enabled` flag, which is enabled by default).

You can view logs on Windows 11 by searching for the `Event Viewer` application and creating a Custom View for all event levels of the "Application" logs.

The `eventlog` support from Golang doesn't seem to include a debug function, so all debug logs are rerouted as info-level logs in the event viewer. In addition, there are event IDs which essentially go unused in this use case (`0`) as I believe they're mostly OS-specific event types and would be hard to utilize through the logging methods we're currently using.

---

UDENG-2323