### PR TITLE
maint: rename TestNew() subtest for system tests

### DIFF
--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 	}{
 		"Return a new system": {},
 
-		"Only prints a warning when the Landscape config validation failed": {systemLandscapeConfigFile: "invalid_ini.conf"},
+		"Ignore errors when the Landscape config validation failed (only warnings)": {systemLandscapeConfigFile: "invalid_ini.conf"},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
This was lost in the previous PR rebase, sorry for it.