### PR TITLE
fix(gui): Slicker Landscape config page

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -53,7 +53,7 @@
     "purchaseStatusServer":"Something went wrong with Microsoft Store. Please try again later.",
     "purchaseStatusUnknown": "Unknown error when trying to purchase the subscription. Consider restarting this app.",
 
-    "landscapeHeading": "You can manage your Ubuntu instances remotely with {landscapeLink}.\n\nConfigure the connection to Landscape:",
+    "landscapeHeading": "Configure the connection to {landscapeLink} to manage your Ubuntu WSL instances remotely.",
     "@landscapeHeading": {
         "placeholders": {
             "landscapeLink": {
@@ -61,9 +61,9 @@
             }
         }
     },
-    "landscapeQuickSetupSaas": "Quick Setup (SaaS)",
+    "landscapeQuickSetupSaas": "Landscape SaaS configuration",
     "landscapeQuickSetupSaasHint": "Register with landscape.canonical.com",
-    "landscapeQuickSetupSelfHosted": "Quick Setup (Self-hosted)",
+    "landscapeQuickSetupSelfHosted": "Self-hosted Landscape configuration",
     "landscapeQuickSetupSelfHostedHint": "Register with your own Landscape server",
     "landscapeFQDNLabel": "Landscape server address",
     "landscapeFQDNError": "Invalid URI. Format should be a hostname or IP address.",

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -141,7 +141,7 @@ class LandscapeConfigForm extends StatelessWidget {
     final lang = AppLocalizations.of(context);
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: _kHeight),
+      padding: const EdgeInsets.symmetric(vertical: 2 * _kHeight),
       // The FocusTraversalGroup is necessary to keep the tab navigation order wed expect:
       // We ping-pong between the radio buttons and the form fields that belong to the selected radio button,
       // by assigning odd NumericFocusOrder() values to the radio buttons (on the left) and even values to the form fields,

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -158,17 +158,17 @@ class LandscapeConfigForm extends StatelessWidget {
               Flexible(
                 child: Column(
                   children: [
-                    FocusTraversalOrder(
-                      order: const NumericFocusOrder(0),
-                      child: _ConfigTypeRadio(
-                        value: LandscapeConfigType.saas,
-                        title: lang.landscapeQuickSetupSaas,
-                        subtitle: lang.landscapeQuickSetupSaasHint,
-                        groupValue: model.configType,
-                        onChanged:
-                            model.isSaaSSupported ? model.setConfigType : null,
+                    if (model.isSaaSSupported)
+                      FocusTraversalOrder(
+                        order: const NumericFocusOrder(0),
+                        child: _ConfigTypeRadio(
+                          value: LandscapeConfigType.saas,
+                          title: lang.landscapeQuickSetupSaas,
+                          subtitle: lang.landscapeQuickSetupSaasHint,
+                          groupValue: model.configType,
+                          onChanged: model.setConfigType,
+                        ),
                       ),
-                    ),
                     FocusTraversalOrder(
                       order: const NumericFocusOrder(2),
                       child: _ConfigTypeRadio(


### PR DESCRIPTION
This hides the Landscape config option (instead of disabling it). No changes in behaviour nor in how we decide to hide it.
Some strings were changed also per guidance provided in #861. 
Finally I added a little bit more spacing in the top now that the subtitle is one line only.

Here's how it looks like when compiled in release mode.

![image](https://github.com/user-attachments/assets/f9bb98aa-b544-44a2-82d2-6d5da2b186e0)

Closes #861 

---

I'm purposefully basing this PR on top of #873 so I can stress CI to exercise the changes therein introduced. There is no dependency between the two tasks.

---
UDENG-3818