### PR TITLE
fix(agent): SHA256SUMS being looked up in the parent directory

### DIFF
--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -335,7 +335,7 @@ func download(ctx context.Context, f io.Writer, u *url.URL) (err error) {
 // ...
 func wantRootfsChecksum(ctx context.Context, u *url.URL) (string, error) {
 	imageName := filepath.Base(u.Path)
-	shasRelativeURL, err := url.Parse("../SHA256SUMS")
+	shasRelativeURL, err := url.Parse("SHA256SUMS")
 	if err != nil {
 		return "", fmt.Errorf("could not assemble SHA256SUMS location: %v", err)
 	}


### PR DESCRIPTION
We didn't notice this behaviour in tests because our mocked file server was serving files in the root directory (since the parent of / is / everything just worked).

Changing tests to serve and search files inside a subdirectory reveal the problem: we're not looking for the checksums file beside the rootfs but rather in the parent directory. We see log lines like below:

> time="2024-07-18T10:42:53-03:00" level=debug msg="Landscape: received command Install. Target: testDistro_UP4W_TestInstall_Error_when_the_checksum_entry_is_missing_for_the_rootfs_5721719220902747386"
> time="2024-07-18T10:42:53-03:00" level=info msg="checksums file http://127.0.0.1:57850/releases/SHA256SUM" not found"

---
UDENG-3669