### PR TITLE
fix: golangci-lint warnings about unsafe integer conversions

### DIFF
--- a/storeapi/go-wrapper/microsoftstore/errors.go
+++ b/storeapi/go-wrapper/microsoftstore/errors.go
@@ -2,7 +2,7 @@
 package microsoftstore
 
 // StoreAPIError are the error constants in the store api.
-type StoreAPIError int
+type StoreAPIError int64
 
 // Keep up-to-date with `storeapi\base\Exception.hpp`.
 const (
@@ -26,7 +26,7 @@ const (
 )
 
 // NewStoreAPIError creates StoreAPIError from the result of a call to the storeAPI DLL.
-func NewStoreAPIError(hresult uintptr) error {
+func NewStoreAPIError(hresult int64) error {
 	if err := StoreAPIError(hresult); err < ErrSuccess {
 		return err
 	}

--- a/storeapi/go-wrapper/microsoftstore/export_test.go
+++ b/storeapi/go-wrapper/microsoftstore/export_test.go
@@ -2,3 +2,6 @@ package microsoftstore
 
 // FindWorkspaceRoot climbs up the current working directory until the Go workspace root is found.
 var FindWorkspaceRoot = findWorkspaceRoot
+
+// CheckError inspects the values of hres and err to determine what kind of error we have, if any, according to the rules of syscall/dll_windows.go.
+var CheckError = checkError

--- a/storeapi/go-wrapper/microsoftstore/store.go
+++ b/storeapi/go-wrapper/microsoftstore/store.go
@@ -2,8 +2,10 @@ package microsoftstore
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // findWorkspaceRoot climbs up the current working directory until the Go workspace root is found.
@@ -25,4 +27,30 @@ func findWorkspaceRoot() (string, error) {
 			return parent, nil
 		}
 	}
+}
+
+// checkError inspects the values of hres and err to determine what kind of error we have, if any, according to the rules of syscall/dll_windows.go.
+func checkError(hres int64, err error) (int64, error) {
+	// From syscall/dll_windows.go (*Proc).Call doc:
+	// > Callers must inspect the primary return value to decide whether an
+	//   error occurred [...] before consulting the error.
+	if e := NewStoreAPIError(hres); e != nil {
+		return hres, fmt.Errorf("storeApi returned error code %d: %w", hres, e)
+	}
+
+	if err == nil {
+		return hres, nil
+	}
+
+	var target syscall.Errno
+	if b := errors.As(err, &target); !b {
+		// Supposedly unrechable: proc.Call must always return a syscall.Errno
+		return hres, err
+	}
+
+	if target != syscall.Errno(0) {
+		return hres, fmt.Errorf("failed syscall to storeApi: %v (syscall errno %d)", target, err)
+	}
+
+	return hres, nil
 }

--- a/storeapi/go-wrapper/microsoftstore/store.go
+++ b/storeapi/go-wrapper/microsoftstore/store.go
@@ -44,7 +44,7 @@ func checkError(hres int64, err error) (int64, error) {
 
 	var target syscall.Errno
 	if b := errors.As(err, &target); !b {
-		// Supposedly unrechable: proc.Call must always return a syscall.Errno
+		// Supposedly unreachable: proc.Call must always return a syscall.Errno
 		return hres, err
 	}
 

--- a/storeapi/go-wrapper/microsoftstore/store.go
+++ b/storeapi/go-wrapper/microsoftstore/store.go
@@ -34,20 +34,29 @@ func checkError(hres int64, err error) (int64, error) {
 	// From syscall/dll_windows.go (*Proc).Call doc:
 	// > Callers must inspect the primary return value to decide whether an
 	//   error occurred [...] before consulting the error.
+	// There is no possibility of nil  error, the `err` return value is always constructed with the
+	// result of `GetLastError()` which could have been set by something completely
+	// unrelated to our code some time in the past, as well as it could be `ERROR_SUCCESS` which is the `Errno(0)`.
+	// If the act of calling the API fails (not the function we're calling, but the attempt to call it), then we'd
+	// have a meaningful `syscall.Errno` object via the `err` parameter, related to the actual failure (like a function not found in this DLL)
+	// Since our implementation of the store API doesn't touch errno the call should return `hres`
+	// in our predefined range plus garbage in the `err` argument, thus we only care about the `hres` in this case.
 	if e := NewStoreAPIError(hres); e != nil {
 		return hres, fmt.Errorf("storeApi returned error code %d: %w", hres, e)
 	}
 
+	// Supposedly unreachable: proc.Call must always return a non-nil syscall.Errno
 	if err == nil {
 		return hres, nil
 	}
 
 	var target syscall.Errno
 	if b := errors.As(err, &target); !b {
-		// Supposedly unreachable: proc.Call must always return a syscall.Errno
+		// Supposedly unreachable: proc.Call must always return a non-nil syscall.Errno
 		return hres, err
 	}
 
+	// The act of calling our API didn't succeed, function not found in the DLL for example:
 	if target != syscall.Errno(0) {
 		return hres, fmt.Errorf("failed syscall to storeApi: %v (syscall errno %d)", target, err)
 	}

--- a/storeapi/go-wrapper/microsoftstore/store.go
+++ b/storeapi/go-wrapper/microsoftstore/store.go
@@ -61,5 +61,7 @@ func checkError(hres int64, err error) (int64, error) {
 		return hres, fmt.Errorf("failed syscall to storeApi: %v (syscall errno %d)", target, err)
 	}
 
+	// A non-error value in hres plus ERROR_SUCCESS in err.
+	// This shouldn't happen in the current store API implementation anyway.
 	return hres, nil
 }

--- a/storeapi/go-wrapper/microsoftstore/store_test.go
+++ b/storeapi/go-wrapper/microsoftstore/store_test.go
@@ -105,6 +105,9 @@ func TestErrorVerification(t *testing.T) {
 		"Lower bound of the Store API enum range": {hresult: int64(microsoftstore.ErrNotSubscribed), wantErr: true},
 		"With a system error (errno)":             {hresult: 32 /*garbage*/, err: syscall.Errno(2) /*E_FILE_NOT_FOUND*/, wantErr: true},
 		"With a generic (unreachable) error":      {hresult: 1, err: errors.New("test error"), wantErr: true},
+		// This would mean an API call returning a non-error hresult plus GetLastError() returning ERROR_SUCCESS
+		// This shouldn't happen in the current store API implementation anyway.
+		"With weird successful error": {hresult: 1, err: syscall.Errno(0) /*ERROR_SUCCESS*/},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {

--- a/storeapi/go-wrapper/microsoftstore/store_test.go
+++ b/storeapi/go-wrapper/microsoftstore/store_test.go
@@ -95,22 +95,22 @@ func TestErrorVerification(t *testing.T) {
 		hresult int64
 		err     error
 
-		wantError bool
+		wantErr bool
 	}{
 		"Success": {},
 		// If HRESULT is not in the Store API error range and err is not a syscall.Errno then we don't have an error.
-		"With an unknown value (not an error)": {hresult: 1, wantError: false},
+		"With an unknown value (not an error)": {hresult: 1, wantErr: false},
 
-		"Upper bound of the Store API enum range": {hresult: -1, wantError: true},
-		"Lower bound of the Store API enum range": {hresult: int64(microsoftstore.ErrNotSubscribed), wantError: true},
-		"With a system error (errno)":             {hresult: 32 /*garbage*/, err: syscall.Errno(2) /*E_FILE_NOT_FOUND*/, wantError: true},
-		"With a generic (unreachable) error":      {hresult: 1, err: errors.New("test error"), wantError: true},
+		"Upper bound of the Store API enum range": {hresult: -1, wantErr: true},
+		"Lower bound of the Store API enum range": {hresult: int64(microsoftstore.ErrNotSubscribed), wantErr: true},
+		"With a system error (errno)":             {hresult: 32 /*garbage*/, err: syscall.Errno(2) /*E_FILE_NOT_FOUND*/, wantErr: true},
+		"With a generic (unreachable) error":      {hresult: 1, err: errors.New("test error"), wantErr: true},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			res, err := microsoftstore.CheckError(tc.hresult, tc.err)
-			if tc.wantError {
+			if tc.wantErr {
 				require.Error(t, err, "CheckError should have returned an error for value: %v, returned value was: %v", tc.hresult, res)
 			} else {
 				require.NoError(t, err, "CheckError should have not returned an error for value: %v, returned value was: %v", tc.hresult, res)

--- a/storeapi/go-wrapper/microsoftstore/store_test.go
+++ b/storeapi/go-wrapper/microsoftstore/store_test.go
@@ -112,9 +112,9 @@ func TestErrorVerification(t *testing.T) {
 			res, err := microsoftstore.CheckError(tc.hresult, tc.err)
 			if tc.wantErr {
 				require.Error(t, err, "CheckError should have returned an error for value: %v, returned value was: %v", tc.hresult, res)
-			} else {
-				require.NoError(t, err, "CheckError should have not returned an error for value: %v, returned value was: %v", tc.hresult, res)
+				return
 			}
+			require.NoError(t, err, "CheckError should have not returned an error for value: %v, returned value was: %v", tc.hresult, res)
 		})
 	}
 }

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -169,10 +169,11 @@ func TestServeWSLIP(t *testing.T) {
 		"With mirrored networking mode": {netmode: "mirrored", withAdapters: daemontestutils.MultipleHyperVAdaptersInList},
 		"With no access to the system distro but net mode is the default (NAT)": {netmode: "error", withAdapters: daemontestutils.MultipleHyperVAdaptersInList},
 
-		"Error when the networking mode is unknown":        {netmode: "unknown", wantErr: true},
-		"Error when the list of adapters is empty":         {withAdapters: daemontestutils.EmptyList, wantErr: true},
-		"Error when there is no Hyper-V adapter the list":  {withAdapters: daemontestutils.NoHyperVAdapterInList, wantErr: true},
-		"Error when retrieving adapters information fails": {withAdapters: daemontestutils.MockError, wantErr: true},
+		"Error when the networking mode is unknown":            {netmode: "unknown", wantErr: true},
+		"Error when the list of adapters is empty":             {withAdapters: daemontestutils.EmptyList, wantErr: true},
+		"Error when listing adapters requires too much memory": {withAdapters: daemontestutils.RequiresTooMuchMem, wantErr: true},
+		"Error when there is no Hyper-V adapter the list":      {withAdapters: daemontestutils.NoHyperVAdapterInList, wantErr: true},
+		"Error when retrieving adapters information fails":     {withAdapters: daemontestutils.MockError, wantErr: true},
 	}
 
 	for name, tc := range testcases {

--- a/windows-agent/internal/daemon/daemontestutils/networking_mock.go
+++ b/windows-agent/internal/daemon/daemontestutils/networking_mock.go
@@ -15,6 +15,9 @@ const (
 	// MockError is a state that causes the GetAdaptersAddresses to always return an error.
 	MockError MockIPAdaptersState = iota
 
+	// RequiresTooMuchMem is a state that causes the GetAdaptersAddresses to request allocation of MaxUint32 (over the capacity of the real Win32 API).
+	RequiresTooMuchMem
+
 	// EmptyList is a state that causes the GetAdaptersAddresses to return an empty list of adapters.
 	EmptyList
 
@@ -96,6 +99,9 @@ func (m *MockIPConfig) GetAdaptersAddresses(_, _ uint32, _ uintptr, adapterAddre
 	switch m.state {
 	case MockError:
 		return errors.New("mock error")
+	case RequiresTooMuchMem:
+		*sizePointer = math.MaxUint32
+		return ERROR_BUFFER_OVERFLOW
 	case EmptyList:
 		return nil
 	default:

--- a/windows-agent/internal/daemon/networking.go
+++ b/windows-agent/internal/daemon/networking.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os/exec"
 	"reflect"
@@ -140,14 +141,15 @@ func getAddrList(opts options) (head *ipAdapterAddresses, err error) {
 	var buff buffer[ipAdapterAddresses]
 
 	// Win32 API docs recommend a buff size of 15KB.
-	buff.resizeBytes(15 * kilobyte)
-
+	size := 15 * kilobyte
 	for range 10 {
-		size := buff.byteCount()
-		err := opts.getAdaptersAddresses(family, flags, 0, &buff.data[0], &size)
+		size, err = buff.resizeBytes(size)
+		if err != nil {
+			return nil, err
+		}
+		err = opts.getAdaptersAddresses(family, flags, 0, &buff.data[0], &size)
 		if errors.Is(err, ERROR_BUFFER_OVERFLOW) {
 			// Buffer too small, try again with the returned size.
-			buff.resizeBytes(size)
 			continue
 		}
 		if err != nil {
@@ -171,27 +173,31 @@ type buffer[T any] struct {
 	data []T
 }
 
-// byteCount returns the number of bytes in the buffer.
-func (b buffer[T]) byteCount() uint32 {
-	var t T
-	sizeOf := uint32(reflect.TypeOf(t).Size())
-	n := uint32(len(b.data))
-	return n * sizeOf
-}
-
 // ResizeBytes resizes the buffer to the given number of bytes, rounded UP to fit an integer element size.
-func (b *buffer[T]) resizeBytes(n uint32) {
+func (b *buffer[T]) resizeBytes(n uint32) (uint32, error) {
 	var t T
-	sizeOf := uint32(reflect.TypeOf(t).Size())
+	n64 := uint64(n)
+	sizeOf := uint64(reflect.TypeOf(t).Size())
 
-	newLen := int(n / sizeOf)
-	if n%sizeOf != 0 {
+	newLen := n64 / sizeOf
+	if n64%sizeOf != 0 {
 		newLen++
 	}
 
-	if newLen > len(b.data) {
-		b.data = make([]T, newLen)
+	// the sizes the Win32 API GetAdaptersAddresses works with are uint32, thus we cannot allocate
+	// more than MaxUint32 bytes after all.
+	newSize := newLen * sizeOf
+	if newSize >= math.MaxUint32 {
+		return 0, errors.New("buffer allocated size limit reached")
 	}
+
+	if newLen > uint64(len(b.data)) {
+		b.data = make([]T, newLen)
+		// Since make() guarantees len(b.data) == newLen, there is no need to recompute it.
+	}
+
+	//nolint:gosec //uint64 -> uint32 conversion is safe because we checked that newSize < MaxUint32.
+	return uint32(newSize), nil
 }
 
 // ptr returns a pointer to the start of the buffer.

--- a/windows-agent/internal/proservices/landscape/distroinstall/distroinstall.go
+++ b/windows-agent/internal/proservices/landscape/distroinstall/distroinstall.go
@@ -69,6 +69,7 @@ func CreateUser(ctx context.Context, d gowsl.Distro, userName string, userFullNa
 		return 0, fmt.Errorf("could not parse uid %q: %v", string(out), err)
 	}
 
+	//nolint:gosec // strconv.ParseUint with bitSize 32 ensures the value of id64 fits inside uint32.
 	return uint32(id64), nil
 }
 

--- a/wsl-pro-service/internal/system/networking.go
+++ b/wsl-pro-service/internal/system/networking.go
@@ -101,6 +101,7 @@ func (s *System) defaultGateway() (ip net.IP, err error) {
 	}
 
 	b := make([]byte, 4)
+	//nolint:gosec // Value is guaranteed by strconv.ParseUint to fit in uint32 (due the bitSize argument)
 	binary.LittleEndian.PutUint32(b, uint32(gatewayRaw))
 
 	return net.IP(b), nil


### PR DESCRIPTION
Most of the warnings were not a real issue, but the one around the Win32 GetAdapterAddersses was harder to prove with the previous implementation so I refactored it a little bit to make it easy to reach the piece of mind that we're not doing nasting error-prone narrowing conversions.

This should unblock #877 .

UDENG-4234