### PR TITLE
docs: UP4W tutorial cleanup

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -35,7 +35,7 @@ for this tutorial.
 
 (ref::backup-warning)=
 ```{warning}
-**If you already have Ubuntu for WSL pre-installed:** 
+**If you already have Ubuntu WSL pre-installed:** 
 
 We recommend that they are exported then deleted.
 You can then install them as described in this tutorial.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -12,7 +12,7 @@ Throughout this tutorial, commands will be prefixed by a prompt that indicates t
 
 - `PS C:\Users\me\tutorial>` is a PowerShell prompt where the current working directory is `C:\Users\me\tutorial`.
 
-- `root@hostname:~#` indicates a Linux shell prompt with login as root in the root home directory `~`.
+- `ubuntu@wsl:~/tutorial$` indicates a Linux shell prompt login as ubuntu where the current working directory is `/home/ubuntu/tutorial/`
 
 Output logs are included in this tutorial when instructive but are typically omitted to save space.
 ```

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -7,42 +7,44 @@ In this tutorial you will develop an understanding of how UP4W can be installed 
 To complete this tutorial you will need a Windows 11 machine with a minimum of 16GB RAM and a 8-core processor.
 
 ```{note}
-Throughout this tutorial we'll present shell commands together with their output:
+WSL enables using a Linux shell and Windows PowerShell side-by-side on the same machine.
 
-- The commands will be prefixed by a
-prompt matching the shell it's launched in. 
+Throughout this tutorial, commands will be prefixed by a prompt that indicates the shell being used, for example:
 
-  For example, `PS C:\Users\me\tutorial>` is a PowerShell prompt where the current working directory is `C:\Users\me\tutorial`, thus running on Windows.
+- `PS C:\Users\me\tutorial>` is a PowerShell prompt where the current working directory is `C:\Users\me\tutorial`.
 
-  Similarly, a Linux shell prompt logged in as root with the current working directory as the root home directory will look like `root@hostname:~#`
-
-- The outputs are preserved to give you more context.
+- `root@hostname:~#` indicates a Linux shell prompt with login as root in the root home directory `~`.
 ```
+<!-- TODO: continue clean up -->
+<!-- focus on text before command logs -->
+<!-- keep Pro and UP4W together -->
+<!-- keep WSL/Ubuntu/Landscape instructions short -->
+<!-- landscape logs are way too much -->
+<!-- careful with links not rendering -->
 
 ## Set things up
 
-### Install the Windows Subsystem for Linux (WSL) application
+### Install WSL and Ubuntu
 
-```{warning}
-**If you already have it pre-installed:** 
+WSL can be installed directly from the [Microsoft Store](https://www.microsoft.com/store/productId/9P9TQF7MRM4R).
 
-Please reset its configuration to the default settings by (making a backup of your existing `~\.wslconfig` file, then) running:
+If you already have WSL installed you are advised to backup `~\.wslconfig` and remove it before continuing the tutorial:
 
-    PS C:\Users\me\tutorial> Remove-Item ~\.wslconfig
-
+```text
+PS C:\Users\me\tutorial> Remove-Item ~\.wslconfig
 ```
 
-See: [Microsoft Store | Windows Subsystem for Linux](https://www.microsoft.com/store/productId/9P9TQF7MRM4R)
-
-All set. From now on you can use it to launch  WSL instances.
-
-### Install the Ubuntu 22.04 LTS and Ubuntu (Preview) applications
+Ubuntu can also be installed from the Microsoft Store.
+Choose [Ubuntu 22.04 LTS](https://www.microsoft.com/store/productId/9PN20MSR04DW) or [Ubuntu (Preview)](https://www.microsoft.com/store/productId/9P7BDVKVNXZ6)
+for this tutorial.
 
 (ref::backup-warning)=
 ```{warning}
-**If you already have them pre-installed:** 
+**If you already have Ubuntu for WSL pre-installed:** 
 
-Please export them and delete them. Then proceed with the tutorial and install them fresh from the links provided below. At the end of the tutorial you can re-import them to restore your data.
+We recommend that they are exported then deleted.
+You can then install them as described in this tutorial.
+At the end of the tutorial you can re-import and restore your data.
 
  <details><summary> How do I export, delete, and re-import Ubuntu 22.04 LTS? </summary>
 
@@ -77,37 +79,13 @@ Please export them and delete them. Then proceed with the tutorial and install t
  </details>
 ```
 
-See: 
-- [Microsoft Store | Ubuntu 22.04 LTS](https://www.microsoft.com/store/productId/9PN20MSR04DW)
-- [Microsoft Store | Ubuntu (Preview)](https://www.microsoft.com/store/productId/9P7BDVKVNXZ6)
+You can now launch WSL instances of Ubuntu on your Windows machine.
 
-All set. From now on you can launch WSL instances of the Ubuntu 22.04 LTS and Ubuntu (Preview) releases.
+### Set up Landscape
 
-(tut::ensure-ubuntu-pro)=
-### Get an Ubuntu Pro subscription token
+While a Landscape server typically runs on external computers for this tutorial it will be set up on a WSL instance on your Windows machine.
 
-Visit the Ubuntu Pro page to get a subscription.
-
-> See more: [Ubuntu | Ubuntu Pro > Subscribe](https://ubuntu.com/pro/subscribe). If you choose the personal subscription option (`Myself`), the subscription is free for up to 5 machines. 
-
-Visit your Ubuntu Pro Dashboard to retrieve your subscription token.
-
-> See more: [Ubuntu | Ubuntu Pro > Dashboard](https://ubuntu.com/pro/dashboard)
-
-
-All set. From now on you can start adding this token to the Ubuntu Pro client on your WSL instances so you can enjoy Ubuntu Pro benefits on WSL as well. 
-
-### Set up a Landscape server
-
-```{warning}
-**If you already have one:**
-
-Please ignore it and proceed to set up a fresh one as shown below. As your version might differ from the one we assume here, this will guarantee the smoothest experience.
-```
-
-Landscape servers are usually on external computers. However, for the purpose of this tutorial we will set one up on a WSL instance on your Windows machine.
-
-In your Windows PowerShell, `shutdown` WSL, then install the Ubuntu 22.04 LTS instance with the `--root` option.
+In PowerShell, `shutdown` WSL then install the Ubuntu 22.04 LTS instance with the `--root` option.
 
 ```text
 # Ensure a clean WSL environment.
@@ -116,18 +94,10 @@ PS C:\Users\me\tutorial> wsl --shutdown
 PS C:\Users\me\tutorial> ubuntu2204.exe install --root
 Installing, this may take a few minutes...
 Installation successful!
-
 ```
 
-Once this has completed, still in PowerShell, log in to the new instance, add the
-apt repository `ppa:landscape/self-hosted-beta`, and install the package `landscape-server-quickstart`:
-
-```{warning}
-**This will take 5-10 minutes.**
-
-That is because the server is composed of many packages and the
-performance of the installation is affected by the WSL networking, as well as the host machine power.
-```
+After successful installation log in to the new instance, add the landscape apt repository and install the `landscape-server-quickstart` package.
+Note that this installation could take 5-10 minutes depending on your device.
 
 ```text
 PS C:\Users\me\tutorial> ubuntu2204.exe
@@ -188,15 +158,18 @@ Reading state information... Done
 root@mib:~# apt install landscape-server-quickstart -y
 ```
 
-When the installation  process prompts about  Postfix configuration: Under 'General mail configuration type' select **No configuration** and hit **Tab**; then, with the **Ok** button highlighted, press **Enter**.
+A dialog will appear for 'Postfix configuration'.
+For 'General mail configuration type' select **No configuration**.
+Hit **Tab** to highlight the **Ok** button, press **Enter** and
+you will be returned to the shell prompt.
 
 ![Setting no Postfix configuration](./assets/postfix-config.png)
 
-That should bring you back to your shell prompt and you should see the installation unfolding. If it completes successfully, the last few log lines should look as below, with the Landscape systemd units appearing as active.
+If Landscape has installed successfully, the log will indicated that Landscape systemd units are active:
 
 ```text
 
-# The last log lines of the installation process will be similar to this:
+# Log truncated for brevity
   en_ZM.UTF-8... done
   en_ZW.UTF-8... done
 Generation complete.
@@ -249,8 +222,8 @@ root@mib:~# systemctl --state=running --no-legend --no-pager | grep landscape
   landscape-secrets-service.service     loaded active running Landscape's Secrets Management Service
 ```
 
-Once the installation has completed, Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and enter the address `http://127.0.0.1:8080`. It will show the page to create the Landscape global
-admin account. Enter the following credentials and click the **Sign Up** button:
+Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigated to `http://127.0.0.1:8080` to access the Landscape global admin account.
+Enter the following credentials and click the **Sign Up** button:
 
 | Field             | Value           |
 | ----------------- | --------------- |
@@ -261,23 +234,32 @@ admin account. Enter the following credentials and click the **Sign Up** button:
 
 ![New Landscape admin account creation](./assets/new-standalone-user.png)
 
-Finally, copy the Landscape server certificate into your Windows user profile directory. The Landscape client inside of any WSL
-instance will need that certificate to connect to the server.
+The Landscape client inside of any WSL instance will need the Landscape server certificate to connect to the server.
+
+To achieve this copy the Landscape server certificate into your Windows user profile directory:
 
 ```text
 root@mib:~# cp /etc/ssl/certs/landscape_server.pem /mnt/c/users/me/
 root@mib:~#
 ```
 
-Done -- your self hosted Landscape server is now up and running! At this point, if you configure the Landscape client on your Ubuntu WSL instances to know about this server, that will register them with the Landscape service included in your Ubuntu Pro subscription as well, and you'll be able to manage these instances at scale from your Landscape server.
+Done -- your self-hosted Landscape server is now up and running! 
+Now if you configure the Landscape client on your Ubuntu WSL instances to detect this server, they will also be registered with the Landscape service included in your Ubuntu Pro subscription.
 
-Keep the current terminal open so the server stays running while you continue on with this tutorial.
+The server will stay running until you close the terminal, so keep the terminal open for the rest of the tutorial.
+If you do close the terminal running `ubuntu2204.exe` in a new terminal window will start the Landscape server automatically.
 
-```{note}
-**If you accidentally close the terminal**:
+(tut::ensure-ubuntu-pro)=
+### Get an Ubuntu Pro token
 
-Open a new terminal window and run `ubuntu2204.exe`. Landscape server and related components will start automatically.
-```
+An Ubuntu Pro subscription gives you a token that can be added to the Ubuntu Pro client on WSL instances.
+
+Visit the [Ubuntu Pro](https://ubuntu.com/pro/subscribe) page to get a subscription.
+The `Myself` option for a personal subscription is free for up to 5 machines. 
+
+Your subscription token can then be retrieved from the [Ubuntu Pro Dashboard](https://ubuntu.com/pro/dashboard).
+
+With your token you can now install UP4W.
 
 ### Install UP4W
 
@@ -287,24 +269,20 @@ Open a new terminal window and run `ubuntu2204.exe`. Landscape server and relate
 The install link below will work only if you're logged in to the Microsoft Store with an account for which access to the app has been enabled.
 ```
 
-Time to install UP4W! Click on [this link](https://www.microsoft.com/store/productId/9PD1WZNBDXKZ), then on the big blue **Install** button.
+To install UP4W go to [this link to the Microsoft Store](https://www.microsoft.com/store/productId/9PD1WZNBDXKZ) and click **Install**.
 
 ![Install Ubuntu Pro for WSL from the Store](./assets/store.png)
 
+After installation has finished click **Start** to begin configuring UP4W.
 
-Once the installation is complete, you will see a **Start** button. Click it. That will start the UP4W Windows application. We'll use it to configure UP4W at next.
+% :NOTE: Instead of the GUI, it's possible to configure UP4W through the Windows registry, which enables you to do things at scale. This should be explained here or elsewhere.
 
-```{note}
-Instead of using the GUI, it's possible to configure UP4W through the Windows registry, which enables you to do things at scale.
-```
+In the UP4W Windows application click the arrow beside "Already have a token?".
 
-### Configure UP4W for Ubuntu Pro and Landscape
-
-In the UP4W GUI click in the label "Already have a token?" to expand the Ubuntu Pro token input field.
+Paste your token from the Ubuntu Pro dashboard during [Setup](tut::ensure-ubuntu-pro) and click "Confirm".
+You will then be shown the Landscape configuration screen.
 
 ![UP4W GUI main screen](./assets/up4w_gui.png)
-
-Paste your token retrieved from your Ubuntu Pro dashboard during [Setup](tut::ensure-ubuntu-pro) and click on the "Confirm" button (the button becomes green when there is a valid token in the input field). The app will then show the Landscape configuration screen.
 
 Create a new file in your home directory named `landscape.txt` and enter following contents, replacing:
 
@@ -324,49 +302,44 @@ ssl_public_key = C:\Users\<YOUR_WINDOWS_USER_NAME>\landscape_server.pem
 ```
 % If really needed we can start without the SSL public key and add it after the Windows host is registered in Landscape.
 
-Then load that file using the "Custom Configuration" part of the the screen, as shown below:
+Then load that file using the "Custom Configuration" part of the screen, as shown below:
 
 ![Loading Landscape custom config](./assets/loading-custom-landscape-config.png)
 
-Click on the "Continue" button. You'll see a status screen confirming the configuration is complete.
+Click on the "Continue" button and you will see a status screen confirming the configuration is complete.
 
 ![Configuration is complete](./assets/status-complete.png)
 
-Done! You can close the UP4W window if you want.
+Done! You can now close the UP4W window.
 
-This has attached your Ubuntu Pro subscription to UP4W on the Windows host; UP4W will automatically forward it to the Ubuntu Pro client on your Ubuntu WSL instances; thus, all of your Ubuntu WSL instances will be automatically added to your Ubuntu Pro subscription.
+Your Ubuntu Pro subscription is now attached to UP4W on the Windows host.
+UP4W will automatically forward the subscription to the Ubuntu Pro client on your Ubuntu WSL instances.
+This means that all Ubuntu WSL instances will be automatically added to your Ubuntu Pro subscription.
 
 This has also configured the Landscape client built into your UP4W Windows agent to know about your Landscape server; UP4W will forward this configuration to the Landscape client on your Ubuntu WSL instances as well; and all systems where the Landscape client has been configured this way are automatically registered with Landscape.
 
+### UP4W host registration
 
-### Approve your UP4W Windows host registration with Landscape
-
-Go back to the Windows web browser and refresh the Landscape page. On the right-hand side of the main content area of the
+Go back to your web browser and refresh the Landscape page at `http://127.0.0.1:8080`. On the right-hand side of the
 page you should see a request to approve your Windows host registration ("Computers needing authorisation").
-Click on the computer name (below, `mib`); then, when the new page loads, click **Accept**.
+Click on the computer name (in this case: `mib`) and when the new page loads click **Accept**.
 
-```{note}
-**If you've already closed the browser tab**:
-
-Just open a new one, navigate to `http://127.0.0.1:8080` and log in with the credentials you created earlier.
-```
 ![Approve the Windows host registration](./assets/host-pending-approval.png)
 
 ![Accept host](./assets/accept-host.png)
 
-At the top of the page, on the right-hand side of the Landscape logo, click on "Computers". You should see your host machine listed there. Details such as the operating system may take a few minutes to appear.
+At the top of the page, on the right-hand side of the Landscape logo, click on "Computers". You should see your host machine listed. Details such as the operating system may take some time to appear.
 
 ![Host and WSL instances in Landscape](./assets/host.png)
 
-All set. From now on you can use your Landscape server not just to manage the Ubuntu WSL instances that UP4W has pro-attached and Landscape-registered on the host, but to tell UP4W to create and provision them on the host too!
+Now you can leverage UP4W from your Landscape server to create and provision Ubuntu WSL instances on the host.
 
-## Watch UP4W transform your Ubuntu Pro game on WSL!
+## Deploy WSL instances
 
-### Create an Ubuntu WSL instance locally and watch it be automatically pro-attached and Landscape-registered
+### Create an Ubuntu WSL instance locally
 
-Open the Windows PowerShell and run the following command to create a new Ubuntu-Preview instance.
+Open Windows PowerShell and run the following command to create a new Ubuntu-Preview instance.
 When prompted create the default user and password. For convenience, we'll set both to `u`.
-When done you'll be logged in to the new instance shell.
 
 ```text
 PS C:\Users\me\tutorial> ubuntupreview.exe
@@ -386,11 +359,10 @@ u@mib:~$
 
 ```
 
-UP4W should have already pro-attached this instance. To verify:
+You will now be logged in to the new instance shell and can
+check that UP4W has Pro-attached this instance:
 
-- Run `pro status`
-
-You should see some services enabled (for now, ESM) and the account and subscription information at the bottom of the output:
+The output indicates that services like ESM are enabled, with account and subscription information also shown:
 
 ```text
 u@mib:~$ pro status
@@ -409,9 +381,7 @@ Subscription: Ubuntu Pro - free personal subscription
 u@mib:~$
 ```
 
-- Run `sudo apt update`
-
-You should notice in the output that you’re accessing packages from all the enabled services (for now, ESM):
+Packages can be accessed from all the enabled services:
 
 ```text
 u@mib:~$ sudo apt update
@@ -430,27 +400,29 @@ Reading state information... Done
 All packages are up to date.
 ```
 
-UP4W should have also already Landscape-registered this instance:
-
-- To verify, refresh your Landscape server web page - you should see it listed under the "Computers needing authorisation" section.
+UP4W should have also Landscape-registered this instance:
+To verify, refresh the Landscape server web page and the instance should be listed under "Computers needing authorisation".
 
 ![New WSL instance pending approval](./assets/wsl-pending-approval.png)
 
-- To accept the registration first click on the instance name and in the pop-up set "Tags" to `wsl-vision` then click **Accept**
+To accept the registration click on the instance name, set "Tags" to `wsl-vision` in the pop-up then click **Accept**.
+The `wsl-vision` tag will be used for all the instances accepted into Landscape.
 
 ![Accept and tag Ubuntu Preview](./assets/accept-ubuntu-preview-tag.png)
 
-### Use Landscape to create a pro-attached and Landscape-registered Ubuntu WSL instance remotely
+### Create an Ubuntu WSL instance remotely
 
-Back to your Windows browser, at the Landscape page, navigate to "Computers" and click on the Windows machine (below, `mib`). You'll find the "WSL Instances" on the right-hand side of the page and an "Install new" link close to it.
-Click on that link. Once the page has loaded, set "Instance Type" to "Ubuntu", then click "Submit". A status page will
+Back on the Landscape page in your web browser, navigate to "Computers" and click on the Windows machine (below: `mib`). You will find "WSL Instances" on the right side of the page.
+Click on the "Install new" link then set "Instance Type" to "Ubuntu" and click "Submit". A status page will
 appear showing the progress of the new instance creation.
 
 ![Create instance via Landscape](./assets/create-instance-via-landscape.png)
 
 ![Creation progress](./assets/creation-progress.png)
 
-Your Landscape Server will talk to the Landscape client built into your UP4W and ask UP4W to install the `Ubuntu` application and create an Ubuntu WSL instance for you. In your PowerShell, run `ubuntu.exe` to log in to the new instance.
+The Landscape server will talk to the Landscape client built into your UP4W.
+UP4W will then install the `Ubuntu` application and create an Ubuntu WSL instance automatically.
+In PowerShell, run `ubuntu.exe` to log in to the new instance.
 
 ```text
 PS C:\Users\me\tutorial> ubuntu.exe
@@ -469,12 +441,13 @@ This message is shown once a day. To disable it please create the
 me@mib:~$
 ```
 
-As usual, this instance is pro-attached and Landscape-registered -- run `pro status` to verify the pro-attachment and refresh your Landscape server page to verify and accept the registration (as before, apply the  `wsl-vision` tag and click `Accept`).
+You can run `pro status` to verify pro-attachment and refresh your Landscape server page to verify and accept the registration.
+As before, apply the `wsl-vision` tag and click `Accept`.
 
-### Use Landscape to deploy packages to all of your Ubuntu WSL instances at once
+### Deploy packages to all Ubuntu WSL instances
 
-On your Landscape server page, navigate to `Organization` > `Profiles` and click on
-`Package Profiles`, then `Add package profile`. Fill in the form with the following values and click "Save".
+On your Landscape server page, navigate to `Organization` > `Profiles`, click on
+`Package Profiles` then `Add package profile`. Fill in the form with the following values and click "Save".
 
 | Field               | Value                                  |
 | ------------------- | -------------------------------------- |
@@ -486,11 +459,11 @@ On your Landscape server page, navigate to `Organization` > `Profiles` and click
 
 ![Create package profile](./assets/create-package-profile.png)
 
-On the bottom of the "Vision" profile page, in the "Association" section, set the "New tags" field to `wsl-vision` (the tag we used above for all the instances we accepted into Landscape) and click **Change**.
+On the bottom of the "Vision" profile page, in the "Association" section, set the "New tags" field to `wsl-vision` and click **Change**.
 
 ![Applying the profile to the WSL instances](./assets/applying-profile.png)
 
-In the "Summary" section in the middle of the page you will see a status message showing that 2 computers are `applying the profile`. Click on the `applying the profile` link and then, in the "Activities" list, click on **Apply package profile** to see the progress of the package deployment.
+In the "Summary" section in the middle of the page you will see a status message showing that two computers are `applying the profile`. Click on the `applying the profile` link and then, in the "Activities" list, click on **Apply package profile** to see the progress of the package deployment.
 
 ![Progress of the package deployment](./assets/package-deployment-progress.png)
 
@@ -522,10 +495,10 @@ libopencv-viz4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
 python3-opencv/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
 ```
 
-Congratulations -- now that UP4W has removed all the pro-attachment and Landscape-registration hassle, you can quickly skip to using Landscape to manage all your Ubuntu WSL instances at scale!
+You know how to leverage UP4W and Landscape to efficiently manage your Ubuntu WSL instances at scale.
+Below you can see the architecture of what you have built -- congratulations!
 
 ![Your Windows host with instances pro-attached and Landscape-registered through UP4W](./assets/up4w-tutorial-deployment.png)
-*Your Windows host with your Landscape server and two Ubuntu WSL instances pro-attached and Landscape-registered through UP4W.*
 
 ## Tear things down
 
@@ -541,7 +514,7 @@ Additionally remove the `.ubuntupro` directory from your Windows user profile di
 PS C:\Users\me\tutorial> Remove-Item -Recurse -Force C:\Users\me\.ubuntupro
 ```
 
-### Remove the Ubuntu WSL apps
+### Remove Ubuntu WSL apps
 
 ```{warning}
 **If you already have them pre-installed:**
@@ -562,15 +535,15 @@ as done with UP4W. Do the same for the "Ubuntu (Preview)" and "Ubuntu" applicati
 
 The instances will be removed automatically.
 
-### Optionally remove the WSL application
+### Remove WSL app
 
-Only do this if you don't need WSL in this Windows machine for any other reason.
+Only do this if you don't need WSL on this Windows machine following the tutorial.
 
-As before, in the Windows Start Menu, locate the "WSL" application, right-click on it, and select "Uninstall".
+In the Windows Start Menu locate the "WSL" application, right-click on it then select "Uninstall".
 
 ## Next steps
 
-This tutorial has introduced you to all the basic things you can do with UP4W. But there is more to explore:
+This tutorial has introduced you to the amazing things that can be achieved with with UP4W. But there is more to explore:
 
 | IF YOU ARE WONDERING…          | VISIT…              |
 | ------------------------------ | ------------------- |

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -175,8 +175,11 @@ To install UP4W go to [this link to the Microsoft Store](https://www.microsoft.c
 
 After installation has finished click **Start** to begin configuring UP4W.
 
-% :NOTE: Instead of the GUI, it's possible to configure UP4W through the Windows registry, which enables you to do things at scale. This should be explained here or elsewhere.
-
+```{note}
+UP4W can be configured through the [Windows registry](windows-registry) instead of the GUI.
+The steps are outlined briefly in [Install and configure UP4W > Using the registry](howto::configure::registry).
+This approach may be more suitable when operating at scale.
+```
 In the UP4W Windows application click the arrow beside "Already have a token?".
 
 Paste your token from the Ubuntu Pro dashboard during [Setup](tut::ensure-ubuntu-pro) and click "Confirm".

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -285,12 +285,12 @@ All packages are up to date.
 UP4W should have also Landscape-registered this instance.
 To verify, refresh the Landscape server web page and the instance should be listed under "Computers needing authorisation".
 
-![New WSL instance pending approval](./assets/wsl-pending-approval.png)
+<!-- ![New WSL instance pending approval](./assets/wsl-pending-approval.png) -->
 
 To accept the registration click on the instance name, set "Tags" to `wsl-vision` in the pop-up then click **Accept**.
 The `wsl-vision` tag will be used for all the instances accepted into Landscape.
 
-![Accept and tag Ubuntu Preview](./assets/accept-ubuntu-preview-tag.png)
+<!-- ![Accept and tag Ubuntu Preview](./assets/accept-ubuntu-preview-tag.png) -->
 
 ### Create an Ubuntu WSL instance remotely
 
@@ -336,7 +336,7 @@ On the bottom of the "Vision" profile page, in the "Association" section, set th
 
 In the "Summary" section in the middle of the page you will see a status message showing that two computers are `applying the profile`. Click on the `applying the profile` link and then, in the "Activities" list, click on **Apply package profile** to see the progress of the package deployment.
 
-![Progress of the package deployment](./assets/package-deployment-progress.png)
+<!-- ![Progress of the package deployment](./assets/package-deployment-progress.png) -->
 
 When this process has completed, use one of your instance shells to verify that the `python3-opencv` package has been installed.
 For example, in the `Ubuntu` instance the first three packages returned are:

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -44,14 +44,12 @@ At the end of the tutorial you can re-import and restore your data.
 Exporting, deleting and re-importing Ubuntu is achieved with the following commands.
 In each case, `{version}` would need to be replaced with 22.04 or 24.04.
 
-```
-PS C:\Users\me\tutorial> wsl --export Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
+    PS C:\Users\me\tutorial> wsl --export Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
 
-PS C:\Users\me\tutorial> wsl --unregister Ubuntu-{version}
+    PS C:\Users\me\tutorial> wsl --unregister Ubuntu-{version}
 
-PS C:\Users\me\tutorial> wsl --import Ubuntu-{version} .\backup\Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
+    PS C:\Users\me\tutorial> wsl --import Ubuntu-{version} .\backup\Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
 
-```
 
 ```
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -4,7 +4,7 @@ Windows Subsystem for Linux ([WSL](https://ubuntu.com/desktop/wsl)) makes it pos
 With Ubuntu Pro for WSL (UP4W) an [Ubuntu Pro](https://ubuntu.com/pro) subscription empowers you to manage Ubuntu WSL instances at scale.
 
 In this tutorial you will develop an understanding of how UP4W can be installed and deployed for managing multiple WSL instances.
-To complete this tutorial you will need a Windows 11 machine with a minimum of 16GB RAM and a 8-core processor.
+To complete this tutorial you will need a machine running Windows 10 or 11 with a minimum of 16GB RAM and a 8-core processor.
 
 ```{note}
 WSL enables using a Linux shell and Windows PowerShell side-by-side on the same machine.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -14,7 +14,7 @@ Throughout this tutorial, commands will be prefixed by a prompt that indicates t
 
 - `root@hostname:~#` indicates a Linux shell prompt with login as root in the root home directory `~`.
 
-Output logs are included in this tutorial when instructive but are typically ommitted to save space.
+Output logs are included in this tutorial when instructive but are typically omitted to save space.
 ```
 
 ## Set things up

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,4 +1,4 @@
-# Get Started with UP4W
+# Get started with UP4W
 
 In this tutorial you will learn all the basic things that you need to know to start taking advantage of your Ubuntu Pro subscription on Ubuntu WSL at scale with Ubuntu Pro for WSL (UP4W).
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -94,16 +94,16 @@ After successful installation log in to the new instance and add the landscape a
 ```text
 PS C:\Users\me\tutorial> ubuntu2204.exe
 
-root@mib:~# add-apt-repository ppa:landscape/self-hosted-beta -y
+root@mib:~$ add-apt-repository ppa:landscape/self-hosted-beta -y
 
 ```
 
 Update packages and then install the `landscape-server-quickstart` package.
 
 ```text
-root@mib:~# apt update
+root@mib:~$ apt update
 
-root@mib:~# apt install landscape-server-quickstart -y
+root@mib:~$ apt install landscape-server-quickstart -y
 ```
 
 A dialog will appear for 'Postfix configuration'.
@@ -117,7 +117,7 @@ If Landscape has installed successfully, the log will indicate that Landscape sy
 An example log is shown below for the first three units:
 
 ```text
-root@mib:~# systemctl --state=running --no-legend --no-pager | grep -m 3 landscape
+root@mib:~$ systemctl --state=running --no-legend --no-pager | grep -m 3 landscape
   landscape-api.service                 loaded active running LSB: Enable Landscape API
   landscape-appserver.service           loaded active running LSB: Enable Landscape frontend UI
   landscape-async-frontend.service      loaded active running LSB: Enable Landscape async frontend
@@ -140,7 +140,7 @@ The Landscape client inside of any WSL instance will need the Landscape server c
 To achieve this copy the Landscape server certificate into your Windows user profile directory:
 
 ```text
-root@mib:~# cp /etc/ssl/certs/landscape_server.pem /mnt/c/users/me/
+root@mib:~$ cp /etc/ssl/certs/landscape_server.pem /mnt/c/users/me/
 ```
 
 Done -- your self-hosted Landscape server is now up and running! 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -123,7 +123,7 @@ root@mib:~# systemctl --state=running --no-legend --no-pager | grep -m 3 landsca
   landscape-async-frontend.service      loaded active running LSB: Enable Landscape async frontend
 ```
 
-Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigated to `http://127.0.0.1:8080` to access the Landscape global admin account.
+Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigated to `http://127.0.0.1:8080` to create the Landscape global admin account.
 Enter the following credentials and click the **Sign Up** button:
 
 | Field             | Value           |

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -152,14 +152,14 @@ If you do close the terminal running `ubuntu2204.exe` in a new terminal window w
 (tut::ensure-ubuntu-pro)=
 ### Get an Ubuntu Pro token
 
-An Ubuntu Pro subscription gives you a token that can be added to the Ubuntu Pro client on WSL instances.
+An active Ubuntu Pro subscription provides you with a token that can be added to the Ubuntu Pro client on WSL instances.
 
-Visit the [Ubuntu Pro](https://ubuntu.com/pro/subscribe) page to get a subscription.
+Your subscription token can be retrieved from the [Ubuntu Pro Dashboard](https://ubuntu.com/pro/dashboard).
+
+Visit the [Ubuntu Pro](https://ubuntu.com/pro/subscribe) page if you need a new subscription.
 The `Myself` option for a personal subscription is free for up to 5 machines. 
 
-Your subscription token can then be retrieved from the [Ubuntu Pro Dashboard](https://ubuntu.com/pro/dashboard).
-
-With your token you can now install UP4W.
+Once you have a token you are ready to install UP4W.
 
 ### Install UP4W
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -135,7 +135,7 @@ Landscape servers are usually on external computers. However, for the purpose of
 
 In your Windows PowerShell, `shutdown` WSL, then install the Ubuntu 22.04 LTS instance with the `--root` option.
 
-```powershell
+```text
 # Ensure a clean WSL environment.
 PS C:\Users\me\tutorial> wsl --shutdown
 
@@ -155,7 +155,7 @@ That is because the server is composed of many packages and the
 performance of the installation is affected by the WSL networking, as well as the host machine power.
 ```
 
-```bash
+```text
 PS C:\Users\me\tutorial> ubuntu2204.exe
 Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.146.1-microsoft-standard-WSL2 x86_64)
 
@@ -222,7 +222,7 @@ When the installation  process prompts about  Postfix configuration: Under 'Gene
 That should bring you back to your shell prompt and you should see the installation unfolding. If it completes successfully, the last few log lines should look as below, with the Landscape systemd units appearing as active.
 
 
-```bash
+```text
 
 # The last log lines of the installation process will be similar to this:
   en_ZM.UTF-8... done
@@ -292,7 +292,7 @@ admin account. Enter the following credentials and click the **Sign Up** button:
 Finally, copy the Landscape server certificate into your Windows user profile directory. The Landscape client inside of any WSL
 instance will need that certificate to connect to the server.
 
-```bash
+```text
 root@mib:~# cp /etc/ssl/certs/landscape_server.pem /mnt/c/users/me/
 root@mib:~#
 ```
@@ -341,7 +341,7 @@ Create a new file in your home directory named `landscape.txt` and enter followi
 - `<HOSTNAME>` by the actual host name of your Windows machine and
 - `<YOUR_WINDOWS_USER_NAME>` by the actual user name of your Windows account
 
-```
+```text
 [host]
 url = [::1]:6554
 [client]
@@ -400,7 +400,7 @@ Open the Windows PowerShell and run the following command to create a new Ubuntu
 When prompted create the default user and password. For convenience, we'll set both to `u`.
 When done you'll be logged in to the new instance shell.
 
-```powershell
+```text
 PS C:\Users\me\tutorial> ubuntupreview.exe
 
 Installing, this may take a few minutes...
@@ -426,7 +426,7 @@ UP4W should have already pro-attached this instance. To verify:
 You should see some services enabled (for now, ESM) and the account and subscription information at the bottom of the output:
 
 
-```bash
+```text
 u@mib:~$ pro status
 SERVICE          ENTITLED  STATUS       DESCRIPTION
 esm-apps         yes       enabled      Expanded Security Maintenance for Applications
@@ -449,7 +449,7 @@ u@mib:~$
 
 You should notice in the output that you’re accessing packages from all the enabled services (for now, ESM):
 
-```bash
+```text
 u@mib:~$ sudo apt update
 Hit:1 http://archive.ubuntu.com/ubuntu noble InRelease
 Hit:2 http://ppa.launchpad.net/ubuntu-wsl-dev/ppa/ubuntu noble InRelease
@@ -491,7 +491,7 @@ appear showing the progress of the new instance creation.
 
 Your Landscape Server will talk to the Landscape client built into your UP4W and ask UP4W to install the `Ubuntu` application and create an Ubuntu WSL instance for you. In your PowerShell, run `ubuntu.exe` to log in to the new instance.
 
-```powershell
+```text
 PS C:\Users\me\tutorial> ubuntu.exe
 To run a command as administrator (user "root"), use "sudo <command>".
 See "man sudo_root" for details.
@@ -537,7 +537,7 @@ In the "Summary" section in the middle of the page you will see a status message
 When this process has completed, use one of your instance shells to verify that the `python3-opencv` package has been installed.
 For example, in the `Ubuntu` instance it would look as below:
 
-```bash
+```text
 me@mib:~$ apt list --installed | grep opencv
 
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
@@ -577,7 +577,7 @@ In the Windows Start Menu, locate the "Ubuntu Pro for WSL" application and right
 
 Additionally remove the `.ubuntupro` directory from your Windows user profile directory.
 
-```powershell
+```text
 PS C:\Users\me\tutorial> Remove-Item -Recurse -Force C:\Users\me\.ubuntupro
 ```
 
@@ -593,7 +593,7 @@ Otherwise, proceed with the commands below.
 
 In PowerShell run the following command to stop WSL:
 
-```powershell
+```text
 PS C:\Users\me\tutorial> wsl --shutdown
 ```
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -8,12 +8,13 @@ To complete this tutorial you will need a Windows 11 machine with a minimum of 1
 
 ```{note}
 WSL enables using a Linux shell and Windows PowerShell side-by-side on the same machine.
-
 Throughout this tutorial, commands will be prefixed by a prompt that indicates the shell being used, for example:
 
 - `PS C:\Users\me\tutorial>` is a PowerShell prompt where the current working directory is `C:\Users\me\tutorial`.
 
 - `root@hostname:~#` indicates a Linux shell prompt with login as root in the root home directory `~`.
+
+Output logs are included in this tutorial when instructive but are typically ommitted to save space.
 ```
 
 ## Set things up
@@ -82,73 +83,26 @@ While a Landscape server typically runs on external computers for this tutorial 
 In PowerShell, `shutdown` WSL then install the Ubuntu 22.04 LTS instance with the `--root` option.
 
 ```text
-# Ensure a clean WSL environment.
 PS C:\Users\me\tutorial> wsl --shutdown
 
 PS C:\Users\me\tutorial> ubuntu2204.exe install --root
-Installing, this may take a few minutes...
-Installation successful!
 ```
 
-After successful installation log in to the new instance, add the landscape apt repository and install the `landscape-server-quickstart` package.
-Note that this installation could take 5-10 minutes depending on your device.
+After successful installation log in to the new instance and add the landscape apt repository:
+
 
 ```text
 PS C:\Users\me\tutorial> ubuntu2204.exe
-Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.146.1-microsoft-standard-WSL2 x86_64)
 
- * Documentation:  https://help.ubuntu.com
- * Management:     https://landscape.canonical.com
- * Support:        https://ubuntu.com/pro
-
-  System information as of Fri Feb 16 02:21:51 -03 2024
-
-  System load:  0.57                Processes:             54
-  Usage of /:   0.1% of 1006.85GB   Users logged in:       1
-  Memory usage: 25%                 IPv4 address for eth0: 172.18.68.146
-  Swap usage:   4%
-
-This message is shown once a day. To disable it please create the
-/root/.hushlogin file.
-
-# Adding the Landscape Beta PPA:
 root@mib:~# add-apt-repository ppa:landscape/self-hosted-beta -y
-Repository: 'deb https://ppa.launchpadcontent.net/landscape/self-hosted-beta/ubuntu/ jammy main'
-Description:
-Dependencies for Landscape Server Self-Hosted Beta.
-More info: https://launchpad.net/~landscape/+archive/ubuntu/self-hosted-beta
-Adding repository.
-Adding deb entry to /etc/apt/sources.list.d/landscape-ubuntu-self-hosted-beta-jammy.list
-Adding disabled deb-src entry to /etc/apt/sources.list.d/landscape-ubuntu-self-hosted-beta-jammy.list
-Adding key to /etc/apt/trusted.gpg.d/landscape-ubuntu-self-hosted-beta.gpg with fingerprint 35F77D63B5CEC106C577ED856E85A86E4652B4E6
-Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
-Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
-Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
-Hit:4 http://ppa.launchpad.net/ubuntu-wsl-dev/ppa/ubuntu jammy InRelease
-Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
-Hit:6 http://ppa.launchpad.net/landscape/self-hosted-beta/ubuntu jammy InRelease
-Hit:7 http://ppa.launchpad.net/cloud-init-dev/proposed/ubuntu jammy InRelease
-Get:8 https://ppa.launchpadcontent.net/landscape/self-hosted-beta/ubuntu jammy InRelease [17.5 kB]
-Get:9 https://ppa.launchpadcontent.net/landscape/self-hosted-beta/ubuntu jammy/main amd64 Packages [13.4 kB]
-Get:10 https://ppa.launchpadcontent.net/landscape/self-hosted-beta/ubuntu jammy/main Translation-en [8784 B]
-Fetched 39.7 kB in 2s (21.9 kB/s)
-Reading package lists... Done
 
+```
+
+Update packages and then install the `landscape-server-quickstart` package.
+
+```text
 root@mib:~# apt update
-Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
-Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
-Hit:3 http://ppa.launchpad.net/ubuntu-wsl-dev/ppa/ubuntu jammy InRelease
-Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
-Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
-Hit:6 http://ppa.launchpad.net/landscape/self-hosted-beta/ubuntu jammy InRelease
-Hit:7 http://ppa.launchpad.net/cloud-init-dev/proposed/ubuntu jammy InRelease
-Hit:8 https://ppa.launchpadcontent.net/landscape/self-hosted-beta/ubuntu jammy InRelease
-Reading package lists... Done
-Building dependency tree... Done
-Reading state information... Done
-24 packages can be upgraded. Run 'apt list --upgradable' to see them.
 
-# Installing the Landscape Server Quickstart package:
 root@mib:~# apt install landscape-server-quickstart -y
 ```
 
@@ -159,61 +113,14 @@ you will be returned to the shell prompt.
 
 ![Setting no Postfix configuration](./assets/postfix-config.png)
 
-If Landscape has installed successfully, the log will indicated that Landscape systemd units are active:
+If Landscape has installed successfully, the log will indicate that Landscape systemd units are active.
+An example log is shown below for the first three units:
 
 ```text
-
-# Log truncated for brevity
-  en_ZM.UTF-8... done
-  en_ZW.UTF-8... done
-Generation complete.
-Setting up landscape-server-quickstart (23.10+6-0landscape0) ...
-Generating self-signed certificate/key pair.
-If you want to use your own, place the certificate file in
-/etc/ssl/certs/landscape_server.pem and the key file in /etc/ssl/private/landscape_server.key, and reconfigure this package.
-.+..+.+...................................+..........+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...............+...+..+.+.........+...+.........+........+.+..+.......+.....+................+..+...+.......+...+......+...+..+....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*................+.....+....+.....+.+.....+......+.+...............+........+....+...+.........+....................+...+...+..................+.+......+..+...+...+.......+...+......+.....+...+.+......+.....+.............+..+.........+................+........+.+..+.......+.....+...+...+.+.....+....+.....+......+....+.....+.........+.......+.....+......+...+......+.+.....+.......+.....+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-.....+..................+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+..................+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.................+.+..+...............+......+....+...........+.........+.+...........+.+.....+...+....+...+..+...+.........+....+...........+...................+..............+.+......+........+......+.+......+...............+..+...+....+...+......+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
------
-Site 000-default disabled.
-2024-02-16 06:02:43.284Z INFO landscape-quickstart "Upgrading service.conf ..."
-2024-02-16 06:02:43.337Z INFO landscape-quickstart "Updated message-server section."
-2024-02-16 06:02:43.339Z INFO landscape-quickstart "Updated landscape section."
-2024-02-16 06:02:43.346Z INFO landscape-quickstart "Checking local RabbitMQ settings."
-2024-02-16 06:02:44.373Z INFO landscape-quickstart "Configuring RabbitMQ for Landscape ..."
-2024-02-16 06:02:48.196Z INFO landscape-quickstart "Setting up Apache SSL configuration ..."
-2024-02-16 06:02:48.248Z INFO landscape-quickstart "Configuring PostgreSQL for Landscape"
-2024-02-16 06:02:48.268Z INFO landscape-quickstart "Skipping configuration migration ..."
-2024-02-16 06:02:48.269Z INFO landscape-quickstart "Bootstrapping service.conf using psql ..."
-2024-02-16 06:02:48.406Z INFO landscape-quickstart "Created user 'landscape'."
-2024-02-16 06:02:48.478Z INFO landscape-quickstart "Created user 'landscape_superuser'."
-2024-02-16 06:02:48.480Z INFO landscape-quickstart "Checking Landscape databases ..."
-2024-02-16 06:02:50.343Z INFO landscape-quickstart "Checking database schema ..."
-2024-02-16 06:02:58.942Z INFO landscape-quickstart "Schema configuration output:\n\nLoading site configuration...\nWARNING: PostgreSQL has max_prepared_transactions set to 0, not using two-phase commit.\nSetting up database schemas (will timeout after 86400 seconds) ...\nSchema patch version: 499\n"
-2024-02-16 06:02:58.942Z INFO landscape-quickstart "Checking package database initial data ..."
-2024-02-16 06:02:59.016Z INFO landscape-quickstart "Loading stock package database ..."
-2024-02-16 06:09:44.485Z INFO landscape-quickstart "Stock package database loaded successfully."
-2024-02-16 06:09:44.502Z INFO landscape-quickstart "Renaming stock hash-id stores ..."
-2024-02-16 06:09:48.964Z INFO landscape-quickstart "Renamed 33 stock hash-id stores against uuid fd2e9fc2-cc91-11ee-afea-4d057cae229c"
-Processing triggers for libc-bin (2.35-0ubuntu3.6) ...
-Processing triggers for rsyslog (8.2112.0-2ubuntu2.2) ...
-Processing triggers for ufw (0.36.1-4ubuntu0.1) ...
-Processing triggers for man-db (2.10.2-1) ...
-Processing triggers for dbus (1.12.20-2ubuntu4.1) ...
-
-# Check that no Landscape systemd unit is failed:
-root@mib:~# systemctl --state=failed --no-legend --no-pager | grep landscape # Outputs nothing
-root@mib:~# systemctl --state=running --no-legend --no-pager | grep landscape
+root@mib:~# systemctl --state=running --no-legend --no-pager | grep -m 3 landscape
   landscape-api.service                 loaded active running LSB: Enable Landscape API
   landscape-appserver.service           loaded active running LSB: Enable Landscape frontend UI
   landscape-async-frontend.service      loaded active running LSB: Enable Landscape async frontend
-  landscape-hostagent-consumer.service  loaded active running Landscape's WSL Message Consumer
-  landscape-hostagent-messenger.service loaded active running Landscape's WSL Message Service
-  landscape-job-handler.service         loaded active running LSB: Enable Landscape job handler
-  landscape-msgserver.service           loaded active running LSB: Enable Landscape message processing
-  landscape-package-search.service      loaded active running Landscape's Package Search daemon
-  landscape-package-upload.service      loaded active running LSB: Enable Landscape Package Upload service
-  landscape-pingserver.service          loaded active running LSB: Enable Landscape ping server
-  landscape-secrets-service.service     loaded active running Landscape's Secrets Management Service
 ```
 
 Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigated to `http://127.0.0.1:8080` to access the Landscape global admin account.
@@ -234,7 +141,6 @@ To achieve this copy the Landscape server certificate into your Windows user pro
 
 ```text
 root@mib:~# cp /etc/ssl/certs/landscape_server.pem /mnt/c/users/me/
-root@mib:~#
 ```
 
 Done -- your self-hosted Landscape server is now up and running! 
@@ -387,14 +293,14 @@ Hit:5 http://ppa.launchpad.net/landscape/self-hosted-beta/ubuntu noble InRelease
 Hit:6 https://esm.ubuntu.com/apps/ubuntu noble-apps-security InRelease
 Hit:7 http://archive.ubuntu.com/ubuntu noble-backports InRelease
 Hit:8 http://ppa.launchpad.net/cloud-init-dev/proposed/ubuntu noble InRelease
-Hit:9 https://esm.ubuntu.com/infra/ubuntu noble-infra-security InRelease        # Notice the ESM repositories
+Hit:9 https://esm.ubuntu.com/infra/ubuntu noble-infra-security InRelease
 Reading package lists... Done
 Building dependency tree... Done
 Reading state information... Done
 All packages are up to date.
 ```
 
-UP4W should have also Landscape-registered this instance:
+UP4W should have also Landscape-registered this instance.
 To verify, refresh the Landscape server web page and the instance should be listed under "Computers needing authorisation".
 
 ![New WSL instance pending approval](./assets/wsl-pending-approval.png)
@@ -420,18 +326,7 @@ In PowerShell, run `ubuntu.exe` to log in to the new instance.
 
 ```text
 PS C:\Users\me\tutorial> ubuntu.exe
-To run a command as administrator (user "root"), use "sudo <command>".
-See "man sudo_root" for details.
 
-Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.146.1-microsoft-standard-WSL2 x86_64)
-
- * Documentation:  https://help.ubuntu.com
- * Management:     https://landscape.canonical.com
- * Support:        https://ubuntu.com/advantage
-
-
-This message is shown once a day. To disable it please create the
-/home/me/.hushlogin file.
 me@mib:~$
 ```
 
@@ -462,31 +357,14 @@ In the "Summary" section in the middle of the page you will see a status message
 ![Progress of the package deployment](./assets/package-deployment-progress.png)
 
 When this process has completed, use one of your instance shells to verify that the `python3-opencv` package has been installed.
-For example, in the `Ubuntu` instance it would look as below:
+For example, in the `Ubuntu` instance the first three packages returned are:
 
 ```text
-me@mib:~$ apt list --installed | grep opencv
-
-WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+me@mib:~$ apt list --installed | grep -m 3 opencv
 
 libopencv-calib3d4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
 libopencv-contrib4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
 libopencv-core4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-dnn4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-features2d4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-flann4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-highgui4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-imgcodecs4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-imgproc4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-ml4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-objdetect4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-photo4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-shape4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-stitching4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-video4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-videoio4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-libopencv-viz4.5d/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
-python3-opencv/jammy,now 4.5.4+dfsg-9ubuntu4 amd64 [installed,automatic]
 ```
 
 You know how to leverage UP4W and Landscape to efficiently manage your Ubuntu WSL instances at scale.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -218,7 +218,7 @@ This means that all Ubuntu WSL instances will be automatically added to your Ubu
 
 This has also configured the Landscape client built into your UP4W Windows agent to know about your Landscape server; UP4W will forward this configuration to the Landscape client on your Ubuntu WSL instances as well; and all systems where the Landscape client has been configured this way are automatically registered with Landscape.
 
-### UP4W host registration
+### UP4W host registration with Landscape
 
 Go back to your web browser and refresh the Landscape page at `http://127.0.0.1:8080`. On the right-hand side of the
 page you should see a request to approve your Windows host registration ("Computers needing authorisation").

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -15,12 +15,6 @@ Throughout this tutorial, commands will be prefixed by a prompt that indicates t
 
 - `root@hostname:~#` indicates a Linux shell prompt with login as root in the root home directory `~`.
 ```
-<!-- TODO: continue clean up -->
-<!-- focus on text before command logs -->
-<!-- keep Pro and UP4W together -->
-<!-- keep WSL/Ubuntu/Landscape instructions short -->
-<!-- landscape logs are way too much -->
-<!-- careful with links not rendering -->
 
 ## Set things up
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -30,8 +30,8 @@ PS C:\Users\me\tutorial> Remove-Item ~\.wslconfig
 ```
 
 Ubuntu can also be installed from the Microsoft Store.
-Choose [Ubuntu 22.04 LTS](https://www.microsoft.com/store/productId/9PN20MSR04DW) or [Ubuntu (Preview)](https://www.microsoft.com/store/productId/9P7BDVKVNXZ6)
-for this tutorial.
+Both [Ubuntu 24.04 LTS](https://www.microsoft.com/store/productId/9nz3klhxdjp5) and [Ubuntu 22.04 LTS](https://www.microsoft.com/store/productId/9PN20MSR04DW)
+will be used in this tutorial.
 
 (ref::backup-warning)=
 ```{warning}
@@ -241,11 +241,11 @@ Now you can leverage UP4W from your Landscape server to create and provision Ubu
 
 ### Create an Ubuntu WSL instance locally
 
-Open Windows PowerShell and run the following command to create a new Ubuntu-Preview instance.
+Open Windows PowerShell and run the following command to create a new Ubuntu 24.04 instance.
 When prompted create the default user and password. For convenience, we'll set both to `u`.
 
 ```text
-PS C:\Users\me\tutorial> ubuntupreview.exe
+PS C:\Users\me\tutorial> ubuntu2404.exe
 
 Installing, this may take a few minutes...
 Please create a default UNIX user account. The username does not need to match your Windows username.
@@ -406,7 +406,7 @@ PS C:\Users\me\tutorial> wsl --shutdown
 ```
 
 Then, in the Windows Start Menu, locate the "Ubuntu 22.04 LTS" application, right-click on it, and select "Uninstall",
-as done with UP4W. Do the same for the "Ubuntu (Preview)" and "Ubuntu" applications.
+as done with UP4W. Do the same for the "Ubuntu 24.04 LTS" and "Ubuntu" applications.
 
 The instances will be removed automatically.
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -123,7 +123,7 @@ root@mib:~$ systemctl --state=running --no-legend --no-pager | grep -m 3 landsca
   landscape-async-frontend.service      loaded active running LSB: Enable Landscape async frontend
 ```
 
-Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigated to `http://127.0.0.1:8080` to create the Landscape global admin account.
+Once installed Landscape will be served on `localhost` port 8080. Open your favourite browser on Windows and navigate to `http://127.0.0.1:8080` to create the Landscape global admin account.
 Enter the following credentials and click the **Sign Up** button:
 
 | Field             | Value           |

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -6,9 +6,9 @@ In this tutorial you will learn all the basic things that you need to know to st
 
 **What you'll need:**
 
-- A Windows 11 machine with access to the Microsoft Store and a minimum of 16GB of RAM and 8-core processor.
+- A Windows 11 machine with access to the Microsoft Store and a minimum of 16GB of RAM and 8-core processor
 
-- Familiarity with the Windows PowerShell.
+- Familiarity with the Windows PowerShell
 
 <br/>
 
@@ -16,7 +16,7 @@ In this tutorial you will learn all the basic things that you need to know to st
 
 - Set things up
 
-- Watch UP4W transform your Ubuntu Pro game on WSL!
+- Watch UP4W transform your Ubuntu Pro game on WSL
 
 - Tear things down
 
@@ -339,7 +339,7 @@ Paste your token retrieved from your Ubuntu Pro dashboard during [Setup](tut::en
 Create a new file in your home directory named `landscape.txt` and enter following contents, replacing:
 
 - `<HOSTNAME>` by the actual host name of your Windows machine and
-- `<YOUR_WINDOWS_USER_NAME>` by the actual user name of your Windows account.
+- `<YOUR_WINDOWS_USER_NAME>` by the actual user name of your Windows account
 
 ```
 [host]
@@ -421,7 +421,9 @@ u@mib:~$
 
 UP4W should have already pro-attached this instance. To verify:
 
-- Run `pro status`. You should see some services enabled (for now, ESM) and the account and subscription information at the bottom of the output:
+- Run `pro status`
+
+You should see some services enabled (for now, ESM) and the account and subscription information at the bottom of the output:
 
 
 ```bash
@@ -443,7 +445,9 @@ u@mib:~$
 
 
 
-- Run `sudo apt update`. You should notice in the output that you’re accessing packages from all the enabled services (for now, ESM).
+- Run `sudo apt update`
+
+You should notice in the output that you’re accessing packages from all the enabled services (for now, ESM):
 
 ```bash
 u@mib:~$ sudo apt update
@@ -469,7 +473,7 @@ UP4W should have also already Landscape-registered this instance:
 ![New WSL instance pending approval](./assets/wsl-pending-approval.png)
 
 
-- To accept the registration, click on the instance name; in the pop-up, set "Tags" to  `wsl-vision`; finally, click **Accept**.
+- To accept the registration first click on the instance name and in the pop-up set "Tags" to `wsl-vision` then click **Accept**
 
 ![Accept and tag Ubuntu Preview](./assets/accept-ubuntu-preview-tag.png)
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -41,37 +41,18 @@ We recommend that they are exported then deleted.
 You can then install them as described in this tutorial.
 At the end of the tutorial you can re-import and restore your data.
 
- <details><summary> How do I export, delete, and re-import Ubuntu 22.04 LTS? </summary>
+Exporting, deleting and re-importing Ubuntu is achieved with the following commands.
+In each case, `{version}` would need to be replaced with 22.04 or 24.04.
 
-     PS C:\Users\me\tutorial> wsl --export Ubuntu-22.04 .\backup\Ubuntu-22.04.tar.gz
-     Export in progress, this may take a few minutes.
-     The operation completed successfully.
+```
+PS C:\Users\me\tutorial> wsl --export Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
 
-     PS C:\Users\me\tutorial> wsl --unregister Ubuntu-22.04
-     Unregistering..
-     The operation completed successfully.
+PS C:\Users\me\tutorial> wsl --unregister Ubuntu-{version}
 
-     PS C:\Users\me\tutorial> wsl --import Ubuntu-22.04 .\backup\Ubuntu-22.04 .\backup\Ubuntu-22.04.tar.gz
-     Import in progress, this may take a few minutes.
-     The operation completed successfully.
+PS C:\Users\me\tutorial> wsl --import Ubuntu-{version} .\backup\Ubuntu-{version} .\backup\Ubuntu-{version}.tar.gz
 
- </details>
+```
 
-<details><summary> How do I export, delete, and re-import Ubuntu (Preview)? </summary>
-   
-     PS C:\Users\me\tutorial> wsl --export Ubuntu-Preview .\backup\Ubuntu-Preview.tar.gz
-     Export in progress, this may take a few minutes.
-     The operation completed successfully.
-
-     PS C:\Users\me\tutorial> wsl --unregister Ubuntu-Preview
-     Unregistering...
-     The operation completed successfully.
-	 
-     PS C:\Users\me\tutorial> wsl --import Ubuntu-Preview .\backup\Ubuntu-Preview .\backup\Ubuntu-Preview.tar.gz
-     Import in progress, this may take a few minutes.
-     The operation completed successfully.	 
-
- </details>
 ```
 
 You can now launch WSL instances of Ubuntu on your Windows machine.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -2,15 +2,11 @@
 
 In this tutorial you will learn all the basic things that you need to know to start taking advantage of your Ubuntu Pro subscription on Ubuntu WSL at scale with Ubuntu Pro for WSL (UP4W).
 
-<br/>
-
 **What you'll need:**
 
 - A Windows 11 machine with access to the Microsoft Store and a minimum of 16GB of RAM and 8-core processor
 
 - Familiarity with the Windows PowerShell
-
-<br/>
 
 **What you'll do:**
 
@@ -20,8 +16,6 @@ In this tutorial you will learn all the basic things that you need to know to st
 
 - Tear things down
 
-<br/>
-
 ```{note}
 Throughout this tutorial we'll present shell commands together with their output:
 
@@ -30,12 +24,10 @@ prompt matching the shell it's launched in.
 
   For example, `PS C:\Users\me\tutorial>` is a PowerShell prompt where the current working directory is `C:\Users\me\tutorial`, thus running on Windows.
 
-
   Similarly, a Linux shell prompt logged in as root with the current working directory as the root home directory will look like `root@hostname:~#`
 
 - The outputs are preserved to give you more context.
 ```
-
 
 ## Set things up
 
@@ -46,17 +38,13 @@ prompt matching the shell it's launched in.
 
 Please reset its configuration to the default settings by (making a backup of your existing `~\.wslconfig` file, then) running:
 
-
     PS C:\Users\me\tutorial> Remove-Item ~\.wslconfig
 
 ```
 
-
 See: [Microsoft Store | Windows Subsystem for Linux](https://www.microsoft.com/store/productId/9P9TQF7MRM4R)
 
 All set. From now on you can use it to launch  WSL instances.
-
-<br />
 
 ### Install the Ubuntu 22.04 LTS and Ubuntu (Preview) applications
 
@@ -67,7 +55,6 @@ All set. From now on you can use it to launch  WSL instances.
 Please export them and delete them. Then proceed with the tutorial and install them fresh from the links provided below. At the end of the tutorial you can re-import them to restore your data.
 
  <details><summary> How do I export, delete, and re-import Ubuntu 22.04 LTS? </summary>
-
 
      PS C:\Users\me\tutorial> wsl --export Ubuntu-22.04 .\backup\Ubuntu-22.04.tar.gz
      Export in progress, this may take a few minutes.
@@ -100,8 +87,6 @@ Please export them and delete them. Then proceed with the tutorial and install t
  </details>
 ```
 
-
-
 See: 
 - [Microsoft Store | Ubuntu 22.04 LTS](https://www.microsoft.com/store/productId/9PN20MSR04DW)
 - [Microsoft Store | Ubuntu (Preview)](https://www.microsoft.com/store/productId/9P7BDVKVNXZ6)
@@ -121,7 +106,6 @@ Visit your Ubuntu Pro Dashboard to retrieve your subscription token.
 
 
 All set. From now on you can start adding this token to the Ubuntu Pro client on your WSL instances so you can enjoy Ubuntu Pro benefits on WSL as well. 
-
 
 ### Set up a Landscape server
 
@@ -169,7 +153,6 @@ Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.146.1-microsoft-standard-WSL2 x86_
   Usage of /:   0.1% of 1006.85GB   Users logged in:       1
   Memory usage: 25%                 IPv4 address for eth0: 172.18.68.146
   Swap usage:   4%
-
 
 This message is shown once a day. To disable it please create the
 /root/.hushlogin file.
@@ -220,7 +203,6 @@ When the installation  process prompts about  Postfix configuration: Under 'Gene
 ![Setting no Postfix configuration](./assets/postfix-config.png)
 
 That should bring you back to your shell prompt and you should see the installation unfolding. If it completes successfully, the last few log lines should look as below, with the Landscape systemd units appearing as active.
-
 
 ```text
 
@@ -307,7 +289,6 @@ Keep the current terminal open so the server stays running while you continue on
 Open a new terminal window and run `ubuntu2204.exe`. Landscape server and related components will start automatically.
 ```
 
-
 ### Install UP4W
 
 % :TODO: remove this warning once the app is made generally available (after the beta period).
@@ -322,7 +303,6 @@ Time to install UP4W! Click on [this link](https://www.microsoft.com/store/produ
 
 
 Once the installation is complete, you will see a **Start** button. Click it. That will start the UP4W Windows application. We'll use it to configure UP4W at next.
-
 
 ```{note}
 Instead of using the GUI, it's possible to configure UP4W through the Windows registry, which enables you to do things at scale.
@@ -353,7 +333,6 @@ ping_url = https://<HOSTNAME>/ping
 ssl_public_key = C:\Users\<YOUR_WINDOWS_USER_NAME>\landscape_server.pem
 ```
 % If really needed we can start without the SSL public key and add it after the Windows host is registered in Landscape.
-
 
 Then load that file using the "Custom Configuration" part of the the screen, as shown below:
 
@@ -391,7 +370,6 @@ At the top of the page, on the right-hand side of the Landscape logo, click on "
 
 All set. From now on you can use your Landscape server not just to manage the Ubuntu WSL instances that UP4W has pro-attached and Landscape-registered on the host, but to tell UP4W to create and provision them on the host too!
 
-
 ## Watch UP4W transform your Ubuntu Pro game on WSL!
 
 ### Create an Ubuntu WSL instance locally and watch it be automatically pro-attached and Landscape-registered
@@ -418,13 +396,11 @@ u@mib:~$
 
 ```
 
-
 UP4W should have already pro-attached this instance. To verify:
 
 - Run `pro status`
 
 You should see some services enabled (for now, ESM) and the account and subscription information at the bottom of the output:
-
 
 ```text
 u@mib:~$ pro status
@@ -442,8 +418,6 @@ Enable services with: pro enable <service>
 Subscription: Ubuntu Pro - free personal subscription
 u@mib:~$
 ```
-
-
 
 - Run `sudo apt update`
 
@@ -472,11 +446,9 @@ UP4W should have also already Landscape-registered this instance:
 
 ![New WSL instance pending approval](./assets/wsl-pending-approval.png)
 
-
 - To accept the registration first click on the instance name and in the pop-up set "Tags" to `wsl-vision` then click **Accept**
 
 ![Accept and tag Ubuntu Preview](./assets/accept-ubuntu-preview-tag.png)
-
 
 ### Use Landscape to create a pro-attached and Landscape-registered Ubuntu WSL instance remotely
 
@@ -487,7 +459,6 @@ appear showing the progress of the new instance creation.
 ![Create instance via Landscape](./assets/create-instance-via-landscape.png)
 
 ![Creation progress](./assets/creation-progress.png)
-
 
 Your Landscape Server will talk to the Landscape client built into your UP4W and ask UP4W to install the `Ubuntu` application and create an Ubuntu WSL instance for you. In your PowerShell, run `ubuntu.exe` to log in to the new instance.
 
@@ -509,7 +480,6 @@ me@mib:~$
 ```
 
 As usual, this instance is pro-attached and Landscape-registered -- run `pro status` to verify the pro-attachment and refresh your Landscape server page to verify and accept the registration (as before, apply the  `wsl-vision` tag and click `Accept`).
-
 
 ### Use Landscape to deploy packages to all of your Ubuntu WSL instances at once
 
@@ -619,6 +589,4 @@ This tutorial has introduced you to all the basic things you can do with UP4W. B
 | “How do I contribute to UP4W?” | Developer docs      |
 
 %| “Why…?”, “So what?”	UP4W Explanation docs 
-
-
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -39,7 +39,7 @@ prompt matching the shell it's launched in.
 
 ## Set things up
 
-### Install the `Windows Subsystem for Linux` (WSL) application
+### Install the Windows Subsystem for Linux (WSL) application
 
 ```{warning}
 **If you already have it pre-installed:** 
@@ -58,7 +58,7 @@ All set. From now on you can use it to launch  WSL instances.
 
 <br />
 
-### Install the `Ubuntu 22.04 LTS` and `Ubuntu (Preview)` applications
+### Install the Ubuntu 22.04 LTS and Ubuntu (Preview) applications
 
 (ref::backup-warning)=
 ```{warning}

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,20 +1,10 @@
 # Get started with UP4W
 
-In this tutorial you will learn all the basic things that you need to know to start taking advantage of your Ubuntu Pro subscription on Ubuntu WSL at scale with Ubuntu Pro for WSL (UP4W).
+Windows Subsystem for Linux ([WSL](https://ubuntu.com/desktop/wsl)) makes it possible to run Ubuntu — the number 1 open-source operating system — on a Windows machine.
+With Ubuntu Pro for WSL (UP4W) an [Ubuntu Pro](https://ubuntu.com/pro) subscription empowers you to manage Ubuntu WSL instances at scale.
 
-**What you'll need:**
-
-- A Windows 11 machine with access to the Microsoft Store and a minimum of 16GB of RAM and 8-core processor
-
-- Familiarity with the Windows PowerShell
-
-**What you'll do:**
-
-- Set things up
-
-- Watch UP4W transform your Ubuntu Pro game on WSL
-
-- Tear things down
+In this tutorial you will develop an understanding of how UP4W can be installed and deployed for managing multiple WSL instances.
+To complete this tutorial you will need a Windows 11 machine with a minimum of 16GB RAM and a 8-core processor.
 
 ```{note}
 Throughout this tutorial we'll present shell commands together with their output:


### PR DESCRIPTION
This is a **first pass** at improving the main UP4W tutorial.

The main changes here included:

- Edited all main text for clarity and focus
- Added more substantive and focused intro text
- Removed unnecessary and distracting syntax highlighting from CLI code blocks
- Truncated excessively long command logs
- Added shorter, more readable headings, resulting in a more concise contents sidebar
- Made the doc more consistent with the Canonical style guide (e.g., sentence case in headings, no comments in CLI codeblocks, no markup in headings)

The changes resulted in:

- 31% decrease in lines of text
- 15% decrease in page numbers (when rendered as PDF)
- 25% decrease in mouse scrolls from start to finish (estimated from manual testing)

UDENG-2814