### PR TITLE
fix(gui): Remove spaces from the Pro token input field

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -1,5 +1,6 @@
 import 'package:dart_either/dart_either.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:yaru/yaru.dart';
 import '../../core/either_value_notifier.dart';
@@ -78,6 +79,10 @@ class _ProTokenInputFieldState extends State<ProTokenInputField> {
           children: [
             Expanded(
               child: TextField(
+                inputFormatters: [
+                  // This ignores all sorts of (Unicode) whitespaces (not only at the ends).
+                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                ],
                 autofocus: false,
                 controller: _controller,
                 decoration: InputDecoration(

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_widgets_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_widgets_test.dart
@@ -141,6 +141,24 @@ void main() {
             tester.firstWidget<ElevatedButton>(find.byType(ElevatedButton));
         expect(button.enabled, isTrue);
       });
+      testWidgets('good token with spaces', (tester) async {
+        await tester.pumpWidget(theApp);
+        final inputField = find.byType(TextField);
+
+        await tester.enterText(
+          inputField,
+          // good token plus a bunch of types of white spaces.
+          ' ${tks.good} \u{00A0}\u{2000}\u{2002}\u{202F}\u{205F}\u{3000} ',
+        );
+        await tester.pump();
+
+        final input = tester.firstWidget<TextField>(inputField);
+        expect(input.decoration!.errorText, isNull);
+
+        final button =
+            tester.firstWidget<ElevatedButton>(find.byType(ElevatedButton));
+        expect(button.enabled, isTrue);
+      });
     });
     testWidgets('apply', (tester) async {
       var called = false;


### PR DESCRIPTION
Sometimes copy-pasting a pro token comes with trailing spaces. Neither leading, trailing or even middle spaces are alloweable in a token. This PR leverages Flutter builtin mechanisms to filter input supplied to the token text field such that any kind of whitespaces (not only the ASCII ones) are discarded before any further processing.

Closes #857 

---

I'm purposefully basing this PR on top of #873 so I can stress CI to exercise the changes therein introduced. There is no dependency between the two tasks.

---
UDENG-3810