### PR TITLE
Docs: Landing page rewrite

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ WSL is preferred by many organisations as a solution to run a fully-functioning 
 
 ## Project and community
 
-UP4W is a member of the Ubuntu family. It’s an open-source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback. Check out our [contribution page](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/CONTRIBUTING.md) on GitHub in order to bring ideas, report bugs, participate in discussions, and much more!
+UP4W is a member of the Ubuntu family. It’s an open-source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback. Check out our [contribution page](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/CONTRIBUTING.md) on GitHub in order to bring ideas, report bugs, participate in discussions and much more!
 
 Thinking about using UP4W for your next project? Get in touch!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@
 This documentation describes a future release of Ubuntu Pro for WSL. Ubuntu Pro for WSL is not yet generally available in the Microsoft Store.
 ```
 
-![System Landscape](./assets/up4w-systemlandscape.png)
 
 
 Ubuntu Pro for WSL (UP4W) is a desktop application that facilitates access to your [Ubuntu Pro]( https://ubuntu.com/pro) subscription benefits in the context of [Ubuntu WSL](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Ubuntu Pro for WSL (UP4W)
-```{warning}
-This documentation describes a future release of Ubuntu Pro for WSL. Ubuntu Pro for WSL is not yet generally available in the Microsoft Store.
+```{note}
+This documentation describes a future release of UP4W. UP4W is not yet generally available in the Microsoft Store.
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,18 +3,13 @@
 This documentation describes a future release of UP4W. UP4W is not yet generally available in the Microsoft Store.
 ```
 
+Ubuntu Pro for WSL (UP4W) is a powerful automation tool for managing [WSL](https://ubuntu.com/desktop/wsl) instances from a Windows host. If you are responsible for a fleet of devices, UP4W will supercharge your ability to monitor, customise and secure WSL instances.
 
+UP4W is designed to achieve close integration with applications for customising images, enforcing standards and validating security compliance. WSL instances can be created, removed and monitored with [Landscape](https://ubuntu.com/landscape). Microsoft Defender is WSL-aware, making it easy to confirm if instances are compliant. [Cloud-init](https://cloudinit.readthedocs.io/en/latest/) support is built-in, allowing efficient customisation of standard images.
 
-Ubuntu Pro for WSL (UP4W) is a desktop application that facilitates access to your [Ubuntu Pro]( https://ubuntu.com/pro) subscription benefits in the context of [Ubuntu WSL](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/).
+UP4W can be installed from the [Microsoft Store](https://apps.microsoft.com/home?hl=en-gb&gl=IE) and its setup is highly automated. Once you have an [Ubuntu Pro](https://ubuntu.com/pro) subscription, adding your Pro token to UP4W on the Windows host will add that token to all connected WSL instances with the Ubuntu Pro client installed. When the Landscape client is installed on the host, any connected WSL instances will be auto-enrolled in Landscape. WSL instances can then be created, provisioned and managed from the Windows host.
 
-When you install UP4W on your Windows host:
-
-- If you attach your Ubuntu Pro token to UP4W on the host, UP4W will automatically add it to the Ubuntu Pro client on any Ubuntu WSL instance on the host as well, so that all of your instances are added to your Ubuntu Pro subscription.
-- If you configure the Landscape client component of UP4W on the host, UP4W will automatically configure the Landscape client on any Ubuntu WSL instance on the host as well, so that both your host and the instances on the host are registered with Landscape. You can then use Landscape not just to manage the instances but also to create and provision new instances on the host.
-
-Pro-attaching and Landscape-enrolling an Ubuntu instance is not difficult, but when your Ubuntu instance fleet is large it can get tedious.  UP4W takes advantage of the WSL setting to make it a breeze -- regardless of the size of your fleet.
-
-UP4W is of value to system administrators, corporate security teams, and desktop users.
+WSL is preferred by many organisations as a solution to run a fully-functioning Linux environment on a Windows machine. UP4W empowers system administrators and corporate security teams to manage these WSL instances at scale.
 
 ## Project and community
 

--- a/docs/reference/up4w.md
+++ b/docs/reference/up4w.md
@@ -10,3 +10,5 @@ Additionally, Ubuntu Pro for WSL requires a component running inside each of the
 - the [WSL Pro Service](ref::up4w-wsl-pro-service) communicates with the Windows Agent to provide automation services.
 
 Ubuntu Pro for WSL is available through the Microsoft Store.
+
+![System Landscape](../assets/up4w-systemlandscape.png)


### PR DESCRIPTION
This is a rewrite of the main body of the landing page in the UP4W docs.

The rewrite aims to improve clarity and reduce the amount of technical detail in the landing page.
As a part of this process the architectural diagram was moved to a more appropriate section of the docs (`reference/UP4W`).

The overall goal is to clearly state what UP4W offers to the user and provide an entry point to the rest of the docs.
As the docs mature further additional rewrites may be necessary.

Other minor changes include style improvements.