### PR TITLE
fix(wsl-pro-service): Addressing some flakyness

### DIFF
--- a/wsl-pro-service/internal/daemon/daemon_test.go
+++ b/wsl-pro-service/internal/daemon/daemon_test.go
@@ -179,8 +179,7 @@ func TestServe(t *testing.T) {
 					return systemd.gotState.Load() == "STATUS=Connected"
 				}, 30*time.Second, time.Second, "Systemd never switched states to 'Connected'")
 
-				require.Eventually(t, agent.Service.AllConnected,
-					30*time.Second, time.Second, "The daemon should have connected to the Windows Agent")
+				require.Eventually(t, agent.Service.AllConnected, 30*time.Second, time.Second, "The daemon should have connected to the Windows Agent")
 
 				require.Eventually(t, func() bool {
 					conOk := len(agent.Service.Connect.History()) > 0
@@ -293,7 +292,7 @@ func TestServeAndQuit(t *testing.T) {
 
 				require.False(t, systemd.gotUnsetEnvironment.Load(), "Unexpected value sent by Daemon to systemd notifier's unsetEnvironment")
 
-				require.Eventually(t, agent.Service.AllConnected, 10*time.Second, 100*time.Millisecond, "Daemon never connected to agent's service")
+				require.Eventually(t, agent.Service.AllConnected, 10*time.Second, 500*time.Millisecond, "Daemon never connected to agent's service")
 			}
 
 			d.Quit(ctx, tc.quitForcefully)
@@ -372,7 +371,7 @@ func TestReconnection(t *testing.T) {
 					return systemd.gotState.Load() == "STATUS=Connected"
 				}, maxTimeout, time.Second, "Service should have set systemd state to Connected")
 
-				require.Eventually(t, agent.Service.AllConnected, 10*time.Second, 100*time.Millisecond, "Daemon never connected to agent's service")
+				require.Eventually(t, agent.Service.AllConnected, 10*time.Second, 500*time.Millisecond, "Daemon never connected to agent's service")
 
 				if tc.firstConnectionLong {
 					// "Long-lived" means longer than a minute
@@ -389,7 +388,7 @@ func TestReconnection(t *testing.T) {
 			agent = testutils.NewMockWindowsAgent(t, ctx, publicDir)
 			defer agent.Stop()
 
-			require.Eventually(t, agent.Service.AllConnected, 20*time.Second, 100*time.Millisecond, "Daemon never connected to agent's service")
+			require.Eventually(t, agent.Service.AllConnected, 20*time.Second, 500*time.Millisecond, "Daemon never connected to agent's service")
 			require.EqualValues(t, 1, systemd.readyNotifications.Load(), "Service should have notified systemd after connecting to the control stream")
 		})
 	}

--- a/wsl-pro-service/internal/streams/server_test.go
+++ b/wsl-pro-service/internal/streams/server_test.go
@@ -38,7 +38,6 @@ func TestServe(t *testing.T) {
 	}()
 
 	// Test handshake
-
 	require.Eventually(t, agent.Service.AllConnected, 20*time.Second, 500*time.Millisecond, "Setup: Agent service never became ready")
 
 	// Test receiving a pro token and returning success
@@ -51,7 +50,6 @@ func TestServe(t *testing.T) {
 	require.Empty(t, agent.Service.ProAttachment.History()[1].GetResult(), "ProAttachment should return a successful result")
 
 	// Test receiving a pro token and returning error
-
 	err = agent.Service.ProAttachment.Send(&agentapi.ProAttachCmd{Token: "HARDCODED_FAILURE"})
 	require.NoError(t, err, "Send should return no error")
 
@@ -61,7 +59,6 @@ func TestServe(t *testing.T) {
 	require.NotEmpty(t, agent.Service.ProAttachment.History()[2].GetResult(), "ProAttachment should return an error result")
 
 	// Test receiving a Landscape config and returning success
-
 	err = agent.Service.LandscapeConfig.Send(&agentapi.LandscapeConfigCmd{Config: "hello=world"})
 	require.NoError(t, err, "Send should return no error")
 
@@ -71,7 +68,6 @@ func TestServe(t *testing.T) {
 	require.Empty(t, agent.Service.LandscapeConfig.History()[1].GetResult(), "LandscapeConfig should return a successful result")
 
 	// Test receiving a Landscape config and returning error
-
 	err = agent.Service.LandscapeConfig.Send(&agentapi.LandscapeConfigCmd{Config: "HARDCODED_FAILURE"})
 	require.NoError(t, err, "Send should return no error")
 

--- a/wsl-pro-service/internal/streams/server_test.go
+++ b/wsl-pro-service/internal/streams/server_test.go
@@ -38,9 +38,7 @@ func TestServe(t *testing.T) {
 
 	// Test handshake
 
-	require.Eventually(t, func() bool {
-		return agent.Service.AllConnected()
-	}, 20*time.Second, 100*time.Millisecond, "Setup: Agent service never became ready")
+	require.Eventually(t, agent.Service.AllConnected, 20*time.Second, 500*time.Millisecond, "Setup: Agent service never became ready")
 
 	// Test receiving a pro token and returning success
 	err = agent.Service.ProAttachment.Send(&agentapi.ProAttachCmd{Token: "token345"})
@@ -113,9 +111,7 @@ func TestStop(t *testing.T) {
 		close(errCh)
 	}()
 
-	require.Eventually(t, func() bool {
-		return agent.Service.AllConnected()
-	}, 20*time.Second, 100*time.Millisecond, "Setup: Agent service never became ready")
+	require.Eventually(t, agent.Service.AllConnected, 20*time.Second, 500*time.Millisecond, "Setup: Agent service never became ready")
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
Some of the wsl-pro-service tests frequently show up as spurious failures, such as `internal/streams/server_tests.go` `TestServe` and `TestStop`. Some observed both in GH CI as well as in Launchpad builds (autopkgtests).

This PR is an attempt to mitigate some non-deterministic failure behavior in this module. Here I focused on the test code itself, as I think I found opportunity for improvement in there. It's possible that some flaky behavior I didn't see or address now will be adressed in futures PRs where I plan to rework the gRPC client creation and reconnection logic, which will have more invasive changes in the production code anyways.

Here's a gist of the reasoning behind the changes:

- `streams.Server.Serve()` - test cases run it in a different goroutine spawn by the test code. The changes increase the slack of time in attempt to give the runtime more change to schedule starting the server. Similarly, all checks to the mock agent's all connected getter (`agent.Service.AllConnected()`) got the same slack on `require.Eventually` check calls. Its work mentioning that the condition asserted by the require calls is already guarded by mutexes, so no races.

- `streams_tests.mockService` relies on a boolean flag to decide whether the RPC's should fail or not, but as the RPCs happen in a different goroutine, that might happen to run on a different thread, the effects of the call to `s.setBlocking` might not be visible to the thread handling the RPCs. Thus a mutex is introduced into the mock service.

---
UDENG-2724