### PR TITLE
feat(gui): Landscape redesign to fit an input field for the SSL key

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -53,7 +53,7 @@
     "purchaseStatusServer":"Something went wrong with Microsoft Store. Please try again later.",
     "purchaseStatusUnknown": "Unknown error when trying to purchase the subscription. Consider restarting this app.",
 
-    "landscapeHeading": "You can manage your Ubuntu instances remotely with {landscapeLink}.",
+    "landscapeHeading": "You can manage your Ubuntu instances remotely with {landscapeLink}.\n\nConfigure the connection to Landscape:",
     "@landscapeHeading": {
         "placeholders": {
             "landscapeLink": {
@@ -61,21 +61,33 @@
             }
         }
     },
-    "landscapeQuickSetup": "Quick Setup (Recommended)",
-    "landscapeQuickSetupHint": "Provide your Landscape enrollment information",
+    "landscapeQuickSetupSaas": "Quick Setup (SaaS)",
+    "landscapeQuickSetupSaasHint": "Register with landscape.canonical.com",
+    "landscapeQuickSetupSelfHosted": "Quick Setup (Self-hosted)",
+    "landscapeQuickSetupSelfHostedHint": "Register with your own Landscape server",
     "landscapeFQDNLabel": "Landscape server address",
     "landscapeFQDNError": "Invalid URI. Format should be a hostname or IP address.",
     "landscapeAccountNameLabel": "Landscape Account Name",
     "landscapeAccountNameError": "Invalid account name",
     "landscapeKeyLabel": "Registration Key",
-    "landscapeCustomSetup": "Custom Configuration",
-    "landscapeCustomSetupHint": "Load a custom client configuration file",
+    "landscapeCustomSetup": "Advanced Configuration",
+    "landscapeCustomSetupHint": "Load a custom Landscape client configuration file",
     "landscapeFileLabel": "Config file path",
     "landscapeFileTooLarge": "Configuration file is too large",
-    "landscapeFileEmpty": "A path must be specified",
+    "landscapeFileEmptyPath": "A path must be specified",
+    "landscapeFileEmptyContents": "File must not be empty",
     "landscapeFileNotFound": "File not found",
+    "landscapeFileIsDir": "File cannot be a directory",
     "landscapeFilePicker": "Select file...",
     "landscapeConfigureButton": "Configure Landscape",
+    "landscapeApplyError": "Error when attempting to apply the config:\n\t{message}",
+    "@landscapeApplyError": {
+        "placeholders": {
+            "message" : {
+                "type": "String"
+            }
+        }
+    },
 
     "buttonNext": "Continue",
     "buttonSkip": "Skip",

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_model.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_model.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show ChangeNotifier;
+import 'package:flutter/foundation.dart' show ChangeNotifier, kDebugMode;
 import 'package:grpc/grpc.dart' show GrpcError;
 
 import '/core/agent_api_client.dart';
@@ -32,6 +32,9 @@ class LandscapeModel extends ChangeNotifier {
 
   /// The configuration form data for the SaaS configuration.
   final LandscapeSaasConfig saas = LandscapeSaasConfig();
+
+  // TODO: Remove this condition when Landscape SaaS starts supporting WSL.
+  bool get isSaaSSupported => kDebugMode;
 
   /// The configuration form data for the self-hosted configuration.
   final LandscapeSelfHostedConfig selfHosted = LandscapeSelfHostedConfig();

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -165,7 +165,8 @@ class LandscapeConfigForm extends StatelessWidget {
                         title: lang.landscapeQuickSetupSaas,
                         subtitle: lang.landscapeQuickSetupSaasHint,
                         groupValue: model.configType,
-                        onChanged: model.setConfigType,
+                        onChanged:
+                            model.isSaaSSupported ? model.setConfigType : null,
                       ),
                     ),
                     FocusTraversalOrder(
@@ -287,7 +288,7 @@ class _ConfigTypeRadio extends StatelessWidget {
   });
   final String title, subtitle;
   final LandscapeConfigType value, groupValue;
-  final Function(LandscapeConfigType?) onChanged;
+  final Function(LandscapeConfigType?)? onChanged;
 
   @override
   Widget build(BuildContext context) {

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -67,130 +67,6 @@ class Pro4WSLPage extends StatelessWidget {
   }
 }
 
-class ColumnLandingPage extends StatelessWidget {
-  const ColumnLandingPage({
-    super.key,
-    required this.leftChildren,
-    required this.children,
-    this.onNext,
-    this.onSkip,
-    this.onBack,
-    this.svgAsset = 'assets/Ubuntu-tag.svg',
-    this.title = 'Landscape',
-  });
-
-  final List<Widget> leftChildren;
-  final List<Widget> children;
-  final String svgAsset;
-  final String title;
-
-  final void Function()? onNext;
-  final void Function()? onSkip;
-  final void Function()? onBack;
-
-  @override
-  Widget build(BuildContext context) {
-    final lang = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-
-    return Pro4WSLPage(
-      body: Padding(
-        padding: const EdgeInsets.all(32.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            IntrinsicHeight(
-              child: Row(
-                children: [
-                  // Left column "header"
-                  Expanded(
-                    flex: 5,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        RichText(
-                          text: TextSpan(
-                            children: [
-                              WidgetSpan(
-                                child: SvgPicture.asset(
-                                  svgAsset,
-                                  height: 70,
-                                ),
-                              ),
-                              const WidgetSpan(
-                                child: SizedBox(
-                                  width: 8,
-                                ),
-                              ),
-                              TextSpan(
-                                text: title,
-                                style: theme.textTheme.displaySmall
-                                    ?.copyWith(fontWeight: FontWeight.w100),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const SizedBox(
-                          height: 24,
-                        ),
-                        ...leftChildren,
-                      ],
-                    ),
-                  ),
-                  // Divider
-                  const Expanded(
-                    flex: 1,
-                    child: VerticalDivider(
-                      thickness: 0.2,
-                      color: Colors.white,
-                    ),
-                  ),
-                  // Right column content
-                  Expanded(
-                    flex: 6,
-                    child: Column(
-                      children: [...children],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(
-              height: 16.0,
-            ),
-            // Navigation buttons
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                OutlinedButton(
-                  onPressed: onBack,
-                  child: Text(lang.buttonBack),
-                ),
-                Row(
-                  children: [
-                    FilledButton(
-                      onPressed: onSkip,
-                      child: Text(lang.buttonSkip),
-                    ),
-                    const SizedBox(
-                      width: 16.0,
-                    ),
-                    ElevatedButton(
-                      onPressed: onNext,
-                      child: Text(lang.buttonNext),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 // A more stylized page that mimics the design of the https://ubuntu.com/pro
 // landing page, with a dark background and an [svgAsset] logo followed by
 // a title with some opacity, rendering the [children] in a column layout.
@@ -213,7 +89,7 @@ class LandingPage extends StatelessWidget {
 
     return Pro4WSLPage(
       body: Padding(
-        padding: const EdgeInsets.all(48.0),
+        padding: const EdgeInsets.fromLTRB(32.0, 32.0, 32.0, 8.0),
         child: centered
             ? Center(
                 child: ConstrainedBox(
@@ -284,7 +160,7 @@ class _PageContent extends StatelessWidget {
           ),
         ),
         const SizedBox(
-          height: 24,
+          height: 12,
         ),
         ...children,
       ],

--- a/gui/packages/ubuntupro/test/pages/landscape/landscape_data_model_test.dart
+++ b/gui/packages/ubuntupro/test/pages/landscape/landscape_data_model_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ubuntupro/pages/landscape/landscape_model.dart';
+
+void main() {
+  group('saas data model', () {
+    final testcases = {
+      'success': (
+        account: 'test',
+        wantError: isFalse,
+        wantComplete: isTrue,
+        wantConfig: contains('landscape.canonical.com')
+      ),
+      'with empty account': (
+        account: '',
+        wantError: isFalse,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with account standalone': (
+        account: 'standalone',
+        wantError: isTrue,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+    };
+    for (final MapEntry(key: name, value: tc) in testcases.entries) {
+      test(name, () {
+        final c = LandscapeSaasConfig();
+        c.accountName = tc.account;
+        expect(c.accountNameError, tc.wantError);
+        expect(c.isComplete, tc.wantComplete);
+        expect(c.config(), tc.wantConfig);
+      });
+    }
+  });
+  group('self-hosted data model', () {
+    const testUrl = 'test.landscape.company.com';
+    final testcases = {
+      'success': (
+        url: testUrl,
+        certPath: '',
+        wantFqdnError: isFalse,
+        wantFileError: FileError.none,
+        wantComplete: isTrue,
+        wantConfig: contains(testUrl)
+      ),
+      'with SaaS URL': (
+        url: saasURL,
+        certPath: '',
+        wantFqdnError: isTrue,
+        wantFileError: FileError.none,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with SaaS hostname': (
+        url: Uri.parse(saasURL).host,
+        certPath: '',
+        wantFqdnError: isTrue,
+        wantFileError: FileError.none,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with ssl key path as dir': (
+        url: testUrl,
+        // the directory that contains the test sources.
+        certPath: './test',
+        wantFqdnError: isFalse,
+        wantFileError: FileError.dir,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with ssl key changing into empty path': (
+        url: testUrl,
+        // Magic value to make the test case apply a good path first, then an empty path.
+        certPath: '-',
+        wantFqdnError: isFalse,
+        // SSL key path is an optional entry.
+        wantFileError: FileError.none,
+        wantComplete: isTrue,
+        wantConfig: contains(testUrl),
+      ),
+      'with ssl key file empty': (
+        url: testUrl,
+        certPath: './test/testdata/landscape/empty.txt',
+        wantFqdnError: isFalse,
+        wantFileError: FileError.emptyFile,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with ssl key not found': (
+        url: testUrl,
+        certPath: notFoundPath,
+        wantFqdnError: isFalse,
+        wantFileError: FileError.notFound,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+    };
+    for (final MapEntry(key: name, value: tc) in testcases.entries) {
+      test(name, () {
+        final c = LandscapeSelfHostedConfig();
+        c.fqdn = tc.url;
+
+        // Dart records can't be modified, so we need a proxy variable.
+        var path = tc.certPath;
+        if (tc.certPath == '-') {
+          // Apply a good path first.
+          c.sslKeyPath = customConf;
+          path = '';
+        }
+        c.sslKeyPath = path;
+
+        expect(c.fqdnError, tc.wantFqdnError);
+        expect(c.fileError, tc.wantFileError);
+        expect(c.isComplete, tc.wantComplete);
+        expect(c.config(), tc.wantConfig);
+      });
+    }
+  });
+  group('custom data model', () {
+    final testcases = {
+      'success': (
+        path: customConf,
+        wantFileError: FileError.none,
+        wantComplete: isTrue,
+        wantConfig: contains('some.url.com'),
+      ),
+      'with config file not found': (
+        path: notFoundPath,
+        wantFileError: FileError.notFound,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with empty path': (
+        path: '',
+        wantFileError: FileError.emptyPath,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with empty config file': (
+        path: './test/testdata/landscape/empty.txt',
+        wantFileError: FileError.emptyFile,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with config file too large': (
+        // a big file (1.5 MB) always present when running tests.
+        path: './build/unit_test_assets/fonts/MaterialIcons-Regular.otf',
+        wantFileError: FileError.tooLarge,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+      'with config file as dir': (
+        // a big file (1.5 MB) always present when running tests.
+        path: './test/',
+        wantFileError: FileError.dir,
+        wantComplete: isFalse,
+        wantConfig: isNull
+      ),
+    };
+
+    for (final MapEntry(key: name, value: tc) in testcases.entries) {
+      test(name, () async {
+        final c = LandscapeCustomConfig();
+        if (tc.path.isEmpty) {
+          // Applying an empty path is only a problem if a previous value was not empty,
+          // otherwise the UI would show error messages from start.
+          c.configPath = customConf;
+        }
+        c.configPath = tc.path;
+        expect(c.fileError, tc.wantFileError);
+        expect(c.isComplete, tc.wantComplete);
+        expect(c.config(), tc.wantConfig);
+      });
+    }
+  });
+}
+
+const saasURL = 'https://landscape.canonical.com';
+const customConf = './test/testdata/landscape/custom.conf';
+const notFoundPath = './test/testdata/landscape/notfound.txt';

--- a/gui/packages/ubuntupro/test/pages/landscape/landscape_model_test.dart
+++ b/gui/packages/ubuntupro/test/pages/landscape/landscape_model_test.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:agentapi/agentapi.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:grpc/grpc.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntupro/core/agent_api_client.dart';
@@ -11,119 +10,170 @@ import 'landscape_model_test.mocks.dart';
 
 @GenerateMocks([AgentApiClient])
 void main() {
-  group('landscape config', () {
+  group('state management', () {
     final client = MockAgentApiClient();
-    final tempDir = Directory.systemTemp.createTempSync();
-    const tempFileName = 'Pro4WSLLandscapePageTEMP.conf';
-    final tempFilePath = '${tempDir.path}/$tempFileName';
+    test('active', () {
+      final model = LandscapeModel(client);
+      expect(model.configType, LandscapeConfigType.selfHosted);
 
-    tearDownAll(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
+      for (final type in LandscapeConfigType.values) {
+        model.setConfigType(type);
+        expect(model.configType, type);
       }
     });
 
-    test('default Landscape configuration', () {
+    test('notify changes', () {
+      // Verifies that all set* methods notify listeners.
+
       final model = LandscapeModel(client);
-      expect(model.fqdn, '');
-      expect(model.accountName, '');
-      expect(model.key, '');
-      expect(model.path, '');
+      var notified = false;
+      model.addListener(() {
+        notified = true;
+      });
+
+      model.setConfigType(LandscapeConfigType.custom);
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setCustomConfigPath(customConf);
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setConfigType(LandscapeConfigType.saas);
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setAccountName('testuser');
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setSaasRegistrationKey('123');
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setConfigType(LandscapeConfigType.selfHosted);
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setFqdn(testFqdn);
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setSelfHostedRegistrationKey('123');
+      expect(notified, isTrue);
+      notified = false;
+
+      model.setSslKeyPath(customConf);
+      expect(notified, isTrue);
+      notified = false;
     });
 
-    test('no errors by default', () {
+    test('assertions', () {
+      // Verifies that methods throw assertions when called under non-relevant scenarios.
+
       final model = LandscapeModel(client);
-      expect(model.fqdnError, isFalse);
-      expect(model.fileError, FileError.none);
-      expect(model.receivedInput, isFalse);
-      expect(model.hasError, isTrue);
-    });
 
-    test('valid FQDN', () {
+      model.setConfigType(LandscapeConfigType.saas);
+      // Those assertions exist because the methods are not relevant for the current config type.
+      // Allowing those conditions to proceed could contribute to hide logic errors.
+      expect(() => model.setCustomConfigPath(customConf), throwsAssertionError);
+      expect(() => model.setFqdn(testFqdn), throwsAssertionError);
+      expect(() => model.setSslKeyPath(customConf), throwsAssertionError);
+      expect(
+        () => model.setSelfHostedRegistrationKey('123'),
+        throwsAssertionError,
+      );
+      expect(() => model.setCustomConfigPath(customConf), throwsAssertionError);
+
+      model.setConfigType(LandscapeConfigType.selfHosted);
+      expect(() => model.setAccountName('testuser'), throwsAssertionError);
+      expect(() => model.setSaasRegistrationKey('123'), throwsAssertionError);
+      expect(() => model.setCustomConfigPath(customConf), throwsAssertionError);
+
+      model.setConfigType(LandscapeConfigType.custom);
+      expect(() => model.setAccountName('testuser'), throwsAssertionError);
+      expect(() => model.setSaasRegistrationKey('123'), throwsAssertionError);
+      expect(() => model.setFqdn(testFqdn), throwsAssertionError);
+      expect(
+        () => model.setSelfHostedRegistrationKey('123'),
+        throwsAssertionError,
+      );
+      expect(() => model.setSslKeyPath(customConf), throwsAssertionError);
+    });
+  });
+
+  group('apply config', () {
+    const msg = 'test message';
+    const error = GrpcError.custom(StatusCode.unavailable, msg);
+    test('saas', () async {
+      final client = MockAgentApiClient();
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => throw error,
+      );
       final model = LandscapeModel(client);
-      model.fqdn = 'example.com';
-      expect(model.validateFQDN(), isTrue);
-      expect(model.fqdnError, isFalse);
-      expect(model.fqdn, 'https://example.com');
-      model.fqdn = 'https://anotherexample.com';
-      expect(model.validateFQDN(), isTrue);
-      expect(model.fqdnError, isFalse);
-      expect(model.fqdn, 'https://anotherexample.com');
-    });
 
-    test('invalid fqdn', () {
+      model.setConfigType(LandscapeConfigType.saas);
+      expect(model.applyConfig, throwsAssertionError);
+
+      model.setAccountName('testaccount');
+      var err = await model.applyConfig();
+      expect(err, msg);
+
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => LandscapeSource()..ensureUser(),
+      );
+
+      model.setAccountName('testaccount');
+      err = await model.applyConfig();
+      expect(err, isNull);
+    });
+    test('self-hosted', () async {
+      final client = MockAgentApiClient();
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => throw error,
+      );
       final model = LandscapeModel(client);
-      model.fqdn = '::';
-      expect(model.validateFQDN(), isFalse);
-      expect(model.fqdnError, isTrue);
-    });
 
-    test('valid path', () async {
+      model.setConfigType(LandscapeConfigType.selfHosted);
+      expect(model.applyConfig, throwsAssertionError);
+
+      model.setFqdn(testFqdn);
+      var err = await model.applyConfig();
+      expect(err, msg);
+
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => LandscapeSource()..ensureUser(),
+      );
+
+      model.setFqdn(testFqdn);
+      err = await model.applyConfig();
+      expect(err, isNull);
+    });
+    test('custom', () async {
+      final client = MockAgentApiClient();
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => throw error,
+      );
       final model = LandscapeModel(client);
-      final tempFile = File(tempFilePath);
-      await tempFile.writeAsString('');
-      model.path = tempFile.path;
-      expect(model.validatePath(), isTrue);
-      expect(model.fileError, FileError.none);
-      await tempFile.delete();
-    });
 
-    test('invalid path', () async {
-      final model = LandscapeModel(client);
-      final tempFile = File(tempFilePath);
-      model.path = tempFile.path;
-      expect(model.validatePath(), isFalse);
-      expect(model.fileError, FileError.notFound);
+      model.setConfigType(LandscapeConfigType.custom);
+      expect(model.applyConfig, throwsAssertionError);
 
-      model.path = tempFile.path;
-      await tempFile.writeAsString('.' * (1024 * 1024 + 1));
-      expect(model.validatePath(), isFalse);
-      expect(model.fileError, FileError.tooLarge);
+      model.setCustomConfigPath(customConf);
+      var err = await model.applyConfig();
+      expect(err, msg);
 
-      model.path = '';
-      expect(model.validatePath(), isFalse);
-      expect(model.fileError, FileError.empty);
-    });
+      when(client.applyLandscapeConfig(any)).thenAnswer(
+        (_) async => LandscapeSource()..ensureUser(),
+      );
 
-    test('valid config', () async {
-      final model = LandscapeModel(client);
-      model.selected = LandscapeConfigType.manual;
-      model.fqdn = 'example.com';
-      expect(model.validConfig(), isTrue);
-
-      model.selected = LandscapeConfigType.file;
-      expect(model.validConfig(), isFalse);
-      final tempFile = File(tempFilePath);
-      await tempFile.writeAsString('');
-      model.path = tempFile.path;
-      expect(model.validConfig(), isTrue);
-
-      model.fqdn = '';
-      expect(model.validConfig(), isTrue);
-
-      model.selected = LandscapeConfigType.manual;
-      expect(model.validConfig(), isFalse);
-    });
-
-    test('valid apply', () async {
-      when(client.applyLandscapeConfig(any))
-          .thenAnswer((_) async => LandscapeSource()..ensureUser());
-      //when(client.applyProToken(any)).thenAnswer((_) async => SubscriptionInfo()..ensureUser());
-      var model = LandscapeModel(client);
-      model.fqdn = 'example.com';
-      expect(await model.applyConfig(), isTrue);
-
-      model = LandscapeModel(client);
-      model.selected = LandscapeConfigType.file;
-      final tempFile = File(tempFilePath);
-      await tempFile.writeAsString('');
-      model.path = tempFile.path;
-      expect(await model.applyConfig(), isTrue);
-    });
-
-    test('invalid apply', () async {
-      final model = LandscapeModel(client);
-      expect(await model.applyConfig(), isFalse);
+      model.setCustomConfigPath(customConf);
+      err = await model.applyConfig();
+      expect(err, isNull);
     });
   });
 }
+
+const customConf = './test/testdata/landscape/custom.conf';
+const saasURL = 'https://landscape.canonical.com';
+const testFqdn = 'test.landscape.company.com';

--- a/gui/packages/ubuntupro/test/testdata/landscape/custom.conf
+++ b/gui/packages/ubuntupro/test/testdata/landscape/custom.conf
@@ -1,0 +1,13 @@
+[host]
+url = some.url.com
+
+[client]
+log_level = debug
+account_name = test
+ping_url = https://some.url.com/ping
+registration_key = ""
+tags = wsl
+url = https://some.url.com/message-system
+ssl_public_key = "C:\\Users\\user\\Desktop\\ssl\\public.pem"
+include_manager_plugins = ScriptExecution
+script_users = ALL


### PR DESCRIPTION
Adding one single field motivated a whole UI redesign. The discussion and thought process is documented in #802 .

The key pilar to understand this PR is: we no longer show relationship between the form fields being displayed, but rather separate them into subforms so the fields that are visible are the ones relevant to the type of configuration the user is currently doing.

[This comment in #802](https://github.com/canonical/ubuntu-pro-for-wsl/issues/802#issuecomment-2237200764) summarizes what I mean by inter-field relationship, non-trivial logic that would disable or enable or change the forbidden values of a form field depending on the values of neighbour fields. The previous logic was at the limit of being fine because the form was small, adding just one extra field was enough to turn it complex enough to justify a redesign.

We now present those types of configuration as three distinct subforms: the Landscape SaaS, self-hosted Landscape and an "advanced configuration" through which the user can supply a custom Landscape client configuration file. That way input validation is much clearer now and there is no interleaved logic causing form fields to be visible in a disabled state. The end result is a clearer UX.

The backing validation logic is split in subclasses mirroring the UI split in subforms.

The design is more horizontal now, the left side of the UI is havier on static text while the right side is more interactive.

Because of the way the widgets were composed to achieve this layout, an extra care was required to achieve a coherent tab navigation.

Before (good enough logic, tab navigation just worked):


https://github.com/user-attachments/assets/6886e8b6-5f7d-4e3e-826d-45e86f897a66



After (smaller and more focused subforms, no interleaving logic, tab navigation works with a little more effort):


https://github.com/user-attachments/assets/e001c436-fa70-49ae-a09b-7e463afb919d

