### PR TITLE
fix(test): No `os.Exit()` calls in `TestMain` and no SA3000 warning

### DIFF
--- a/common/grpc/logconnections/logconnections_test.go
+++ b/common/grpc/logconnections/logconnections_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logconnections"
@@ -109,5 +108,5 @@ func TestMain(m *testing.M) {
 		logrus.StandardLogger().SetLevel(logrus.DebugLevel)
 	}
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -101,7 +101,7 @@ func TestMain(m *testing.M) {
 	defer cleanup()
 	testImagePath = path
 
-	exitCode := m.Run()
+	m.Run()
 
 	if err := cleanupRegistry(); err != nil {
 		log.Printf("Cleanup: registry: %v\n", err)
@@ -111,8 +111,6 @@ func TestMain(m *testing.M) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Printf("Cleanup: could not remove Appx: %v: %s", err, out)
 	}
-
-	os.Exit(exitCode)
 }
 
 func usePrebuiltProject(buildPath string) (err error) {

--- a/storeapi/go-wrapper/microsoftstore/store_test.go
+++ b/storeapi/go-wrapper/microsoftstore/store_test.go
@@ -33,8 +33,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 func TestGenerateUserJWT(t *testing.T) {

--- a/windows-agent/internal/distros/distro/distro_test.go
+++ b/windows-agent/internal/distros/distro/distro_test.go
@@ -23,8 +23,7 @@ import (
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 // globalStartupMu protects against multiple distros starting at the same time.

--- a/windows-agent/internal/distros/worker/worker_test.go
+++ b/windows-agent/internal/distros/worker/worker_test.go
@@ -30,8 +30,7 @@ func init() {
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 func TestNew(t *testing.T) {

--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -40,8 +40,7 @@ import (
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 const defaultLandscapeConfig = `

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -26,8 +26,7 @@ import (
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 func TestNew(t *testing.T) {

--- a/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -30,8 +29,7 @@ func TestMain(m *testing.M) {
 
 	task.Register[testTask]()
 
-	exit := m.Run()
-	defer os.Exit(exit)
+	m.Run()
 }
 
 func TestServe(t *testing.T) {

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
@@ -22,7 +22,7 @@ import (
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestHelp(t *testing.T) {

--- a/wsl-pro-service/internal/daemon/daemon_test.go
+++ b/wsl-pro-service/internal/daemon/daemon_test.go
@@ -21,7 +21,7 @@ import (
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
 
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
When upgrading golangci-lint in #870 I introduced a bunch of os.Exit calls in test functions blindily following the SA300 warning. That's bad, because it prevents the Go runtime to perform some clean-up after `m.Run()` returns.
In fact, [Go 1.15 changelog](https://go.dev/doc/go1.15#testingpkgtesting) clearly states that m.Run() does the right thing in regards to the program's exit code. `staticcheck` running alone won't report that warning. `golangci-lint` is failing to propagate the go version, thus confusing the downstream linter.