### PR TITLE
fix(wsl-pro-service): Do not translate empty paths

### DIFF
--- a/wsl-pro-service/internal/system/landscape.go
+++ b/wsl-pro-service/internal/system/landscape.go
@@ -170,6 +170,11 @@ func overrideSSLCertificate(ctx context.Context, s *System, section *ini.Section
 
 	pathWindows := k.String()
 
+	if len(pathWindows) == 0 {
+		// Empty paths are translated by wslpath as the current working directory, which is not what we want.
+		return nil
+	}
+
 	cmd := s.backend.WslpathExecutable(ctx, "-ua", pathWindows)
 	out, err := runCommand(cmd)
 	if err != nil {

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -199,12 +199,13 @@ func TestUserProfileDir(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		cachedCmdExe      bool
-		cmdExeNotExist    bool
-		cmdExeErr         bool
-		wslpathErr        bool
-		wslpathBadOutput  bool
-		overrideProcMount bool
+		cachedCmdExe           bool
+		cmdExeNotExist         bool
+		cmdExeErr              bool
+		emptyUserprofileEnvVar bool
+		wslpathErr             bool
+		wslpathBadOutput       bool
+		overrideProcMount      bool
 
 		wantErr bool
 	}{
@@ -218,6 +219,7 @@ func TestUserProfileDir(t *testing.T) {
 		"Error finding cmd.exe because there is no Windows FS in /proc/mounts": {wantErr: true, overrideProcMount: true},
 		"Error when cmd.exe does not exist":                                    {cmdExeNotExist: true, overrideProcMount: true, wantErr: true},
 		"Error on cmd.exe error":                                               {cmdExeErr: true, wantErr: true},
+		"Error when UserProfile env var is empty":                              {emptyUserprofileEnvVar: true, wantErr: true},
 		"Error on wslpath error":                                               {wslpathErr: true, wantErr: true},
 		"Error when wslpath returns a bad path":                                {wslpathBadOutput: true, wantErr: true},
 	}
@@ -229,6 +231,9 @@ func TestUserProfileDir(t *testing.T) {
 			system, mock := testutils.MockSystem(t)
 			if tc.cmdExeErr {
 				mock.SetControlArg(testutils.CmdExeErr)
+			}
+			if tc.emptyUserprofileEnvVar {
+				mock.SetControlArg(testutils.EmptyUserprofileEnvVar)
 			}
 			if tc.wslpathErr {
 				mock.SetControlArg(testutils.WslpathErr)
@@ -251,7 +256,7 @@ func TestUserProfileDir(t *testing.T) {
 
 			got, err := system.UserProfileDir(context.Background())
 			if tc.wantErr {
-				require.Error(t, err, "Expected UserProfile to return an error")
+				require.Error(t, err, "Expected UserProfile to return an error, but returned %s intead", got)
 				return
 			}
 			require.NoError(t, err, "Expected UserProfile to return no errors")

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -669,6 +669,7 @@ func TestEnsureValidLandscapeConfig(t *testing.T) {
 		"Appends any required fields - no ssl":                      {systemLandscapeConfigFile: "minimal.conf"},
 		"Transform Windows SSL certificate path":                    {systemLandscapeConfigFile: "windows_ssl_only.conf"},
 		"Transform Windows SSL certificate path with forward slash": {systemLandscapeConfigFile: "windows_ssl_only_forward_slash.conf"},
+		"Do not transform Windows SSL certificate empty path":       {systemLandscapeConfigFile: "windows_ssl_empty.conf", wantNoLandscapeConfigCmd: true},
 		"Refresh computer_title if changed":                         {systemLandscapeConfigFile: "old_computer_title.conf"},
 
 		"Regular with additional keys":            {systemLandscapeConfigFile: "regular.conf"},

--- a/wsl-pro-service/internal/system/testdata/TestEnsureValidLandscapeConfig/golden/do_not_transform_windows_ssl_certificate_empty_path
+++ b/wsl-pro-service/internal/system/testdata/TestEnsureValidLandscapeConfig/golden/do_not_transform_windows_ssl_certificate_empty_path
@@ -1,0 +1,4 @@
+[client]
+hostagent_uid  = landscapeUID1234
+ssl_public_key = 
+computer_title = TEST_DISTRO

--- a/wsl-pro-service/internal/system/testdata/landscape.conf.d/windows_ssl_empty.conf
+++ b/wsl-pro-service/internal/system/testdata/landscape.conf.d/windows_ssl_empty.conf
@@ -1,0 +1,4 @@
+[client]
+hostagent_uid  = landscapeUID1234
+ssl_public_key = 
+computer_title = TEST_DISTRO

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -86,8 +86,9 @@ const (
 	LandscapeEnableErr  = "UP4W_LANDSCAPE_ENABLE_ERR"
 	LandscapeDisableErr = "UP4W_LANDSCAPE_DISABLE_ERR"
 
-	WslpathErr       = "UP4W_WSLPATH_ERR"
-	WslpathBadOutput = "UP4W_WSLPATH_BAD_OUTPUT"
+	WslpathErr             = "UP4W_WSLPATH_ERR"
+	WslpathBadOutput       = "UP4W_WSLPATH_BAD_OUTPUT"
+	EmptyUserprofileEnvVar = "UP4W_EMPTY_USERPROFILE_ENV_VAR"
 
 	CmdExeErr = "UP4W_CMDEXE_ERR"
 
@@ -608,13 +609,17 @@ func CmdExeMock(t *testing.T) {
 			return exitBadUsage
 		}
 
-		if argv[1] != "echo %UserProfile%" {
+		if argv[1] != "echo.%UserProfile%" {
 			fmt.Fprintf(os.Stderr, "Mock not implemented for args %q\n", argv)
 			return exitBadUsage
 		}
 
 		if envExists(CmdExeErr) {
 			return exitError
+		}
+		if envExists(EmptyUserprofileEnvVar) {
+			fmt.Print("\r\n")
+			return exitOk
 		}
 
 		fmt.Fprintln(os.Stdout, windowsUserProfileDir)

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -511,12 +511,18 @@ func WslPathMock(t *testing.T) {
 			if envExists(WslpathErr) {
 				return exitError
 			}
+			// That's what wslpath returns when it's called with -ua followed by an empty string.
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Could not get current working directory: %v", err)
+			}
 
 			stdout, ok := map[string]string{
 				windowsUserProfileDir:                   linuxUserProfileDir,
 				`D:\Users\TestUser\certificate`:         filepath.Join(defaultWindowsMount, "Users/TestUser/certificate"),
 				`D:/Users/TestUser/certificate`:         filepath.Join(defaultWindowsMount, "Users/TestUser/certificate"),
 				`/idempotent/path/to/linux/certificate`: `/idempotent/path/to/linux/certificate`,
+				``:                                      cwd,
 			}[argv[1]]
 
 			if !ok {

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -521,9 +521,9 @@ func WslPathMock(t *testing.T) {
 			stdout, ok := map[string]string{
 				windowsUserProfileDir:                   linuxUserProfileDir,
 				`D:\Users\TestUser\certificate`:         filepath.Join(defaultWindowsMount, "Users/TestUser/certificate"),
-				`D:/Users/TestUser/certificate`:         filepath.Join(defaultWindowsMount, "Users/TestUser/certificate"),
-				`/idempotent/path/to/linux/certificate`: `/idempotent/path/to/linux/certificate`,
-				``:                                      cwd,
+				"D:/Users/TestUser/certificate":         filepath.Join(defaultWindowsMount, "Users/TestUser/certificate"),
+				"/idempotent/path/to/linux/certificate": "/idempotent/path/to/linux/certificate",
+				"":                                      cwd,
 			}[argv[1]]
 
 			if !ok {


### PR DESCRIPTION
I wanted this PR to be laser-focus, just a bugfix, thus I'm not refactoring the executable-mocking just yet.

The issue is: when we invoke `wslpath -au ''`  we get the absolute path of the current working directory.
That's surely not what we expect of a Windows path.

It could be problematic if the user passes a custom Landscape config file containing this line `ssl_public_key= `, as we'd modify the final client.conf into `ssl_public_key = /` (systemd makes it so our current working directory is `/`). Landscape client would tolerate the empty value in the INI sintax, but this would force it to try to read `/` as a certificate file. Clearly not what we want.

A similar thing could happen in `system.UserProfileDir()`, but that's even funnier. Having %USERPROFILE% set to an empty string is indeed an odd edge case, so I'm not 100% sure the added code is worth it, as we're likely to err out attempting to open inexistant directories. I think it worths it because we are sure on how we err out. Leaving as it was could lead us into reading files we were not supposed to.

They issues were:

`echo %USERPROFILE%` would output `ECHO is on` if that environment variable is empty. We fix it by running `echo.%USERPROFILE%` instead. It outputs an empty line for that case. Finally, if the output is empty, we bail out.

![image](https://github.com/user-attachments/assets/1fceae7f-3985-4148-b6e5-60a014068621)

I made some modifications in the wslpath and cmd.exe mocks to get closer to the surprising behavior, so I could add test cases 
demonstrating the surprising behavior.

---
Closes UDENG-3788
