### PR TITLE
docs: Make refs to config file extension more consistent with UI

### DIFF
--- a/docs/reference/landscape.md
+++ b/docs/reference/landscape.md
@@ -15,7 +15,7 @@ The latter offers advantages unique to Ubuntu WSL – the ability to create new 
 (ref::landscape-config)=
 ## Landscape configuration schema
 
-Both Landscape clients are configured via a single `.ini` file. This file is provided to the Windows host.
+Both Landscape clients are configured via a single, plain text configuration file (e.g., `landscape.conf` or `landscape.ini`). This file is provided to the Windows host.
 > See more: [How to configure UP4W for Ubuntu Pro and Landscape](howto::configure-up4w)
 
 The schema for this file is the same as Landscape for Ubuntu desktop or server, with a few additional keys specific to the WSL settings, which can be grouped into keys that affect just the Windows-side client and keys that affect both the Windows-side client and the Ubuntu WSL-side client(s). These additions are documented below.
@@ -23,6 +23,7 @@ The schema for this file is the same as Landscape for Ubuntu desktop or server, 
 > See more: [Landscape | Configure Ubuntu Pro for WSL for Landscape](https://ubuntu.com/landscape/docs/register-wsl-hosts-to-landscape/)
 
 Here is an example of what the configuration looks like:
+
 ```ini
 [host]
 url = landscape-server.domain.com:6554

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -118,7 +118,7 @@ You will then be shown the Landscape configuration screen.
 
 ![UP4W GUI main screen](./assets/up4w_gui.png)
 
-Create a new file in your home directory named `landscape.txt` and enter following contents.
+Create a new file in your home directory named `landscape.conf` and enter following contents.
 For the purpose of this tutorial, replace:
 
 <!-- QUERY: double check below in relation to landscape docs -->
@@ -144,7 +144,7 @@ explicitly reference a path to the SSL public key on a Windows host machine.
 For example, if you followed the [Landscape Quickstart](https://ubuntu.com/landscape/docs/quickstart-deployment)
 installation, the auto-generated self-signed certificate can be found at `/etc/ssl/certs/landscape_server.pem`.
 
-This can be copied to a Windows machine and referenced in `landscape.txt`:
+This can be copied to a Windows machine and referenced in `landscape.conf`:
 
   ssl_public_key = C:\Users\<YOUR_WINDOWS_USER_NAME>\landscape_server.pem
 
@@ -153,7 +153,7 @@ been registered in Landscape.
 ```
 
 Then input `<SERVER_URL>` in "Quick Setup" in the field labelled "Landscape FQDN".
-Alternatively, provide a path to `landscape.txt` in "Custom Configuration".
+Alternatively, provide a path to `landscape.conf` in "Custom Configuration".
 
 ![Loading Landscape custom config](./assets/loading-custom-landscape-config.png)
 


### PR DESCRIPTION
This PR makes references to the Landscape configuration file in the docs more consistent with the Ubuntu Pro For WSL UI, which includes a placeholder for `landscape.conf` during setup.

In `reference/landscape.md` it is now mentioned that this is a plain text file and that other extensions, such as `.ini` can also be used.

UDENG-3592