### PR TITLE
fix(windows-agent): `NotifyConfigUpdate` only distributes the `[client]` section

### DIFF
--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/ubuntu-pro-for-wsl/common/testutils"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/wsltestutils"
 	"github.com/canonical/ubuntu-pro-for-wsl/mocks/landscape/landscapemockservice"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/cloudinit"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/config"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/database"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
@@ -911,6 +912,77 @@ func TestNotifyConfigUpdate(t *testing.T) {
 	}
 }
 
+func TestNotifyConfigUpdateWithAgentYaml(t *testing.T) {
+	if wsl.MockAvailable() {
+		t.Parallel()
+	}
+
+	testcases := map[string]struct {
+		conf string
+
+		want               string
+		wantNotInAgentYaml []string
+	}{
+
+		"Task and agent.yaml don't contain [host] section":    {conf: "[host]\nurl=localhost\n[client]\ncomputer_title=another\n", want: "[client]\ncomputer_title=another\n", wantNotInAgentYaml: []string{"host:", "url:"}},
+		"Task and agent.yaml only contains [client] section)": {conf: "[irrelevant]\nnothing=important\n[host]\nurl=localhost\n[client]\ncomputer_title=another\n", want: "[client]\ncomputer_title=another\n", wantNotInAgentYaml: []string{"irrelevant:", "nothing:", "host:", "url:"}},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if wsl.MockAvailable() {
+				t.Parallel()
+				ctx = wsl.WithMock(ctx, wslmock.New())
+			}
+
+			storageDir := t.TempDir()
+			db, err := database.New(ctx, storageDir)
+			require.NoError(t, err, "Setup: database New should not return an error")
+
+			distroName, _ := wsltestutils.RegisterDistro(t, ctx, true)
+			d, err := db.GetDistroAndUpdateProperties(ctx, distroName, distro.Properties{})
+			require.NoError(t, err, "Setup: distro %s GetDistroAndUpdateProperties should return no errors", distroName)
+			defer d.Cleanup(ctx)
+
+			homedir := t.TempDir()
+			c := config.New(ctx, storageDir)
+			cloudInit, err := cloudinit.New(ctx, c, homedir)
+			require.NoError(t, err, "Setup: cloudinit New should not return an error")
+			service, err := landscape.New(ctx, c, db, &cloudInit, landscape.WithHomeDir(homedir))
+			require.NoError(t, err, "Setup: New should not return an error")
+
+			c.SetLandscapeNotifier(func(ctx context.Context, config, uid string) {
+				service.NotifyConfigUpdate(ctx, config, uid)
+				cloudInit.Update(ctx)
+			})
+
+			// We want to inspect the tasks databases even if those calls fail.
+			_ = c.SetUserLandscapeConfig(ctx, tc.conf)
+			_ = c.SetLandscapeAgentUID(ctx, "landscapeUID")
+
+			// There is no direct way to observe the result of that function other than relying on the implementation details of the task database.
+			tasksFiles, err := filepath.Glob(filepath.Join(storageDir, "*.tasks"))
+			require.NoError(t, err, "NotifyConfigUpdate: could not list the tasks files storage dir: %s", storageDir)
+
+			b, err := os.ReadFile(tasksFiles[0])
+			require.NoError(t, err, "NotifyConfigUpdate: should have caused creation of a tasks file")
+			task := strings.TrimSpace(strings.ReplaceAll(string(b), " ", ""))
+			require.NotEmpty(t, task, "NotifyConfigUpdate: tasks file should not be empty")
+
+			agentYaml, err := os.ReadFile(filepath.Join(homedir, ".cloud-init", "agent.yaml"))
+			require.NoError(t, err, "NotifyConfigUpdate: could not read agent.yaml")
+			for _, wantNot := range tc.wantNotInAgentYaml {
+				require.NotContains(t, agentYaml, wantNot, "NotifyConfigUpdate: agent.yaml should be empty")
+			}
+
+			require.Contains(t, task, tasks.LandscapeConfigure{}.String(), "NotifyConfigUpdate: tasks file should contain a LandscapeConfigure task")
+			require.Contains(t, task, tc.want, "NotifyConfigUpdate: tasks file should contain the expected Landscape client config")
+		})
+	}
+}
 func executeLandscapeConfigTemplate(t *testing.T, in string, certPath string, url net.Addr) string {
 	t.Helper()
 

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -323,6 +323,16 @@ func (s *Service) NotifyConfigUpdate(ctx context.Context, landscapeConf, agentUI
 	if agentUID == "" {
 		landscapeConf = ""
 	}
+
+	if landscapeConf != "" {
+		var err error
+		landscapeConf, err = filterClientSection(landscapeConf)
+		if err != nil {
+			log.Errorf(ctx, "Landscape: could not notify config changes: %v", err)
+			return
+		}
+	}
+
 	distributeConfig(ctx, s.db, landscapeConf)
 	s.reconnectIfNewSettings(ctx)
 }

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -242,6 +242,30 @@ func distributeConfig(ctx context.Context, db *database.DistroDB, landscapeConf 
 	}
 }
 
+func filterClientSection(landscapeConf string) (string, error) {
+	f, err := ini.Load(strings.NewReader(landscapeConf))
+	if err != nil {
+		return "", fmt.Errorf("could not load Landscape configuration: %v", err)
+	}
+
+	if !f.HasSection("client") {
+		return "", errors.New("missing [client] section in Landscape configuration")
+	}
+
+	for _, section := range f.Sections() {
+		if section.Name() != "client" {
+			f.DeleteSection(section.Name())
+		}
+	}
+
+	var b strings.Builder
+	if _, err := f.WriteTo(&b); err != nil {
+		return "", fmt.Errorf("could not write filtered configuration: %v", err)
+	}
+
+	return b.String(), nil
+}
+
 type retryConnection struct {
 	once sync.Once
 	ch   chan struct{}

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -242,6 +242,7 @@ func distributeConfig(ctx context.Context, db *database.DistroDB, landscapeConf 
 	}
 }
 
+// filterClientSection removes all sections from the Landscape configuration except the [client] section.
 func filterClientSection(landscapeConf string) (string, error) {
 	f, err := ini.Load(strings.NewReader(landscapeConf))
 	if err != nil {


### PR DESCRIPTION
For provisioning the cloudinit package already does this filtering, and even if there was no need for doing so that code wouldn't change because it needs to translate the `[client]` section to YAML.

We cannot just change `config.LandscapeClientConfig()` to filter stuff out because there are clients relying on it to access the host section. That would imply creating another method to get the full config, which seems as fine as this.