### PR TITLE
fix: workaround livepatch disable failure

### DIFF
--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -21,13 +21,13 @@ ProtectHostname=yes
 ProtectKernelLogs=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
-RestrictNamespaces=yes
+RestrictNamespaces=mnt
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 
 # Only permit system calls used by common system services, excluding any special purpose calls
-SystemCallFilter=@system-service
+SystemCallFilter=@system-service @sandbox
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`pro detach` fails due to livepatch disable failing in a container.
Lifting some systemd service restrictions is enough as a workaround to make it work until a proper fix lands in ubuntu-pro.

Thanks to @CarlosNihelton for the fix.

UDENG-3357