### PR TITLE
fix(windows-agent): Deprecate `ubuntu_advantage` 

### DIFF
--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -129,7 +129,7 @@ func marshalConfig(conf Config) ([]byte, error) {
 
 	contents := make(map[string]interface{})
 
-	if err := ubuntuAdvantageModule(conf, contents); err != nil {
+	if err := ubuntuProModule(conf, contents); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func marshalConfig(conf Config) ([]byte, error) {
 	return w.Bytes(), nil
 }
 
-func ubuntuAdvantageModule(c Config, out map[string]interface{}) error {
+func ubuntuProModule(c Config, out map[string]interface{}) error {
 	token, src, err := c.Subscription()
 	if err != nil {
 		return err
@@ -162,7 +162,7 @@ func ubuntuAdvantageModule(c Config, out map[string]interface{}) error {
 		Token string `yaml:"token"`
 	}
 
-	out["ubuntu_advantage"] = uaModule{Token: token}
+	out["ubuntu_pro"] = uaModule{Token: token}
 	return nil
 }
 

--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -123,8 +123,8 @@ func (c CloudInit) RemoveDistroData(distroName string) (err error) {
 func marshalConfig(conf Config) ([]byte, error) {
 	w := &bytes.Buffer{}
 
-	if _, err := fmt.Fprintln(w, "# cloud-init\n# This file was generated automatically and must not be edited"); err != nil {
-		return nil, fmt.Errorf("could not write # cloud-init stenza and warning message: %v", err)
+	if _, err := fmt.Fprintln(w, "#cloud-config\n# This file was generated automatically and must not be edited"); err != nil {
+		return nil, fmt.Errorf("could not write #cloud-config stenza and warning message: %v", err)
 	}
 
 	contents := make(map[string]interface{})

--- a/windows-agent/internal/cloudinit/cloudinit_test.go
+++ b/windows-agent/internal/cloudinit/cloudinit_test.go
@@ -185,14 +185,14 @@ hostagent_uid = landscapeUID1234
 func TestWriteDistroData(t *testing.T) {
 	t.Parallel()
 
-	const oldCloudInit = `# cloud-init
+	const oldCloudInit = `#cloud-config
 # I'm an old piece of user data
 data:
 	is_this_data: Yes, it is
 	new: false
 `
 
-	const newCloudInit = `# cloud-init
+	const newCloudInit = `#cloud-config
 # I'm a shiny new piece of user data
 data:
 	new: true

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error-cases
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error-cases
@@ -4,5 +4,5 @@ landscape:
     client:
         data: This is an old data field
         info: This is the old configuration
-ubuntu_advantage:
+ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error-cases
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error-cases
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
@@ -4,5 +4,5 @@ landscape:
     client:
         data: This is an old data field
         info: This is the old configuration
-ubuntu_advantage:
+ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
@@ -4,5 +4,5 @@ landscape:
     client:
         data: This is an old data field
         info: This is the old configuration
-ubuntu_advantage:
+ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
@@ -4,5 +4,5 @@ landscape:
     client:
         data: This is an old data field
         info: This is the old configuration
-ubuntu_advantage:
+ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
@@ -4,5 +4,5 @@ landscape:
     client:
         data: This is an old data field
         info: This is the old configuration
-ubuntu_advantage:
+ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
@@ -5,5 +5,5 @@ landscape:
         hostagent_uid: landscapeUID1234
         info: This is the new configuration
         url: www.example.com/new/rickroll
-ubuntu_advantage:
+ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/with_empty_contents
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/with_empty_contents
@@ -1,3 +1,3 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 {}

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
@@ -4,5 +4,5 @@ landscape:
     client:
         info: This is the new configuration
         url: www.example.com/new/rickroll
-ubuntu_advantage:
+ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 ubuntu_advantage:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape
@@ -1,4 +1,4 @@
 #cloud-config
 # This file was generated automatically and must not be edited
-ubuntu_advantage:
+ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape_[client]_section
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape_[client]_section
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 ubuntu_advantage:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape_[client]_section
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_landscape_[client]_section
@@ -1,4 +1,4 @@
 #cloud-config
 # This file was generated automatically and must not be edited
-ubuntu_advantage:
+ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_pro_token
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_pro_token
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_both_contain_default_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_both_contain_default_tags/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_both_contain_supplied_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_both_contain_supplied_tags/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_don't_contain_[host]_section/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_don't_contain_[host]_section/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_only_contains_[client]_section)/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_only_contains_[client]_section)/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_default_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_default_tags/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_supplied_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_supplied_tags/agent.yaml
@@ -1,4 +1,4 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 landscape:
     client:

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
@@ -1,3 +1,3 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 {}

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
@@ -1,3 +1,3 @@
-# cloud-init
+#cloud-config
 # This file was generated automatically and must not be edited
 {}


### PR DESCRIPTION
We should use `ubuntu_pro` module instead. `cloud-init` does understand `ubuntu_advantage`. Their docs state:
> Activate only on keys: ubuntu_pro, ubuntu-advantage, ubuntu_advantage

Yet, there are about 4 months since they deprecated ubuntu_advantage: https://github.com/canonical/cloud-init/pull/4865

Docs are up-to-date, so current users are likely to add `ubuntu_pro` key in their user-data. That wouldn't clash with the agent.yaml, in fact which token would then be applied can become unpredictable as both would reach cc_ubuntu_pro.py module.

So, inline with cloud-init docs, let's migrate to the `ubuntu_pro` key :)

I suspect @didrocks and @jibel faced this exact behavior (mix of both keys) during their tests.

Ah, I also sneaked a fix in the `#cloud-config` stenza. It's not been a problem in our tests because we always tested user-provided user-data as YAML (the WSL datasource merges both and rewrites the final raw userdata that is fed into the cloud-init pipeline). Should we put a shell script instead, we'd see that cloud-init wouldn't understand the part coming from `agent.yaml`.