### PR TITLE
fix: prevent subprocesses to sent notification to systemd

### DIFF
--- a/wsl-pro-service/internal/daemon/daemon.go
+++ b/wsl-pro-service/internal/daemon/daemon.go
@@ -240,6 +240,9 @@ func (d *Daemon) systemdNotifyReady(ctx context.Context) error {
 	}
 	if sent {
 		log.Debug(ctx, i18n.G("Ready state sent to systemd"))
+		if err := os.Unsetenv("NOTIFY_SOCKET"); err != nil {
+			log.Warningf(ctx, "couldn't unset NOTIFY_SOCKET for subprocesses: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Unset NOTIFY_SOCKET just after forwarding readyness to systemd. This way, subprocesses will not attempt to notify systemd that they are ready.

Unfortunately, this could only be tested in some e2e tests, grepping for subprocess warnings and we are not at that level of details yet in the e2e test infra.

UDENG-3363