### PR TITLE
feat(gui): Hide Landscape config page by default

### DIFF
--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -48,6 +48,7 @@ void main() {
         'USERPROFILE': tmpHome!.path,
         'LOCALAPPDATA': tmpLocalAppData!.path,
         'UP4W_ALLOW_STORE_PURCHASE': '1',
+        kLandscapeAllowedEnvVar: '1',
       },
     );
   });

--- a/gui/packages/ubuntupro/lib/app.dart
+++ b/gui/packages/ubuntupro/lib/app.dart
@@ -6,9 +6,11 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:wizard_router/wizard_router.dart';
 import 'package:yaru/yaru.dart';
 
+import 'constants.dart';
 import 'core/agent_api_client.dart';
 import 'core/agent_connection.dart';
 import 'core/agent_monitor.dart';
+import 'core/environment.dart';
 import 'pages/landscape/landscape_page.dart';
 import 'pages/startup/startup_page.dart';
 import 'pages/subscribe_now/subscribe_now_page.dart';
@@ -41,6 +43,9 @@ class Pro4WSLApp extends StatelessWidget {
             supportedLocales: AppLocalizations.supportedLocales,
             onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
             builder: (context, child) {
+              final landscapeFeatureIsEnabled =
+                  Environment()[kLandscapeAllowedEnvVar] != null &&
+                      Environment()[kLandscapeAllowedEnvVar] != '';
               return Wizard(
                 routes: {
                   Routes.startup: WizardRoute(
@@ -72,19 +77,29 @@ class Pro4WSLApp extends StatelessWidget {
                       return null;
                     },
                   ),
-                  Routes.configureLandscape:
-                      const WizardRoute(builder: LandscapePage.create),
-                  Routes.subscriptionStatus: WizardRoute(
-                    builder: SubscriptionStatusPage.create,
-                    onReplace: (_) => Routes.subscribeNow,
-                    onBack: (_) => Routes.subscribeNow,
-                  ),
-                  Routes.configureLandscapeLate: WizardRoute(
-                    builder: (context) => LandscapePage.create(
-                      context,
-                      isLate: true,
+                  if (landscapeFeatureIsEnabled) ...{
+                    Routes.configureLandscape:
+                        const WizardRoute(builder: LandscapePage.create),
+                    Routes.subscriptionStatus: WizardRoute(
+                      builder: SubscriptionStatusPage.create,
+                      onReplace: (_) => Routes.subscribeNow,
+                      onBack: (_) => Routes.subscribeNow,
+                      userData: true,
                     ),
-                  ),
+                    Routes.configureLandscapeLate: WizardRoute(
+                      builder: (context) => LandscapePage.create(
+                        context,
+                        isLate: true,
+                      ),
+                    ),
+                  } else ...{
+                    Routes.subscriptionStatus: WizardRoute(
+                      builder: SubscriptionStatusPage.create,
+                      onReplace: (_) => Routes.subscribeNow,
+                      onBack: (_) => Routes.subscribeNow,
+                      userData: false,
+                    ),
+                  },
                 },
               );
             },

--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -12,3 +12,6 @@ const kVersion = String.fromEnvironment(
   'UP4W_FULL_VERSION',
   defaultValue: 'Dev',
 );
+
+/// The environment variable users should set to enable integration with Landscape.
+const kLandscapeAllowedEnvVar = 'UP4W_ALLOW_LANDSCAPE_INTEGRATION';

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -131,7 +131,7 @@ class LandscapeInput extends StatelessWidget {
           ],
         ),
         const SizedBox(
-          height: 32.0,
+          height: 16.0,
         ),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -314,7 +314,7 @@ class _FileFormState extends State<_FileForm> {
           style: widget.sectionBodyStyle,
         ),
         const SizedBox(
-          height: 16.0,
+          height: 8.0,
         ),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_page.dart
@@ -85,8 +85,14 @@ class SubscriptionStatusPage extends StatelessWidget {
   /// Initializes the view-model and inject it in the widget tree so the child page can access it via the BuildContext.
   static Widget create(BuildContext context) {
     final client = getService<AgentApiClient>();
+    final landscapeFeatureIsEnabled =
+        Wizard.of(context).routeData as bool? ?? false;
     return ProxyProvider<ValueNotifier<ConfigSources>, SubscriptionStatusModel>(
-      update: (context, src, _) => SubscriptionStatusModel(src.value, client),
+      update: (context, src, _) => SubscriptionStatusModel(
+        src.value,
+        client,
+        landscapeFeatureIsEnabled: landscapeFeatureIsEnabled,
+      ),
       child: const SubscriptionStatusPage(),
     );
   }

--- a/gui/packages/ubuntupro/test/pages/subscription_status/subscription_status_model_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subscription_status/subscription_status_model_test.dart
@@ -80,7 +80,7 @@ void main() {
 
   group('config Landscape:', () {
     final client = MockAgentApiClient();
-    final susbcriptions = [
+    final subscriptions = [
       SubscriptionInfo()..ensureOrganization(),
       SubscriptionInfo()..ensureMicrosoftStore(),
       SubscriptionInfo()..ensureUser(),
@@ -96,7 +96,7 @@ void main() {
       return 'landscape ${landscape.toString().split(':').first} with pro ${sub.toString().split(':').first} => $want';
     }
 
-    for (final subs in susbcriptions) {
+    for (final subs in subscriptions) {
       for (final landscape in landscapeSources) {
         test(makeSubTestName(landscape, subs), () {
           final want = landscape.hasOrganization() ? isFalse : isTrue;

--- a/gui/packages/ubuntupro/test/pages/subscription_status/subscription_status_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subscription_status/subscription_status_page_test.dart
@@ -100,6 +100,65 @@ void main() {
         expect(find.text(lang.landscapeConfigureButton), findsOneWidget);
       });
     });
+
+    group('landscape feature disabled:', () {
+      testWidgets('user', (tester) async {
+        final landscape = LandscapeSource()..ensureNone();
+        info.ensureUser();
+        final app = buildApp(
+          info,
+          landscape,
+          client,
+          landscapeFeatureIsEnabled: false,
+        );
+
+        await tester.pumpWidget(app);
+
+        final context = tester.element(find.byType(SubscriptionStatusPage));
+        final lang = AppLocalizations.of(context);
+
+        expect(find.text(lang.detachPro), findsOneWidget);
+        expect(find.text(lang.landscapeConfigureButton), findsNothing);
+      });
+
+      testWidgets('store', (tester) async {
+        final landscape = LandscapeSource()..ensureUser();
+        info.ensureMicrosoftStore();
+        final app = buildApp(
+          info,
+          landscape,
+          client,
+          landscapeFeatureIsEnabled: false,
+        );
+
+        await tester.pumpWidget(app);
+
+        final context = tester.element(find.byType(SubscriptionStatusPage));
+        final lang = AppLocalizations.of(context);
+
+        expect(find.text(lang.manageSubscription), findsOneWidget);
+        expect(find.text(lang.landscapeConfigureButton), findsNothing);
+      });
+
+      testWidgets('organization', (tester) async {
+        final landscape = LandscapeSource();
+        info.ensureOrganization();
+        final app = buildApp(
+          info,
+          landscape,
+          client,
+          landscapeFeatureIsEnabled: false,
+        );
+
+        await tester.pumpWidget(app);
+
+        final context = tester.element(find.byType(SubscriptionStatusPage));
+        final lang = AppLocalizations.of(context);
+
+        expect(find.text(lang.orgManaged), findsOneWidget);
+        expect(find.text(lang.landscapeConfigureButton), findsNothing);
+      });
+    });
   });
   testWidgets('creates a model', (tester) async {
     final app = buildMultiProviderWizardApp(
@@ -211,8 +270,9 @@ void main() {
 Widget buildApp(
   SubscriptionInfo info,
   LandscapeSource landscape,
-  AgentApiClient client,
-) {
+  AgentApiClient client, {
+  bool landscapeFeatureIsEnabled = true,
+}) {
   return buildMultiProviderWizardApp(
     routes: {
       '/': WizardRoute(
@@ -224,6 +284,7 @@ Widget buildApp(
         create: (_) => SubscriptionStatusModel(
           ConfigSources(proSubscription: info, landscapeSource: landscape),
           client,
+          landscapeFeatureIsEnabled: landscapeFeatureIsEnabled,
         ),
       ),
     ],

--- a/windows-agent/internal/proservices/ui/export_test.go
+++ b/windows-agent/internal/proservices/ui/export_test.go
@@ -1,0 +1,4 @@
+package ui
+
+// LandscapeAllowedEnvVar is the environment variable users should set to enable integration with Landscape.
+const LandscapeAllowedEnvVar = landscapeAllowedEnvVar

--- a/windows-agent/internal/proservices/ui/ui.go
+++ b/windows-agent/internal/proservices/ui/ui.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
@@ -72,8 +73,15 @@ func (s *Service) ApplyProToken(ctx context.Context, info *agentapi.ProAttachInf
 	return subs, nil
 }
 
+const landscapeAllowedEnvVar = "UP4W_ALLOW_LANDSCAPE_INTEGRATION"
+
 // ApplyLandscapeConfig handles the gRPC call to set landscape configuration.
 func (s *Service) ApplyLandscapeConfig(ctx context.Context, landscapeConfig *agentapi.LandscapeConfig) (*agentapi.LandscapeSource, error) {
+	isEnabled := os.Getenv(landscapeAllowedEnvVar)
+	if isEnabled == "" {
+		return nil, fmt.Errorf("UI service: Landscape integration is disabled, set %s to enable it", landscapeAllowedEnvVar)
+	}
+
 	c := landscapeConfig.GetConfig()
 
 	err := s.config.SetUserLandscapeConfig(ctx, c)

--- a/windows-agent/internal/proservices/ui/ui_test.go
+++ b/windows-agent/internal/proservices/ui/ui_test.go
@@ -239,26 +239,31 @@ func TestNotifyPurchase(t *testing.T) {
 }
 
 func TestApplyLandscapeConfig(t *testing.T) {
-	t.Parallel()
-
+	// Tests can no longer be parallel because we rely on environment variables.
 	testCases := map[string]struct {
 		setUserLandscapeConfigErr bool
 		landscapeSource           config.Source
 		returnBadSource           bool
+		disableLandscape          bool
 
 		wantErr bool
 		want    interface{}
 	}{
 		"Success": {want: lsUser},
 
-		"Error when setting the config returns error":  {setUserLandscapeConfigErr: true, wantErr: true},
-		"Error when attempting to override org config": {landscapeSource: config.SourceRegistry, wantErr: true},
-		"Error when Landscape source is incoherent":    {returnBadSource: true, wantErr: true},
+		"When setting the config fails":              {setUserLandscapeConfigErr: true, wantErr: true},
+		"Override org config is not allowed":         {landscapeSource: config.SourceRegistry, wantErr: true},
+		"When Landscape source is incoherent":        {returnBadSource: true, wantErr: true},
+		"When the Landscape integration is disabled": {disableLandscape: true, wantErr: true},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+			if tc.disableLandscape {
+				t.Setenv(ui.LandscapeAllowedEnvVar, "")
+			} else {
+				t.Setenv(ui.LandscapeAllowedEnvVar, "1")
+			}
 
 			ctx := context.Background()
 


### PR DESCRIPTION
The key point of this change is: Landscape config page is disabled by default and can be enabled by setting the environment variable `UP4W_ALLOW_LANDSCAPE_INTEGRATION`.

Reverting this behavior in the future is quite easy, changing the semantics of the environment variable in `app.dart` and `ui.go` is just enough, ofc changing the environment variable name is also desirable.

We set that environment variable for integration tests so we make sure to keep that feature maintained and upgraded, preventing surprises when we eventually decide to plug it in by default.
More tests were added to make sure individual components (models/views) behave well with and without that feature enabled.
I put an assertion on the agent as well, to make sure it rejects RPC calls to `ApplyLandscapeConfig` if that environment variable is not set. Notice that nothing prevents the usage of the registry, empowering advanced users.

---
UDENG-3360