### PR TITLE
fix: force all subprocessed commands in english

### DIFF
--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -213,6 +213,7 @@ func runCommand(cmd *exec.Cmd) ([]byte, error) {
 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	cmd.Env = append(cmd.Env, "LC_ALL=C") // Ensure that the output is in English
 
 	err := cmd.Run()
 	out := bytes.TrimSpace(stdout.Bytes())


### PR DESCRIPTION
All commands should be set to english until we have a proper API for each of them.