### PR TITLE
docs: Exclude diagrams readme

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -165,6 +165,7 @@ custom_required_modules = []
 # Add files or directories that should be excluded from processing.
 custom_excludes = [
     'doc-cheat-sheet*',
+    'diagrams/readme.md',
     ]
 
 # Add CSS files (located in .sphinx/_static/)

--- a/docs/diagrams/readme.md
+++ b/docs/diagrams/readme.md
@@ -1,7 +1,7 @@
 Diagrams in this directory are auto-generated.
 Any PR that makes changes in the `docs/workspace.dsl` file in this repo will
 trigger a GitHub action that updates the diagrams.
-This will add a new commit to the PR.
+This will generate a second PR that can be reviewed before merging with the first PR.
 
 # Contributing
 


### PR DESCRIPTION
This adds the `readme.md` file in the diagrams directory of the docs to the excluded list,
which should prevent build errors associated with the attempt to render the file on RtD.

A small change is also made to the readme to update it based on recent changes to the diagram autogeneration workflow.

UDENG-3361