### PR TITLE
docs: Update vale config to get vocab dependency

### DIFF
--- a/docs/.sphinx/get_vale_conf.py
+++ b/docs/.sphinx/get_vale_conf.py
@@ -20,6 +20,19 @@ def main():
         file.write(download.text)
         file.close()
 
+    if os.path.exists(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical"):
+        print("Vocab directory exists")
+    else:
+        os.makedirs(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical")
+    
+    url = "https://api.github.com/repos/canonical/praecepta/contents/styles/config/vocabularies/Canonical"
+    r = requests.get(url)
+    for item in r.json():
+        download = requests.get(item["download_url"])
+        file = open(".sphinx/styles/config/vocabularies/Canonical/" + item["name"], "w")
+        file.write(download.text)
+        file.close()
+
     config = requests.get("https://raw.githubusercontent.com/canonical/praecepta/main/vale.ini")
     file = open(".sphinx/vale.ini", "w")
     file.write(config.text)


### PR DESCRIPTION
This updates the configuration settings for the [Vale](https://vale.sh/) linter, based on recent changes to the docs Starter Pack.

The linter now works as expected. Running checks on a specific file can be done as follows:

`make vale TARGET=tutorial/getting-started.md`

This prints a list of errors, suggestions and warnings relating to documentation style, such as:

` 162:1   warning     Avoid inline comments in codeblocks   Canonical.016-No-inline-comments`

UDENG-3785