### PR TITLE
fix(agent): No empty cloudinit

### DIFF
--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -92,10 +92,10 @@ func (c CloudInit) WriteDistroData(distroName string, cloudInit string) error {
 // removeFileInDir attempts to remove the file 'dir/file' if it exists. Missing file is not an error.
 func removeFileInDir(dir, file string) error {
 	err := os.Remove(filepath.Join(dir, file))
-	if err == nil || os.IsNotExist(err) {
-		return nil
+	if err != nil && !os.IsNotExist(err) {
+		return err
 	}
-	return err
+	return nil
 }
 
 // writeFileInDir:

--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -37,6 +37,12 @@ func New(ctx context.Context, conf Config, publicDir string) (CloudInit, error) 
 		conf:    conf,
 	}
 
+	// c.writeAgentData() is no longer guaranteed to create the cloud-init directory,
+	// so let's check now if we have permission to do so.
+	if err := os.MkdirAll(c.dataDir, 0700); err != nil {
+		return CloudInit{}, fmt.Errorf("could not create cloud-init directory: %v", err)
+	}
+
 	if err := c.writeAgentData(); err != nil {
 		return CloudInit{}, err
 	}

--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -60,6 +60,11 @@ func (c CloudInit) writeAgentData() (err error) {
 		return err
 	}
 
+	// Nothing to write, we don't want an empty agent.yaml confusing the real cloud-init.
+	if cloudInit == nil {
+		return removeFileInDir(c.dataDir, "agent.yaml")
+	}
+
 	err = writeFileInDir(c.dataDir, "agent.yaml", cloudInit)
 	if err != nil {
 		return err
@@ -76,6 +81,15 @@ func (c CloudInit) WriteDistroData(distroName string, cloudInit string) error {
 	}
 
 	return nil
+}
+
+// removeFileInDir attempts to remove the file 'dir/file' if it exists. Missing file is not an error.
+func removeFileInDir(dir, file string) error {
+	err := os.Remove(filepath.Join(dir, file))
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 // writeFileInDir:

--- a/windows-agent/internal/cloudinit/cloudinit_test.go
+++ b/windows-agent/internal/cloudinit/cloudinit_test.go
@@ -237,7 +237,7 @@ data:
 			require.NoError(t, err, "Setup: cloud-init New should return no errors")
 
 			if !tc.noOldData {
-				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0600), "Setup: could not write old distro data directory")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700), "Setup: could not write old distro data directory")
 				require.NoError(t, os.WriteFile(path, []byte(oldCloudInit), 0600), "Setup: could not write old distro data")
 			}
 

--- a/windows-agent/internal/cloudinit/cloudinit_test.go
+++ b/windows-agent/internal/cloudinit/cloudinit_test.go
@@ -20,10 +20,12 @@ func TestNew(t *testing.T) {
 	testCases := map[string]struct {
 		breakWriteAgentData bool
 		emptyConfig         bool
-		wantErr             bool
+
+		wantErr         bool
+		wantNoAgentYaml bool
 	}{
 		"Success": {},
-		"No file if there is no config to write into":        {emptyConfig: true},
+		"No file if there is no config to write into":        {emptyConfig: true, wantNoAgentYaml: true},
 		"Error when cloud-init agent file cannot be written": {breakWriteAgentData: true, wantErr: true},
 	}
 
@@ -55,7 +57,7 @@ func TestNew(t *testing.T) {
 
 			// We don't assert on specifics, as they are tested in WriteAgentData tests.
 			path := filepath.Join(publicDir, ".cloud-init", "agent.yaml")
-			if tc.emptyConfig {
+			if tc.wantNoAgentYaml {
 				require.NoFileExists(t, path, "there should be no agent data file if there is no config to write into")
 				return
 			}

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/with_empty_contents
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/with_empty_contents
@@ -1,3 +1,0 @@
-#cloud-config
-# This file was generated automatically and must not be edited
-{}

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -112,13 +112,9 @@ func TestNew(t *testing.T) {
 
 func checkFileExists(path string) func() bool {
 	return func() bool {
-		return fileExists(path)
+		s, err := os.Stat(path)
+		return err == nil && !s.IsDir()
 	}
-}
-
-func fileExists(path string) bool {
-	s, err := os.Stat(path)
-	return err == nil && !s.IsDir()
 }
 
 func TestRegisterGRPCServices(t *testing.T) {

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
@@ -1,3 +1,8 @@
 #cloud-config
 # This file was generated automatically and must not be edited
-{}
+landscape:
+    client:
+        tags: wsl
+        user: JohnDoe
+ubuntu_pro:
+    token: test-token

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
@@ -1,3 +1,8 @@
 #cloud-config
 # This file was generated automatically and must not be edited
-{}
+landscape:
+    client:
+        tags: wsl
+        user: JohnDoe
+ubuntu_pro:
+    token: test-token


### PR DESCRIPTION
When the config is empty, the yaml serialization outputs {}. We still added some commentary in the agent.yaml, resulting in a bunch of nothing that confused cloud-init, because it's enablement is based on the existence of the files, their contents are only checked later. That wouldn't be a problem per se, as the WSL datasource would recognize there's nothing to do and bail out, but that would have costed unnecesary CPU cicles, and worse than that, the current implementation of cloud-init makes it log as an error the fact that there is nothing to do at this point, which results in more noise if the user see the output of cloud-init status --long.

The fix is rather simple: do not write an empty object into agent.yaml. If the config is empty we delete that file. This way, if there is nothing from the user nor the agent's perspective, cloud-init will remain trully disabled.

I updated some tests that relied on the fact that cloud-init would create the agent.yaml file unconditionally, which is no longer the case.

UDENG-4169