### PR TITLE
fix: Replaces Landscape "FQDN" with "server address"

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -63,7 +63,7 @@
     },
     "landscapeQuickSetup": "Quick Setup (Recommended)",
     "landscapeQuickSetupHint": "Provide your Landscape enrollment information",
-    "landscapeFQDNLabel": "Landscape FQDN",
+    "landscapeFQDNLabel": "Landscape server address",
     "landscapeFQDNError": "Invalid URI. Format should be a hostname or IP address.",
     "landscapeAccountNameLabel": "Landscape Account Name",
     "landscapeAccountNameError": "Invalid account name",


### PR DESCRIPTION
That name is ubiquitous in Landscape docs
But look a bit cryptic to most users.

Here's how it looks after this small change:
![image](https://github.com/canonical/ubuntu-pro-for-wsl/assets/11138291/e250a3a6-0c95-440b-bb4f-ef1a492cd643)

---
Fixes UDENG-3259 and #801 