### PR TITLE
fix(gui): SSL public key hint must have a certificate file extension

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -72,6 +72,7 @@
     "landscapeKeyLabel": "Registration Key",
     "landscapeCustomSetup": "Advanced Configuration",
     "landscapeCustomSetupHint": "Load a custom Landscape client configuration file",
+    "landscapeSSLKeyLabel": "Server SSL public key",
     "landscapeFileLabel": "Config file path",
     "landscapeFileTooLarge": "Configuration file is too large",
     "landscapeFileEmptyPath": "A path must be specified",

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -379,7 +379,7 @@ class _SelfHostedForm extends StatelessWidget {
             buttonLabel: lang.landscapeFilePicker,
             errorText: model.selfHosted.fileError.localize(lang),
             hint: 'C:\\landscape.conf',
-            inputlabel: 'Server SSL public key',
+            inputlabel: lang.landscapeSSLKeyLabel,
             onChanged: model.setSslKeyPath,
           ),
         ),

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -378,7 +378,7 @@ class _SelfHostedForm extends StatelessWidget {
           child: _FilePickerField(
             buttonLabel: lang.landscapeFilePicker,
             errorText: model.selfHosted.fileError.localize(lang),
-            hint: 'C:\\landscape.conf',
+            hint: 'C:\\landscape.pem',
             inputlabel: lang.landscapeSSLKeyLabel,
             onChanged: model.setSslKeyPath,
           ),


### PR DESCRIPTION
Thanks @edibotopic for noticing that :)

Additional to that fix. the first commit of this PR moves a user-facing string (SSL Key input label) from the source code to the translatable resource, so it can be properly localized.