### PR TITLE
docs: Format landing page contents

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,37 @@ UP4W can be installed from the [Microsoft Store](https://apps.microsoft.com/home
 
 WSL is preferred by many organisations as a solution to run a fully-functioning Linux environment on a Windows machine. UP4W empowers system administrators and corporate security teams to manage these WSL instances at scale.
 
+## In this documentation
+
+````{grid} 1 1 2 2
+
+```{grid-item-card} [Tutorial](tutorial/index)
+
+**Start here** with a hands-on introduction for new users, guiding you through your first-steps
+```
+
+```{grid-item-card} [How-to guides](howto/index)
+
+**Follow step-by-step** instructions for key operations and common tasks
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](reference/index)
+
+**Read technical descriptions** of important factual information relating to UP4W
+```
+
+```{grid-item-card} [UP4W Dev](dev/index)
+
+**Review guides and reference material** aimed at developers
+```
+
+````
+
 ## Project and community
 
 UP4W is a member of the Ubuntu family. It’s an open-source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback. Check out our [contribution page](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/CONTRIBUTING.md) on GitHub in order to bring ideas, report bugs, participate in discussions and much more!

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ WSL is preferred by many organisations as a solution to run a fully-functioning 
 
 ```{grid-item-card} [UP4W Dev](dev/index)
 
-**Review guides and reference material** aimed at developers
+**Review guides and reference material** aimed at contributors
 ```
 
 ````

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -399,11 +399,7 @@ In the Windows Start Menu locate the "WSL" application, right-click on it then s
 
 This tutorial has introduced you to the amazing things that can be achieved with with UP4W. But there is more to explore:
 
-| IF YOU ARE WONDERING…          | VISIT…              |
-| ------------------------------ | ------------------- |
-| “How do I…?”                   | UP4W How-to docs    |
-| “What is…?”                    | UP4W Reference docs |
-| “How do I contribute to UP4W?” | Developer docs      |
-
-%| “Why…?”, “So what?”	UP4W Explanation docs 
-
+In the rest of the documentation you can find [how-to guides](../howto/index)
+for completing specific tasks, [reference](../reference/index) material
+describing key information relating to UP4W and dedicated [documentation for
+developers](../dev/index).

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -397,7 +397,7 @@ In the Windows Start Menu locate the "WSL" application, right-click on it then s
 
 ## Next steps
 
-This tutorial has introduced you to the amazing things that can be achieved with with UP4W. But there is more to explore:
+This tutorial has introduced you to the amazing things that can be achieved with UP4W.
 
 In the rest of the documentation you can find [how-to guides](../howto/index)
 for completing specific tasks, [reference](../reference/index) material


### PR DESCRIPTION
This adds an "In this documentation" section to the landing page that aligns with the Diataxis framework and other product documentation.

A similar content block was removed from the main tutorial and replaced with text that includes internal links to the docs.
This content block was non-functional (there were no working links) and it would have duplicated what is now on the landing page.

UDENG-3001