### PR TITLE
maint: ensure vendorizing has been done when building source package

### DIFF
--- a/wsl-pro-service/debian/rules
+++ b/wsl-pro-service/debian/rules
@@ -14,6 +14,10 @@ export GOTOOLCHAIN := local
 export GOFLAGS := $(shell ./debian/prepare-source.sh)
 
 %:
+ifeq ($(strip $(GOFLAGS)),)
+	@echo "GOFLAGS is empty, vendoring probably failed"
+	exit 1
+endif
 	@echo "Building with flags $(GOFLAGS)"
 	dh $@ --builddirectory=_build --with=apport
 


### PR DESCRIPTION
Source package build can fail due to go mod vendor needed ssh key access.
Ensure we detect this case and fails early.