### PR TITLE
fix: Replace all calls of the grpc-go deprecated Dial* functions

### DIFF
--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -275,15 +275,11 @@ func TestQuitBeforeServe(t *testing.T) {
 func grpcPersistentCall(t *testing.T, addr string) (drop func() codes.Code) {
 	t.Helper()
 
-	const timeout = 100 * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoErrorf(t, err, "Could not dial GRPC server.")
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoErrorf(t, err, "Could not create a GRPC client.")
 
 	c := grpctestservice.NewTestServiceClient(conn)
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	started := make(chan struct{})
 	errch := make(chan error)

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -318,9 +318,10 @@ func requireCannotDialGRPC(t *testing.T, addr string, msg string) {
 	t.Helper()
 
 	// Try to connect. Non-blocking call so no error is wanted.
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoErrorf(t, err, "error dialing GRPC server.\nMessage: %s", msg)
 	defer conn.Close()
+	conn.Connect()
 
 	// Timing out and checking that the connection was never established.
 	time.Sleep(300 * time.Millisecond)

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -70,13 +70,9 @@ func newConnection(ctx context.Context, d serviceData) (conn *connection, err er
 		return nil, err
 	}
 
-	// A context to control only the Dial (only needed for this function)
-	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	log.Info(ctx, "Landscape: connecting")
 
-	grpcConn, err := grpc.DialContext(dialCtx, conn.settings.url, grpc.WithTransportCredentials(creds))
+	grpcConn, err := grpc.NewClient(conn.settings.url, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, err
 	}

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Service orquestrates the Landscape hostagent connection. It lasts for the entire lifetime of the program.
-// It creates the executor and ensures there is always an active connection, creating a new one otherwise.
+// It creates the executor and ensures there is always an active connection, creating a new one if necessary.
 type Service struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -43,7 +43,7 @@ type Service struct {
 
 	// connRetrier is used in order to ask the keepConnected
 	// function to try again now (instead of waiting for the retrial
-	// time). Do not use directly. Instead use signalRetryConnection().
+	// time). Do not use directly. Instead use reconnect().
 	connRetrier *retryConnection
 
 	cloudinit CloudInit
@@ -358,7 +358,7 @@ func (s *Service) disconnect() {
 
 // The following methods expose some internals for the other components to use.
 
-// signalRetryConnection signals the Landscape client to attempt to connect to Landscape.
+// reconnect signals the Landscape client to attempt to connect to Landscape.
 // It will not block if there is an ative connection. until the reconnect petition
 // has been received.
 func (s *Service) reconnect() {

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -168,9 +168,10 @@ func TestRegisterGRPCServices(t *testing.T) {
 			if !tc.insecureClient {
 				creds = loadClientCertificates(t, filepath.Join(publicDir, common.CertificatesDir))
 			}
-			conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+			conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 			require.NoError(t, err, "Setup: could not create a client connection")
 			defer conn.Close()
+			conn.Connect()
 			c := agentapi.NewUIClient(conn)
 
 			// Test the client connection.

--- a/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
@@ -333,8 +333,8 @@ func newMockWSLProService(t *testing.T, ctx context.Context, opt mockWslProServi
 
 	mock = &mockWSLProService{}
 
-	conn, err := grpc.DialContext(ctx, opt.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err, "wslDistroMock: could not dial control address")
+	conn, err := grpc.NewClient(opt.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "wslDistroMock: could not setup a control address client")
 
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)

--- a/wsl-pro-service/internal/daemon/daemon.go
+++ b/wsl-pro-service/internal/daemon/daemon.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ubuntu/decorate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Daemon is a grpc daemon with systemd support.
@@ -292,19 +291,12 @@ func (d *Daemon) connect(ctx context.Context) (server *streams.Server, err error
 		return nil, err
 	}
 	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStreamInterceptor(interceptorschain.StreamClient(
 			log.StreamClientInterceptor(logrus.StandardLogger(), log.WithClientID(distroName)),
 		)), grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		return nil, fmt.Errorf("could not create a gRPC client: %v", err)
 	}
-
-	defer func(err *error) {
-		if *err != nil {
-			conn.Close()
-		}
-	}(&err)
 
 	return streams.NewServer(ctx, d.system, conn), nil
 }

--- a/wsl-pro-service/internal/daemon/daemon.go
+++ b/wsl-pro-service/internal/daemon/daemon.go
@@ -291,13 +291,13 @@ func (d *Daemon) connect(ctx context.Context) (server *streams.Server, err error
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpc.DialContext(ctx, addr,
+	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStreamInterceptor(interceptorschain.StreamClient(
 			log.StreamClientInterceptor(logrus.StandardLogger(), log.WithClientID(distroName)),
 		)), grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
-		return nil, fmt.Errorf("could not dial: %v", err)
+		return nil, fmt.Errorf("could not create a gRPC client: %v", err)
 	}
 
 	defer func(err *error) {

--- a/wsl-pro-service/internal/streams/multiclient_test.go
+++ b/wsl-pro-service/internal/streams/multiclient_test.go
@@ -54,10 +54,10 @@ func TestConnect(t *testing.T) {
 				defer s.Stop()
 			}
 
-			conn, err := grpc.DialContext(ctx, lis.Addr().String(),
+			conn, err := grpc.NewClient(lis.Addr().String(),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
-			require.NoError(t, err, "Setup: Dial should have succeeded")
+			require.NoError(t, err, "Setup: Creating a client should have succeeded")
 			defer conn.Close()
 
 			client, err := streams.Connect(ctx, conn)
@@ -104,10 +104,10 @@ func TestSendAndRecv(t *testing.T) {
 	}()
 	defer s.Stop()
 
-	conn, err := grpc.DialContext(ctx, lis.Addr().String(),
+	conn, err := grpc.NewClient(lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-	require.NoError(t, err, "Setup: Dial should have succeeded")
+	require.NoError(t, err, "Setup: Creating a client should have succeeded")
 	defer conn.Close()
 
 	client, err := streams.Connect(ctx, conn)

--- a/wsl-pro-service/internal/streams/server_test.go
+++ b/wsl-pro-service/internal/streams/server_test.go
@@ -23,9 +23,9 @@ func TestServe(t *testing.T) {
 	agent := testutils.NewMockWindowsAgent(t, ctx, t.TempDir())
 	defer agent.Stop()
 
-	conn, err := grpc.DialContext(ctx, agent.Listener.Addr().String(),
+	conn, err := grpc.NewClient(agent.Listener.Addr().String(),
 		grpc.WithTransportCredentials(agent.ClientCredentials))
-	require.NoError(t, err, "Setup: could not Dial the mock windows agent")
+	require.NoError(t, err, "Setup: could not create a client to the mock windows agent")
 	defer conn.Close()
 
 	server := streams.NewServer(ctx, sys, conn)
@@ -94,9 +94,9 @@ func TestStop(t *testing.T) {
 	agent := testutils.NewMockWindowsAgent(t, ctx, t.TempDir())
 	defer agent.Stop()
 
-	conn, err := grpc.DialContext(ctx, agent.Listener.Addr().String(),
+	conn, err := grpc.NewClient(agent.Listener.Addr().String(),
 		grpc.WithTransportCredentials(agent.ClientCredentials))
-	require.NoError(t, err, "Setup: could not Dial the mock windows agent")
+	require.NoError(t, err, "Setup: could not create a client to the mock windows agent")
 	defer conn.Close()
 
 	server := streams.NewServer(ctx, sys, conn)


### PR DESCRIPTION
Finally I got time to put some love into this task to carefully analyze the best way to replace `Dial` and `DialContext` in this project. I was especially concerned about the way we depended on the context passed to `DialContext` in tests, but it turned out to be not that hard to do most of the necessary replacements.

The gRPC folks also call out for the builtin retry policies. That's a topic for a follow-up PR, because that's more risky and involving that just the replacement of the deprecated APIs., wihch is just enough to unblock dependabot PR's gRPC and protobuf related PRs.

---
UDENG-2653.