### PR TITLE
fix(agent): Don't bail out if we cannot find a WSL adapter

### DIFF
--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -49,7 +49,8 @@ func (d Daemon) Serve(ctx context.Context, args ...Option) (err error) {
 
 	wslIP, err := getWslIP(ctx, args...)
 	if err != nil {
-		return fmt.Errorf("could not get the WSL adapter IP: %v", err)
+		log.Errorf(ctx, "could not get the WSL adapter IP: %v", err)
+		wslIP = net.IPv4(127, 0, 0, 1)
 	}
 
 	var cfg net.ListenConfig

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -168,11 +168,11 @@ func TestServeWSLIP(t *testing.T) {
 		"With a single Hyper-V Adapter": {withAdapters: daemontestutils.SingleHyperVAdapterInList},
 		"With mirrored networking mode": {netmode: "mirrored", withAdapters: daemontestutils.MultipleHyperVAdaptersInList},
 		"With no access to the system distro but net mode is the default (NAT)": {netmode: "error", withAdapters: daemontestutils.MultipleHyperVAdaptersInList},
-
-		"Error when the networking mode is unknown":        {netmode: "unknown", wantErr: true},
-		"Error when the list of adapters is empty":         {withAdapters: daemontestutils.EmptyList, wantErr: true},
-		"Error when there is no Hyper-V adapter the list":  {withAdapters: daemontestutils.NoHyperVAdapterInList, wantErr: true},
-		"Error when retrieving adapters information fails": {withAdapters: daemontestutils.MockError, wantErr: true},
+		// With the current patch those tests won't fail anymore.
+		"Error when the networking mode is unknown":        {netmode: "unknown"},
+		"Error when the list of adapters is empty":         {withAdapters: daemontestutils.EmptyList},
+		"Error when there is no Hyper-V adapter the list":  {withAdapters: daemontestutils.NoHyperVAdapterInList},
+		"Error when retrieving adapters information fails": {withAdapters: daemontestutils.MockError},
 	}
 
 	for name, tc := range testcases {

--- a/windows-agent/internal/daemon/networking.go
+++ b/windows-agent/internal/daemon/networking.go
@@ -80,7 +80,7 @@ func findWslAdapterIP(opts options) (net.IP, error) {
 		return node.ip(), nil
 	}
 
-	return nil, fmt.Errorf("could not find WSL adapter")
+	return nil, fmt.Errorf("could not find WSL adapter, check if there exists a WSL instance")
 }
 
 // networkingMode detects whether the WSL network is mirrored or not.


### PR DESCRIPTION
The UP4W background agent relies on the existence of the WSL net adapter and the distro instance to properly detect on which address it should serve.

Clean installs of Windows with recent versions of WSL won’t have any of those until the user creates the first WSL instance.

The `daemon` reports the error to find the address and the agent quickly exits.

We need to detect that situation and listen on localhost, so we have time to read Landscape information from registry (or talk to the GUI), so that we may end up creating WSL instances for the current user.
The current implementation won't never allow that, because the agent exits early if the WSL adapter address is not found.

There is a secondary issue to this: once an instance is created it won’t be able to talk to the agent if the networking mode is NAT (the current default), because `wsl-pro-service` expects the agent listening on the WSL adapter.  At least the provisioning tasks are delivered via cloud-init, thus independently of the communication to the agent, so that lack of communication won’t be an apparent issue and it solves itself when the agent restarts.

No user instance means no system distro and no WSL net adapter. Without this the agent will exit quickly and never have a chance to talk to Landscape to receive an install command.

---
