### PR TITLE
fix(windows-agent): Don't bail out if WSL adapter is not available

### DIFF
--- a/gui/packages/ubuntupro/lib/core/agent_connection.dart
+++ b/gui/packages/ubuntupro/lib/core/agent_connection.dart
@@ -41,7 +41,7 @@ class AgentConnection extends ChangeNotifier {
     await _connectivitySubscription?.cancel();
     _state = AgentConnectionState.connecting;
     notifyListeners();
-    await monitor.reset();
+
     final monitorEvent = await monitor.start().last;
     if (monitorEvent != AgentState.ok) {
       _state = AgentConnectionState.disconnected;

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
@@ -350,7 +350,7 @@ func TestLogs(t *testing.T) {
 			select {
 			case <-time.After(20 * time.Second):
 				require.Fail(t, "Run should have exited")
-			default:
+			case <-ch:
 			}
 
 			// Don't check for log files if the directory was not writable

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -108,7 +108,7 @@ func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
 
 var errRestartDaemon = errors.New("Daemon: Restart requested")
 
-// Calls d.serve once and handles the possible outcomes of it, returning the error sent via the d.err channel
+// tryServingOnce calls d.serve once and handles the possible outcomes of it, returning the error sent via the d.err channel
 // plus a true value if it should be restarted. When this function returns, the daemon is no longer serving.
 func (d *Daemon) tryServingOnce(ctx context.Context, opts options) error {
 	defer func() {
@@ -314,7 +314,7 @@ func (d *Daemon) serve(ctx context.Context, opts options) (<-chan error, stopFun
 
 type stopFunc func(ctx context.Context, force bool)
 
-// Returns a closure capable of stopping the gRPCServer gracefully or forcefully.
+// newStopFunc returns a closure capable of stopping the gRPCServer gracefully or forcefully.
 // It must be called from the same goroutine that started the server.
 func newStopFunc(grpcServer *grpc.Server) stopFunc {
 	return func(ctx context.Context, force bool) {

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -22,6 +23,20 @@ type GRPCServiceRegisterer func(ctx context.Context) *grpc.Server
 type Daemon struct {
 	listeningPortFilePath string
 
+	// serving signals that Serve has been called once. This channel is closed when Serve is called.
+	serving chan struct{}
+
+	// quit allows other goroutines to signal to stop the daemon while still running. It's intentionally never closed so clients can call Quit() safely.
+	quit chan quitRequest
+
+	// stopped lets the Quit() method block the caller until the daemon has stopped serving.
+	stopped chan struct{}
+
+	// err is channel through which the current serving goroutine will deliver its exit error, if any.
+	// It's intentionally never closed because a writer cannot know up-front it will be the last one.
+	err chan error
+
+	registerer GRPCServiceRegisterer
 	grpcServer *grpc.Server
 }
 
@@ -34,7 +49,11 @@ func New(ctx context.Context, registerGRPCServices GRPCServiceRegisterer, addrDi
 
 	return &Daemon{
 		listeningPortFilePath: listeningPortFilePath,
-		grpcServer:            registerGRPCServices(ctx),
+		registerer:            registerGRPCServices,
+		err:                   make(chan error, 1),
+		quit:                  make(chan quitRequest, 1),
+		serving:               make(chan struct{}),
+		stopped:               make(chan struct{}, 1),
 	}
 }
 
@@ -42,7 +61,110 @@ func New(ctx context.Context, registerGRPCServices GRPCServiceRegisterer, addrDi
 // Before serving, it writes a file on disk on which port it's listening on for client
 // to be able to reach our server.
 // This file is removed once the server stops listening.
-func (d Daemon) Serve(ctx context.Context, args ...Option) (err error) {
+// The server is automatically restarted if it was stopped by a concurrent call to Restart().
+// This method is designed to be called just and only once, when it returns the daemon is no longer useful.
+func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
+	// Once this method leaves the daemon is done forever.
+	defer d.cleanup()
+
+	// let the world know we were requested to serve.
+	close(d.serving)
+
+	for {
+		retry, err := d.tryServingOnce(ctx, args...)
+		if retry {
+			continue
+		}
+		return err
+	}
+}
+
+// Calls d.serve once and handles the possible outcomes of it, returning the error sent via the d.err channel
+// plus a true value if it should be restarted. When this function returns, the daemon is no longer serving.
+func (d *Daemon) tryServingOnce(ctx context.Context, args ...Option) (bool, error) {
+	defer func() {
+		// let the world know we're currently stopped (probably not in definitive)
+		_ = os.Remove(d.listeningPortFilePath)
+		d.stopped <- struct{}{}
+	}()
+
+	// Try to start serving.
+	if err := d.serve(ctx, args...); err != nil {
+		return false, err
+	}
+
+	// We now have one serving goroutine.
+	// All code paths below must join on d.err to ensure the serving goroutine won't be left detached.
+	var quitReq quitRequest
+	select {
+	case <-ctx.Done():
+		// Forceful stop to ensure the goroutine won't leak.
+		d.stop(context.Background(), true)
+		return false, errors.Join(ctx.Err(), <-d.err)
+	case err := <-d.err:
+		return false, err
+	case quitReq = <-d.quit:
+		// proceed.
+	}
+
+	switch quitReq {
+	case quitGraceful:
+		d.stop(ctx, false)
+		return false, <-d.err
+
+	case quitForce:
+		d.stop(ctx, true)
+		return false, <-d.err
+	}
+	// Should restart => for now unreachable. Fix coming soon.
+	return true, nil
+}
+
+// cleanup releases all resources held by the daemon, rendering it unusable.
+func (d *Daemon) cleanup() {
+	defer close(d.stopped)
+	d.grpcServer = nil
+}
+
+// Quit gracefully quits listening loop and stops the grpc server.
+// It can drop any existing connexion if force is true.
+// Although this method is idempotent, once it returns, the daemon is no longer useful.
+func (d *Daemon) Quit(ctx context.Context, force bool) {
+	select {
+	case <-d.serving:
+		// proceeds.
+	default:
+		log.Warning(ctx, "Quit called before Serve.")
+		return
+	}
+
+	req := quitGraceful
+	if force {
+		req = quitForce
+	}
+
+	select {
+	case <-ctx.Done():
+		log.Warning(ctx, "Stop daemon requested meanwhile context was canceled.")
+		return
+
+	case d.quit <- req:
+		<-d.stopped
+	}
+}
+
+type quitRequest int
+
+const (
+	quitGraceful quitRequest = iota
+	quitForce
+)
+
+// serve implements the actual serving of the daemon, creating a new gRPC server and listening
+// on a new goroutine that reports its running status and errors via the daemon channels:
+// - d.stopped to let callers of Quit() remain blocked until it exits and
+// - d.err to let the caller of Serve() know if it exited with an error.
+func (d *Daemon) serve(ctx context.Context, args ...Option) (err error) {
 	//nolint:govet // i18n depends on strings being acquired at runtime.
 	defer decorate.OnError(&err, i18n.G("Daemon: error while serving"))
 
@@ -66,21 +188,35 @@ func (d Daemon) Serve(ctx context.Context, args ...Option) (err error) {
 	if err := os.WriteFile(d.listeningPortFilePath, []byte(addr), 0600); err != nil {
 		return err
 	}
-	defer os.Remove(d.listeningPortFilePath)
 
 	log.Debugf(ctx, "Daemon: address file written to %s", d.listeningPortFilePath)
 	log.Infof(ctx, "Daemon: serving gRPC requests on %s", addr)
 
-	if err := d.grpcServer.Serve(lis); err != nil {
-		return fmt.Errorf("gRPC serve error: %v", err)
-	}
+	d.grpcServer = d.registerer(ctx)
+
+	go func() {
+		err := d.grpcServer.Serve(lis)
+		// This is the only place where we write into d.err so it can report this goroutine being done.
+		d.err <- wrapf("gRPC serve error: %v", err)
+	}()
+
 	return nil
 }
 
-// Quit gracefully quits listening loop and stops the grpc server.
-// It can drop any existing connexion if force is true.
-func (d Daemon) Quit(ctx context.Context, force bool) {
+// wrapf wraps an error with fmt.Errorf(), returning nil if err is nil.
+func wrapf(format string, err error, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf(format, append(a, err)...)
+}
+
+// Handles stopping the daemon's gRPC server.
+// This must be called by the same goroutine that started the server.
+func (d *Daemon) stop(ctx context.Context, force bool) {
+	// ... thus no need to check d.grpcServer for nil.
 	log.Info(ctx, "Stopping daemon requested.")
+
 	if force {
 		d.grpcServer.Stop()
 		return

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -283,19 +283,14 @@ func (d *Daemon) serve(ctx context.Context, opts *options) (err error) {
 
 	go func() {
 		err := d.grpcServer.Serve(lis)
+		if err != nil {
+			err = fmt.Errorf("gRPC serve error: %v", err)
+		}
 		// This is the only place where we write into d.err so it can report this goroutine being done.
-		d.err <- wrapf("gRPC serve error: %v", err)
+		d.err <- err
 	}()
 
 	return nil
-}
-
-// wrapf wraps an error with fmt.Errorf(), returning nil if err is nil.
-func wrapf(format string, err error, a ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-	return fmt.Errorf(format, append(a, err)...)
 }
 
 // Handles stopping the daemon's gRPC server.

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -208,6 +208,7 @@ func (d *Daemon) restart(ctx context.Context) {
 		return
 	}
 
+	// This select binds the time this would block on sending via d.quit (when the channel is full) to the context cancellation.
 	select {
 	case <-ctx.Done():
 		log.Warning(ctx, "Restart daemon requested meanwhile context was canceled.")

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -78,6 +78,14 @@ type Option func(*options)
 // The server is automatically restarted if it was stopped by a concurrent call to Restart().
 // This method is designed to be called just and only once, when it returns the daemon is no longer useful.
 func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
+	select {
+	case <-d.serving:
+		return errors.New("Serve called more than once")
+	case <-d.stopped:
+		return errors.New("Serve called after Quit")
+	default:
+		// Proceeds.
+	}
 	// Once this method leaves the daemon is done forever.
 	defer d.cleanup()
 

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -156,8 +156,7 @@ func (d *Daemon) cleanup() {
 	if d.netSubs == nil {
 		return
 	}
-	err := d.netSubs.Stop()
-	if err != nil {
+	if err := d.netSubs.Stop(); err != nil {
 		log.Errorf(context.Background(), "Daemon: stopping network watcher: %v", err)
 	}
 	d.netSubs = nil

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -254,11 +254,9 @@ func (d *Daemon) serve(ctx context.Context, opts options) (<-chan error, stopFun
 			}, opts)
 
 			if err != nil {
-				log.Errorf(ctx, "Daemon: could not start network monitoring: %v", err)
-				// should we return (and not proceed with serving) instead?
-			} else {
-				d.netSubs = n
+				return fmt.Errorf("Daemon: could not start network monitoring: %v", err)
 			}
+			d.netSubs = n
 		}
 
 		var cfg net.ListenConfig

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -96,7 +96,7 @@ func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
 	}
 
 	for {
-		retry, err := d.tryServingOnce(ctx, &opts)
+		retry, err := d.tryServingOnce(ctx, opts)
 		if retry {
 			continue
 		}
@@ -106,7 +106,7 @@ func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
 
 // Calls d.serve once and handles the possible outcomes of it, returning the error sent via the d.err channel
 // plus a true value if it should be restarted. When this function returns, the daemon is no longer serving.
-func (d *Daemon) tryServingOnce(ctx context.Context, opts *options) (bool, error) {
+func (d *Daemon) tryServingOnce(ctx context.Context, opts options) (bool, error) {
 	defer func() {
 		// let the world know we're currently stopped (probably not in definitive)
 		_ = os.Remove(d.listeningPortFilePath)
@@ -228,7 +228,7 @@ const (
 // on a new goroutine that reports its running status and errors via the daemon channels:
 // - d.stopped to let callers of Quit() remain blocked until it exits and
 // - d.err to let the caller of Serve() know if it exited with an error.
-func (d *Daemon) serve(ctx context.Context, opts *options) (err error) {
+func (d *Daemon) serve(ctx context.Context, opts options) (err error) {
 	//nolint:govet // i18n depends on strings being acquired at runtime.
 	defer decorate.OnError(&err, i18n.G("Daemon: error while serving"))
 

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -109,7 +109,9 @@ func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
 func (d *Daemon) tryServingOnce(ctx context.Context, opts options) (bool, error) {
 	defer func() {
 		// let the world know we're currently stopped (probably not in definitive)
-		_ = os.Remove(d.listeningPortFilePath)
+		if err := os.Remove(d.listeningPortFilePath); err != nil {
+			log.Warningf(ctx, "Daemon: could not remove address file: %v", err)
+		}
 		d.stopped <- struct{}{}
 	}()
 

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -514,11 +514,13 @@ func TestQuitBeforeServe(t *testing.T) {
 		serverErr <- d.Serve(ctx)
 	}()
 
-	<-time.After(100 * time.Millisecond)
+	select {
+	case err := <-serverErr:
+		require.Fail(t, "Calling Quit() before Serve() on a fresh daemon should not result in an error", err)
+	case <-time.After(1 * time.Second):
+	}
+
 	d.Quit(ctx, false)
-
-	require.NoError(t, <-serverErr, "Calling Serve() after Quit() should not result in an error")
-
 	requireWaitPathDoesNotExist(t, filepath.Join(addrDir, common.ListeningPortFileName), "Port file should not exist after returning from Serve()")
 }
 

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -3,7 +3,6 @@ package daemon_test
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -99,7 +98,7 @@ func TestStartQuit(t *testing.T) {
 					return string(addrContents) != "# Old port file"
 				}, 5*time.Second, 100*time.Millisecond, "Pre-existing address file should be overwritten after dameon.New()")
 			} else {
-				requireWaitPathExists(t, addrPath, "Serve should create an address file")
+				daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should create an address file")
 				addrContents, err = os.ReadFile(addrPath)
 				require.NoError(t, err, "Address file should be readable")
 			}
@@ -155,114 +154,7 @@ func TestStartQuit(t *testing.T) {
 
 			require.NoError(t, <-serveErr, "Serve should return no error when stopped normally")
 			requireCannotDialGRPC(t, address, "No new connection should be allowed when the server is no longer running")
-			requireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
-		})
-	}
-}
-
-func TestRestart(t *testing.T) {
-	t.Parallel()
-
-	testsCases := map[string]struct {
-		afterQuit     bool
-		beforeServing bool
-		cancelEarly   bool
-
-		wantAddrFileDeleted bool
-		wantServeErr        bool
-	}{
-		"Success": {},
-		"Does nothing when the context is cancelled":  {cancelEarly: true, wantAddrFileDeleted: true, wantServeErr: true},
-		"Does nothing when daemon is not serving yet": {beforeServing: true},
-		"Does nothing when the daemon is done":        {afterQuit: true, wantAddrFileDeleted: true},
-	}
-
-	for name, tc := range testsCases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			addrDir := t.TempDir()
-
-			registerer := func(context.Context, bool) *grpc.Server {
-				server := grpc.NewServer()
-				var service testGRPCService
-				grpctestservice.RegisterTestServiceServer(server, service)
-				return server
-			}
-
-			d := daemon.New(ctx, registerer, addrDir)
-
-			serveErr := make(chan error, 1)
-
-			if tc.beforeServing {
-				go func() {
-					d.Restart(ctx)
-					serveErr <- nil
-				}()
-
-				select {
-				case <-time.After(100 * time.Millisecond):
-					require.Fail(t, "Restart should return immediately when daemon is not serving")
-				case <-serveErr:
-					// proceed.
-				}
-			}
-
-			go func() {
-				serveErr <- d.Serve(ctx)
-				close(serveErr)
-			}()
-
-			addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
-
-			var err error
-			requireWaitPathExists(t, addrPath, "Serve should have created a .address file")
-			addrSt, err := os.Stat(addrPath)
-			require.NoError(t, err, "Address file should be readable")
-
-			if tc.afterQuit {
-				d.Quit(ctx, false)
-			}
-			if tc.cancelEarly {
-				cancel()
-			}
-			// Now we know the GRPC server has started serving.
-			d.Restart(ctx)
-
-			// d.Serve() shouldn't have exitted with an error yet at this point.
-			select {
-			case err := <-serveErr:
-				if tc.wantServeErr {
-					require.Error(t, err, "Serve should return with error when stopped by the context")
-				} else {
-					require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
-				}
-			case <-time.After(100 * time.Millisecond):
-				// proceed.
-			}
-
-			if tc.wantAddrFileDeleted {
-				requireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
-				return
-			}
-
-			requireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
-			// Contents could be the same without our control, thus best to check the file time.
-			newAddrSt, err := os.Stat(addrPath)
-			require.NoError(t, err, "Address file should be readable")
-			require.NotEqual(t, addrSt.ModTime(), newAddrSt.ModTime(), "Address file should be overwritten after Restart")
-
-			// Restart a second time
-			d.Restart(ctx)
-			// d.Serve() shouldn't have exitted with an error yet at this point.
-			select {
-			case err := <-serveErr:
-				require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
-			case <-time.After(100 * time.Millisecond):
-				// proceed.
-			}
+			daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
 		})
 	}
 }
@@ -453,7 +345,7 @@ func TestAddingWSLAdapterRestarts(t *testing.T) {
 
 	addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
 
-	requireWaitPathExists(t, addrPath, "Serve should create an address file")
+	daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should create an address file")
 	addrSt, err := os.Stat(addrPath)
 	require.NoError(t, err, "Address file should be readable")
 
@@ -468,7 +360,7 @@ func TestAddingWSLAdapterRestarts(t *testing.T) {
 		// proceed.
 	}
 
-	requireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
+	daemontestutils.RequireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
 	// Contents could be the same without our control, thus best to check the file time.
 	newAddrSt, err := os.Stat(addrPath)
 	require.NoError(t, err, "Address file should be readable")
@@ -521,7 +413,7 @@ func TestQuitBeforeServe(t *testing.T) {
 	}
 
 	d.Quit(ctx, false)
-	requireWaitPathDoesNotExist(t, filepath.Join(addrDir, common.ListeningPortFileName), "Port file should not exist after returning from Serve()")
+	daemontestutils.RequireWaitPathDoesNotExist(t, filepath.Join(addrDir, common.ListeningPortFileName), "Port file should not exist after returning from Serve()")
 }
 
 // grpcPersistentCall will create a persistent GRPC connection to the server.
@@ -578,49 +470,6 @@ func requireCannotDialGRPC(t *testing.T, addr string, msg string) {
 	time.Sleep(300 * time.Millisecond)
 	validStates := []connectivity.State{connectivity.Connecting, connectivity.TransientFailure}
 	require.Contains(t, validStates, conn.GetState(), "unexpected state after dialing. Expected any of %q but got %q", validStates, conn.GetState())
-}
-
-// requireWaitPathExists checks periodically for the existence of a path. If the path
-// does not exist after waiting for the specified timeout, the test fails. This function
-// is blocking.
-func requireWaitPathExists(t *testing.T, path string, msg string) {
-	t.Helper()
-
-	fileExists := func() bool {
-		_, err := os.Lstat(path)
-		if err == nil {
-			return true
-		}
-		require.ErrorIsf(t, err, fs.ErrNotExist, "could not stat path %q. Message: %s", path, msg)
-		return false
-	}
-
-	require.Eventually(t, fileExists, 5*time.Second, 100*time.Millisecond, "%q does not exists: %v", path, msg)
-
-	// Prevent error when accessing the file right after:
-	// 'The process cannot access the file because it is being used by another process'
-	time.Sleep(10 * time.Millisecond)
-}
-
-// requireWaitPathDoesNotExist checks periodically for the existence of a path. If the path
-// does not exist after waiting for the specified timeout, the test fails. This function
-// is blocking.athDoesNotExist checks periodiclly for the existence of a path. If the path
-// does not exist after waiting for the specified timeout, the test fails. This function
-// is blocking.
-func requireWaitPathDoesNotExist(t *testing.T, path string, msg string) {
-	t.Helper()
-
-	var err error
-	fileDoesNotExist := func() bool {
-		_, err = os.Lstat(path)
-		if err == nil {
-			return false
-		}
-		require.ErrorIsf(t, err, fs.ErrNotExist, "could not stat path %q. Message: %s", path, msg)
-		return true
-	}
-
-	require.Eventually(t, fileDoesNotExist, 100*time.Millisecond, time.Millisecond, "%q still exists: %v", path, msg)
 }
 
 // Our mock GRPC service.

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -135,7 +135,7 @@ func TestStartQuit(t *testing.T) {
 				require.Equal(t, codes.Unavailable, code, "GRPC call should return an error of type %q, instead got %q", codes.Unavailable, code)
 			} else {
 				// We have an hanging connection which should make us time out
-				require.False(t, immediateQuit, "Quit should wait for exisiting connections to close before quitting")
+				require.False(t, immediateQuit, "Quit should wait for existing connections to close before quitting")
 				requireCannotDialGRPC(t, address, "No new connection should be allowed after calling Quit")
 
 				// release hanging connection and wait for Quit to exit.

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -146,7 +146,7 @@ func TestStartQuit(t *testing.T) {
 
 			require.NoError(t, <-serveErr, "Serve should return no error when stopped normally")
 			requireCannotDialGRPC(t, address, "No new connection should be allowed when the server is no longer running")
-			requireWaitPathDoesNotExist(t, addrPath, "Address file should be removed after quitting the server")
+			requireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
 		})
 	}
 }

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -158,6 +158,113 @@ func TestStartQuit(t *testing.T) {
 	}
 }
 
+func TestRestart(t *testing.T) {
+	t.Parallel()
+
+	testsCases := map[string]struct {
+		afterQuit     bool
+		beforeServing bool
+		cancelEarly   bool
+
+		wantAddrFileDeleted bool
+		wantServeErr        bool
+	}{
+		"Success": {},
+		"Does nothing when the context is cancelled":  {cancelEarly: true, wantAddrFileDeleted: true, wantServeErr: true},
+		"Does nothing when daemon is not serving yet": {beforeServing: true},
+		"Does nothing when the daemon is done":        {afterQuit: true, wantAddrFileDeleted: true},
+	}
+
+	for name, tc := range testsCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			addrDir := t.TempDir()
+
+			registerer := func(context.Context, bool) *grpc.Server {
+				server := grpc.NewServer()
+				var service testGRPCService
+				grpctestservice.RegisterTestServiceServer(server, service)
+				return server
+			}
+
+			d := daemon.New(ctx, registerer, addrDir)
+
+			serveErr := make(chan error, 1)
+
+			if tc.beforeServing {
+				go func() {
+					d.Restart(ctx)
+					serveErr <- nil
+				}()
+
+				select {
+				case <-time.After(100 * time.Millisecond):
+					require.Fail(t, "Restart should return immediately when daemon is not serving")
+				case <-serveErr:
+					// proceed.
+				}
+			}
+
+			go func() {
+				serveErr <- d.Serve(ctx)
+				close(serveErr)
+			}()
+
+			addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
+
+			var err error
+			requireWaitPathExists(t, addrPath, "Serve should have created a .address file")
+			addrSt, err := os.Stat(addrPath)
+			require.NoError(t, err, "Address file should be readable")
+
+			if tc.afterQuit {
+				d.Quit(ctx, false)
+			}
+			if tc.cancelEarly {
+				cancel()
+			}
+			// Now we know the GRPC server has started serving.
+			d.Restart(ctx)
+
+			// d.Serve() shouldn't have exitted with an error yet at this point.
+			select {
+			case err := <-serveErr:
+				if tc.wantServeErr {
+					require.Error(t, err, "Serve should return with error when stopped by the context")
+				} else {
+					require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
+				}
+			case <-time.After(100 * time.Millisecond):
+				// proceed.
+			}
+
+			if tc.wantAddrFileDeleted {
+				requireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
+				return
+			}
+
+			requireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
+			// Contents could be the same without our control, thus best to check the file time.
+			newAddrSt, err := os.Stat(addrPath)
+			require.NoError(t, err, "Address file should be readable")
+			require.NotEqual(t, addrSt.ModTime(), newAddrSt.ModTime(), "Address file should be overwritten after Restart")
+
+			// Restart a second time
+			d.Restart(ctx)
+			// d.Serve() shouldn't have exitted with an error yet at this point.
+			select {
+			case err := <-serveErr:
+				require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
+			case <-time.After(100 * time.Millisecond):
+				// proceed.
+			}
+		})
+	}
+}
+
 func TestServeWSLIP(t *testing.T) {
 	t.Parallel()
 

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -390,7 +390,6 @@ func TestAddingWSLAdapterRestarts(t *testing.T) {
 
 	addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
 
-	var err error
 	requireWaitPathExists(t, addrPath, "Serve should create an address file")
 	addrSt, err := os.Stat(addrPath)
 	require.NoError(t, err, "Address file should be readable")

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -292,8 +292,7 @@ func TestServeWSLIP(t *testing.T) {
 		"When there is no Hyper-V adapter the list":      {withAdapters: daemontestutils.NoHyperVAdapterInList},
 		"When retrieving adapters information fails":     {withAdapters: daemontestutils.MockError},
 
-		// Should wantErr?
-		"When the WSL IP cannot be found and monitoring network fails": {withAdapters: daemontestutils.NoHyperVAdapterInList, subscribeErr: errors.New("mock error")},
+		"Error when the WSL IP cannot be found and monitoring network fails": {withAdapters: daemontestutils.NoHyperVAdapterInList, subscribeErr: errors.New("mock error"), wantErr: true},
 	}
 
 	for name, tc := range testcases {

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -73,8 +73,7 @@ func TestStartQuit(t *testing.T) {
 
 			registerer := func(context.Context, bool) *grpc.Server {
 				server := grpc.NewServer()
-				var service testGRPCService
-				grpctestservice.RegisterTestServiceServer(server, service)
+				grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
 				return server
 			}
 
@@ -182,8 +181,7 @@ func TestCanServeOnlyOnce(t *testing.T) {
 
 			registerer := func(context.Context, bool) *grpc.Server {
 				server := grpc.NewServer()
-				var service testGRPCService
-				grpctestservice.RegisterTestServiceServer(server, service)
+				grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
 				return server
 			}
 
@@ -323,8 +321,7 @@ func TestAddingWSLAdapterRestarts(t *testing.T) {
 
 	registerer := func(context.Context, bool) *grpc.Server {
 		server := grpc.NewServer()
-		var service testGRPCService
-		grpctestservice.RegisterTestServiceServer(server, service)
+		grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
 		return server
 	}
 

--- a/windows-agent/internal/daemon/daemontestutils/daemontestutils.go
+++ b/windows-agent/internal/daemon/daemontestutils/daemontestutils.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-
 	//nolint:revive,nolintlint // needed for go:linkname, but only used in tests. nolintlint as false positive then.
 	_ "unsafe"
 

--- a/windows-agent/internal/daemon/daemontestutils/netmonitoring_mock.go
+++ b/windows-agent/internal/daemon/daemontestutils/netmonitoring_mock.go
@@ -12,9 +12,9 @@ import (
 type NetMonitoringMockAPI struct {
 	Before, After map[string]string
 	// m.ListDevices() will always fail.
-	ListDevicesError error
+	ErrorOnListDevices error
 	// m.ListDevices() will fail only after the first call.
-	ListDevicesAfterError error
+	ErrorOnListDevicesAfterFirstCall error
 
 	GetDeviceConnectionNameError error
 	WaitForDeviceChangesImpl     func() error
@@ -27,16 +27,16 @@ func (m *NetMonitoringMockAPI) Close() {}
 
 // ListDevices returns the GUIDs of the network adapters on the host.
 func (m *NetMonitoringMockAPI) ListDevices() ([]string, error) {
-	if m.ListDevicesError != nil {
-		return nil, m.ListDevicesError
+	if m.ErrorOnListDevices != nil {
+		return nil, m.ErrorOnListDevices
 	}
 	if !m.listDevicesCalledFirstTime.Load() {
 		m.listDevicesCalledFirstTime.Store(true)
 		return maps.Keys(m.Before), nil
 	}
 	// After the first call only.
-	if m.ListDevicesAfterError != nil {
-		return nil, m.ListDevicesAfterError
+	if m.ErrorOnListDevicesAfterFirstCall != nil {
+		return nil, m.ErrorOnListDevicesAfterFirstCall
 	}
 	return maps.Keys(m.After), nil
 }

--- a/windows-agent/internal/daemon/daemontestutils/netmonitoring_mock.go
+++ b/windows-agent/internal/daemon/daemontestutils/netmonitoring_mock.go
@@ -1,0 +1,73 @@
+package daemontestutils
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/exp/maps" // When migrate to Go 1.23 use "maps" instead.
+)
+
+// NetMonitoringMockAPI implements the NetworkAdapterRepository interface for testing purposes.
+type NetMonitoringMockAPI struct {
+	Before, After map[string]string
+	// m.ListDevices() will always fail.
+	ListDevicesError error
+	// m.ListDevices() will fail only after the first call.
+	ListDevicesAfterError error
+
+	GetDeviceConnectionNameError error
+	WaitForDeviceChangesImpl     func() error
+
+	listDevicesCalledFirstTime atomic.Bool
+}
+
+// Close releases the resources associated with this object and cancels any outstanding wait operation.
+func (m *NetMonitoringMockAPI) Close() {}
+
+// ListDevices returns the GUIDs of the network adapters on the host.
+func (m *NetMonitoringMockAPI) ListDevices() ([]string, error) {
+	if m.ListDevicesError != nil {
+		return nil, m.ListDevicesError
+	}
+	if !m.listDevicesCalledFirstTime.Load() {
+		m.listDevicesCalledFirstTime.Store(true)
+		return maps.Keys(m.Before), nil
+	}
+	// After the first call only.
+	if m.ListDevicesAfterError != nil {
+		return nil, m.ListDevicesAfterError
+	}
+	return maps.Keys(m.After), nil
+}
+
+// GetDeviceConnectionName returns the connection name of the network adapter with the given GUID.
+func (m *NetMonitoringMockAPI) GetDeviceConnectionName(guid string) (string, error) {
+	if m.GetDeviceConnectionNameError != nil {
+		return "", m.GetDeviceConnectionNameError
+	}
+
+	if m.Before == nil || m.After == nil {
+		return "", errors.New("not implemented")
+	}
+	if !m.listDevicesCalledFirstTime.Load() {
+		if name, ok := m.Before[guid]; ok {
+			return name, nil
+		}
+		return "", fmt.Errorf("device %s not found", guid)
+	}
+
+	if name, ok := m.After[guid]; ok {
+		return name, nil
+	}
+	return "", fmt.Errorf("device %s not found", guid)
+}
+
+// WaitForDeviceChanges blocks the caller until the system triggers a notification of changes to the network adapters.
+func (m *NetMonitoringMockAPI) WaitForDeviceChanges() error {
+	if m.WaitForDeviceChangesImpl != nil {
+		return m.WaitForDeviceChangesImpl()
+	}
+
+	return errors.New("not implemented")
+}

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/daemontestutils"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/netmonitoring"
 )
 
 // WithWslNetworkingMode sets the output of the mock command to run to get the WSL networking mode.
@@ -33,4 +34,22 @@ func WithMockedGetAdapterAddresses(m daemontestutils.MockIPConfig) Option {
 // Restart exposes the private restart method for testing purposes.
 func (d *Daemon) Restart(ctx context.Context) {
 	d.restart(ctx)
+}
+
+// WithNetDevicesAPIProvider sets the NetAdaptersAPIProvider to be used by the netWatcher.Subscribe().
+func WithNetDevicesAPIProvider(p netmonitoring.DevicesAPIProvider) Option {
+	return func(o *options) {
+		o.netMonitoringProvider = p
+	}
+}
+
+// Subscribe subscribes to the addition of network adapters on the host, calling the provided callback.
+// It's a wrapper around the private subscribe function for testing.
+// To ease direct calls, it accepts the variadic Option set instead of the precomputed options.
+func Subscribe(ctx context.Context, f NewAdapterCallback, args ...Option) (*NetWatcher, error) {
+	opt := defaultOptions
+	for _, o := range args {
+		o(&opt)
+	}
+	return subscribe(ctx, f, &opt)
 }

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -51,5 +51,5 @@ func Subscribe(ctx context.Context, f NewAdapterCallback, args ...Option) (*NetW
 	for _, o := range args {
 		o(&opt)
 	}
-	return subscribe(ctx, f, &opt)
+	return subscribe(ctx, f, opt)
 }

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -31,11 +31,6 @@ func WithMockedGetAdapterAddresses(m daemontestutils.MockIPConfig) Option {
 	}
 }
 
-// Restart exposes the private restart method for testing purposes.
-func (d *Daemon) Restart(ctx context.Context) {
-	d.restart(ctx)
-}
-
 // WithNetDevicesAPIProvider sets the NetAdaptersAPIProvider to be used by the netWatcher.Subscribe().
 func WithNetDevicesAPIProvider(p netmonitoring.DevicesAPIProvider) Option {
 	return func(o *options) {

--- a/windows-agent/internal/daemon/export_test.go
+++ b/windows-agent/internal/daemon/export_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/daemontestutils"
@@ -27,4 +28,9 @@ func WithMockedGetAdapterAddresses(m daemontestutils.MockIPConfig) Option {
 			return m.GetAdaptersAddresses(family, flags, reserved, (*daemontestutils.IPAdapterAddresses)(adapterAddresses), sizePointer)
 		}
 	}
+}
+
+// Restart exposes the private restart method for testing purposes.
+func (d *Daemon) Restart(ctx context.Context) {
+	d.restart(ctx)
 }

--- a/windows-agent/internal/daemon/internal_test.go
+++ b/windows-agent/internal/daemon/internal_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/daemontestutils"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/testdata/grpctestservice"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestRestart(t *testing.T) {
+	t.Parallel()
+
+	testsCases := map[string]struct {
+		afterQuit     bool
+		beforeServing bool
+		cancelEarly   bool
+
+		wantAddrFileDeleted bool
+		wantServeErr        bool
+	}{
+		"Success": {},
+		"Does nothing when the context is cancelled":  {cancelEarly: true, wantAddrFileDeleted: true, wantServeErr: true},
+		"Does nothing when daemon is not serving yet": {beforeServing: true},
+		"Does nothing when the daemon is done":        {afterQuit: true, wantAddrFileDeleted: true},
+	}
+
+	for name, tc := range testsCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			addrDir := t.TempDir()
+
+			registerer := func(context.Context, bool) *grpc.Server {
+				server := grpc.NewServer()
+				grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
+				return server
+			}
+
+			d := New(ctx, registerer, addrDir)
+
+			serveErr := make(chan error)
+
+			if tc.beforeServing {
+				go func() {
+					d.restart(ctx)
+					serveErr <- nil
+				}()
+
+				select {
+				case <-time.After(100 * time.Millisecond):
+					require.Fail(t, "Restart should return immediately when daemon is not serving")
+				case <-serveErr:
+					// proceed.
+				}
+			}
+
+			go func() {
+				serveErr <- d.Serve(ctx)
+				close(serveErr)
+			}()
+
+			addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
+
+			var err error
+			daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should have created a .address file")
+			addrSt, err := os.Stat(addrPath)
+			require.NoError(t, err, "Address file should be readable")
+
+			if tc.afterQuit {
+				d.Quit(ctx, false)
+			}
+			if tc.cancelEarly {
+				cancel()
+			}
+			// Now we know the GRPC server has started serving.
+			d.restart(ctx)
+
+			// d.Serve() shouldn't have exitted with an error yet at this point.
+			select {
+			case err := <-serveErr:
+				if tc.wantServeErr {
+					require.Error(t, err, "Serve should return with error when stopped by the context")
+				} else {
+					require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
+				}
+			case <-time.After(100 * time.Millisecond):
+				// proceed.
+			}
+
+			if tc.wantAddrFileDeleted {
+				daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
+				return
+			}
+
+			daemontestutils.RequireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
+			// Contents could be the same without our control, thus best to check the file time.
+			newAddrSt, err := os.Stat(addrPath)
+			require.NoError(t, err, "Address file should be readable")
+			require.NotEqual(t, addrSt.ModTime(), newAddrSt.ModTime(), "Address file should be overwritten after Restart")
+
+			// Restart a second time
+			d.restart(ctx)
+			// d.Serve() shouldn't have exitted with an error yet at this point.
+			select {
+			case err := <-serveErr:
+				require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
+			case <-time.After(100 * time.Millisecond):
+				// proceed.
+			}
+		})
+	}
+}
+
+type testGRPCService struct {
+	grpctestservice.UnimplementedTestServiceServer
+}

--- a/windows-agent/internal/daemon/netmonitoring/netmonitoring.go
+++ b/windows-agent/internal/daemon/netmonitoring/netmonitoring.go
@@ -1,0 +1,23 @@
+// Package netmonitoring defines the network devices monitoring API separated from the daemon package
+// to avoid cyclic dependencies on tests, as the sibling package daemontestutils needs some this interface declaration.
+package netmonitoring
+
+// DevicesAPI is an interface for interacting with the network devices on the host.
+type DevicesAPI interface {
+	// Close releases the resources associated with this object and cancels any outstanding wait operation.
+	Close()
+
+	// ListDevices returns the GUIDs of the network adapters on the host.
+	ListDevices() ([]string, error)
+
+	// GetDeviceConnectionName returns the connection name of the network adapter with the given GUID.
+	GetDeviceConnectionName(guid string) (string, error)
+
+	// WaitForChanges blocks the caller until the system triggers a notification of changes to the network adapters.
+	// It returns nil if the notification is triggered or an error if the context is cancelled or an error occurs.
+	// The wait is cancellable by calling Close().
+	WaitForDeviceChanges() error
+}
+
+// DevicesAPIProvider is a function that returns a new instance of NetAdaptersAPI or an error.
+type DevicesAPIProvider func() (DevicesAPI, error)

--- a/windows-agent/internal/daemon/netmonitoring/netmonitoring.go
+++ b/windows-agent/internal/daemon/netmonitoring/netmonitoring.go
@@ -13,7 +13,7 @@ type DevicesAPI interface {
 	// GetDeviceConnectionName returns the connection name of the network adapter with the given GUID.
 	GetDeviceConnectionName(guid string) (string, error)
 
-	// WaitForChanges blocks the caller until the system triggers a notification of changes to the network adapters.
+	// WaitForDeviceChanges blocks the caller until the system triggers a notification of changes to the network adapters.
 	// It returns nil if the notification is triggered or an error if the context is cancelled or an error occurs.
 	// The wait is cancellable by calling Close().
 	WaitForDeviceChanges() error

--- a/windows-agent/internal/daemon/netmonitoring/netmonitoring_linux.go
+++ b/windows-agent/internal/daemon/netmonitoring/netmonitoring_linux.go
@@ -1,0 +1,6 @@
+package netmonitoring
+
+// DefaultAPIProvider on Linux must delegate to the mock implementation.
+func DefaultAPIProvider() (DevicesAPI, error) {
+	panic("defaultNetAdaptersAPIProvider is not implemented on Linux without a mock")
+}

--- a/windows-agent/internal/daemon/netmonitoring/netmonitoring_windows.go
+++ b/windows-agent/internal/daemon/netmonitoring/netmonitoring_windows.go
@@ -1,0 +1,55 @@
+package netmonitoring
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// DevicesAPIWindows is an implementation of the DevicesAPI interface relying on the well-known registry path `HKLM:SYSTEM\CurrentControlSet\Control\Network\{4D36E972-E325-11CE-BFC1-08002BE10318}` provided by the OS.
+type DevicesAPIWindows struct {
+	k registry.Key
+}
+
+// Close releases the resources associated with this object.
+func (a DevicesAPIWindows) Close() {
+	_ = a.k.Close()
+}
+
+// DefaultAPIProvider returns a new instance of DevicesAPIWindows or an error if it fails to open the registry key.
+func DefaultAPIProvider() (DevicesAPI, error) {
+	k, err := registry.OpenKey(windows.HKEY_LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\Network\{4D36E972-E325-11CE-BFC1-08002BE10318}`, registry.READ)
+	return DevicesAPIWindows{k: k}, err
+}
+
+// ListDevices returns the GUIDs of the network adapters on the host.
+func (a DevicesAPIWindows) ListDevices() ([]string, error) {
+	return a.k.ReadSubKeyNames(-1) // This could potentially be implemented in terms of `GetInterfacesInfo`.
+}
+
+// GetDeviceConnectionName returns the connection name of the network adapter with the given GUID.
+func (a DevicesAPIWindows) GetDeviceConnectionName(guid string) (string, error) {
+	// This could be implemented in terms of GetAdaptersAddresses. All other APIs considered would depend on the registry anyway.
+	sk, err := registry.OpenKey(a.k, filepath.Join(guid, "Connection"), registry.READ)
+	if err != nil {
+		return "", fmt.Errorf("could not read the connection info from adapter GUID %s: %v", guid, err)
+	}
+	defer sk.Close()
+
+	// Ignoring the registry value type trusting the OS will never create non-string values for this key.
+	v, _, err := sk.GetStringValue("Name")
+	if err != nil {
+		return "", fmt.Errorf("could not read the connection name from adapter GUID %s: %v", guid, err)
+	}
+	return v, nil
+}
+
+// WaitForDeviceChanges blocks the caller until the system triggers a notification of changes to the network adapters.
+// The wait can be cancelled by calling Close().
+func (a DevicesAPIWindows) WaitForDeviceChanges() error {
+	// This part could be implemented in terms of CM_Register_Notification, if we find a way to set a Win32 callback without relying on CGo.
+	// Wait synchronuosly on notifications if a subkey is added or deleted, or changes to a value of the key, including adding or deleting a value, or changing an existing value.
+	return windows.RegNotifyChangeKeyValue(windows.Handle(a.k), true, windows.REG_NOTIFY_CHANGE_NAME|windows.REG_NOTIFY_CHANGE_LAST_SET, windows.Handle(0), false)
+}

--- a/windows-agent/internal/daemon/netwatcher.go
+++ b/windows-agent/internal/daemon/netwatcher.go
@@ -50,7 +50,7 @@ func subscribe(ctx context.Context, callback NewAdapterCallback, opts options) (
 		ctx:      nctx,
 		cancel:   cancel,
 		callback: callback,
-		err:      make(chan error, 1),
+		err:      make(chan error),
 		cache:    current,
 	}
 
@@ -58,8 +58,8 @@ func subscribe(ctx context.Context, callback NewAdapterCallback, opts options) (
 		defer close(n.err)
 
 		err := n.start()
-		n.err <- err
 		log.Debugf(context.Background(), "stopped monitoring network adapters: %v", err)
+		n.err <- err
 	}()
 	return n, nil
 }

--- a/windows-agent/internal/daemon/netwatcher.go
+++ b/windows-agent/internal/daemon/netwatcher.go
@@ -1,0 +1,181 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/netmonitoring"
+	"github.com/google/uuid"
+)
+
+// NewAdapterCallback is called when new network adapters are added on the host.
+// It must return true to continue receiving notifications or false to stop the subscription.
+type NewAdapterCallback func(adapterNames []string) bool
+
+// NetWatcher represents a subscription to events of network adapters added on the host.
+type NetWatcher struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	callback NewAdapterCallback
+	api      netmonitoring.DevicesAPI
+
+	cache []string
+
+	// err is a channel through which we join the current waiting goroutine.
+	err chan error
+}
+
+// subscribe subscribes to the addition of network adapters on the host, calling the provided callback
+// with a slice of new adapter names discovered by the time the OS triggers the notification.
+func subscribe(ctx context.Context, callback NewAdapterCallback, opts *options) (*NetWatcher, error) {
+	api, err := opts.netMonitoringProvider()
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize the network adapter API: %v", err)
+	}
+
+	current, err := listAdapters(api)
+	if err != nil {
+		return nil, fmt.Errorf("could not get the current list of network adapters: %v", err)
+	}
+
+	nctx, cancel := context.WithCancel(ctx)
+	// Ensures that the network adapter repository is closed when the context is cancelled so we don't need to do it explicitly.
+	context.AfterFunc(nctx, api.Close)
+	n := &NetWatcher{
+		api:      api,
+		ctx:      nctx,
+		cancel:   cancel,
+		callback: callback,
+		err:      make(chan error, 1),
+		cache:    current,
+	}
+
+	go func() {
+		defer close(n.err)
+
+		err := n.start()
+		n.err <- err
+		log.Debugf(context.Background(), "stopped monitoring network adapters: %v", err)
+	}()
+	return n, nil
+}
+
+// Stop blocks the caller until the subscription to the addition of network adapters on the host is stopped.
+func (n *NetWatcher) Stop() error {
+	n.cancel()
+
+	// joins the goroutine that is waiting for network adapter changes.
+	return <-n.err
+}
+
+// notify notifies the subscriber of the new network adapters added on the host.
+// It returns true if the subscription should continue.
+func (n *NetWatcher) notify() bool {
+	// reloads the list of network adapters and their connection names from the registry
+	current, err := listAdapters(n.api)
+	if err != nil {
+		log.Errorf(n.ctx, "could not get the current list of network adapters: %v", err)
+		return true
+	}
+	// detects which network adapter was added, i.e. are in the current list but not in the cached list.
+	added := difference(current, n.cache)
+	if len(added) == 0 {
+		return true
+	}
+	// updates the cache with the current list of network adapters.
+	n.cache = current
+
+	// finally calls the subscriber with the names of the new network adapters.
+	return n.callback(added)
+}
+
+// start blocks a new goroutine on system notifications about network adapters on the host and notifies the subscriber,
+// while ensuring that this object's context cancellation is respected.
+func (n *NetWatcher) start() error {
+	// Intentionally not closed to prevent potential panics due sending to a closed channel.
+	waitCh := make(chan error)
+
+	for {
+		go func() {
+			if err := n.api.WaitForDeviceChanges(); err != nil {
+				waitCh <- fmt.Errorf("could not wait for network devices changes: %v", err)
+				return
+			}
+			waitCh <- nil
+		}()
+
+		select {
+		case <-n.ctx.Done():
+			return n.ctx.Err()
+		case err := <-waitCh:
+			if err != nil {
+				return err
+			}
+			if !n.notify() {
+				return nil
+			}
+		}
+	}
+}
+
+// Provides the current list of network adapters by their connection names as seen in the output of commands such as `ipconfig /all`.
+func listAdapters(api netmonitoring.DevicesAPI) ([]string, error) {
+	guids, err := api.ListDevices()
+	if err != nil {
+		return nil, fmt.Errorf("could not list network adapter GUIDs: %v", err)
+	}
+
+	// Filter out the entries that are not valid UUIDs.
+	// When using the registry, there is at least one additional subkey named "Descriptions", which is not useful for this purpose.
+	adapterGuids := filter(guids, func(guid string) bool {
+		_, err := uuid.Parse(guid)
+		return err == nil
+	})
+
+	adapterNames := make([]string, 0, len(adapterGuids))
+	for _, guid := range adapterGuids {
+		// Retrieves the connection name of the network adapter with the given GUID, which matches the device's Friendly Name.
+		name, err := api.GetDeviceConnectionName(guid)
+		if err != nil {
+			return nil, err
+		}
+		adapterNames = append(adapterNames, name)
+	}
+
+	slices.Sort(adapterNames)
+	return adapterNames, nil
+}
+
+// Given two sorted slices of strings, returns the elements that are in the first slice but not in the second.
+func difference(a, b []string) []string {
+	l := len(b)
+	if l == 0 {
+		return a
+	}
+
+	diff := make([]string, 0)
+	for _, v := range a {
+		pos, found := sort.Find(l, func(i int) int {
+			return strings.Compare(v, b[i])
+		})
+		if !found || pos == l {
+			diff = append(diff, v)
+		}
+	}
+	return diff
+}
+
+// Given a slice of strings, returns a new slice containing only the elements for which the predicate returns true.
+func filter(s []string, predicate func(string) bool) []string {
+	res := make([]string, 0, len(s))
+	for _, v := range s {
+		if predicate(v) {
+			res = append(res, v)
+		}
+	}
+	return res
+}

--- a/windows-agent/internal/daemon/netwatcher.go
+++ b/windows-agent/internal/daemon/netwatcher.go
@@ -31,7 +31,7 @@ type NetWatcher struct {
 
 // subscribe subscribes to the addition of network adapters on the host, calling the provided callback
 // with a slice of new adapter names discovered by the time the OS triggers the notification.
-func subscribe(ctx context.Context, callback NewAdapterCallback, opts *options) (*NetWatcher, error) {
+func subscribe(ctx context.Context, callback NewAdapterCallback, opts options) (*NetWatcher, error) {
 	api, err := opts.netMonitoringProvider()
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize the network adapter API: %v", err)

--- a/windows-agent/internal/daemon/netwatcher_test.go
+++ b/windows-agent/internal/daemon/netwatcher_test.go
@@ -87,11 +87,11 @@ func TestSubscribe(t *testing.T) {
 					a = before
 				}
 				return &daemontestutils.NetMonitoringMockAPI{
-					Before:                       b,
-					After:                        a,
-					ListDevicesError:             tc.listDevicesError,
-					ListDevicesAfterError:        tc.listDevicesAfterError,
-					GetDeviceConnectionNameError: tc.getConnNameError,
+					Before:                           b,
+					After:                            a,
+					ErrorOnListDevices:               tc.listDevicesError,
+					ErrorOnListDevicesAfterFirstCall: tc.listDevicesAfterError,
+					GetDeviceConnectionNameError:     tc.getConnNameError,
 					WaitForDeviceChangesImpl: func() error {
 						if tc.ctxCancel {
 							cancel()

--- a/windows-agent/internal/daemon/netwatcher_test.go
+++ b/windows-agent/internal/daemon/netwatcher_test.go
@@ -1,0 +1,141 @@
+package daemon_test
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/daemontestutils"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/daemon/netmonitoring"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribe(t *testing.T) {
+	t.Parallel()
+
+	mockError := errors.New("mock error")
+
+	before := map[string]string{
+		uuid.New().String(): "conn0",
+		uuid.New().String(): "conn1",
+		uuid.New().String(): "conn2",
+	}
+
+	after := map[string]string{
+		uuid.New().String(): "new",
+		"not a guid":        "yet_another_new",
+	}
+
+	maps.Copy(after, before)
+
+	testcases := map[string]struct {
+		initError             error
+		listDevicesError      error
+		listDevicesAfterError error
+		getConnNameError      error
+		waitError             error
+
+		ctxCancel           bool
+		startWithNoAdapters bool
+		devicesUnchanged    bool
+
+		wantErr        bool
+		wantNoCallback bool
+		wantName       string
+	}{
+		"Success": {},
+		"When the system starts with no adapters": {startWithNoAdapters: true, wantName: "conn0"},
+
+		"Cannot subscribe when initializing the API fails":    {initError: mockError, wantErr: true},
+		"Cannot subscribe when listing devices fails":         {listDevicesError: mockError, wantErr: true},
+		"Cannot subscribe when getting connection name fails": {getConnNameError: mockError, wantErr: true},
+
+		"Cannot notify when waiting for changes fails":                         {waitError: mockError, wantNoCallback: true},
+		"Cannot notify when the context is cancelled while waiting":            {ctxCancel: true, wantNoCallback: true},
+		"Cannot notify when OS triggers a notification without device changes": {devicesUnchanged: true, wantNoCallback: true},
+		"Cannot notify when listing devices on notification fails":             {listDevicesAfterError: mockError, wantNoCallback: true},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			switch tc.wantName {
+			case "":
+				tc.wantName = "new"
+			case "-":
+				tc.wantName = ""
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			initAPI := func() (netmonitoring.DevicesAPI, error) {
+				if tc.initError != nil {
+					return nil, tc.initError
+				}
+
+				b := before
+				if tc.startWithNoAdapters {
+					b = make(map[string]string, 0)
+				}
+				a := after
+				if tc.devicesUnchanged {
+					a = before
+				}
+				return &daemontestutils.NetMonitoringMockAPI{
+					Before:                       b,
+					After:                        a,
+					ListDevicesError:             tc.listDevicesError,
+					ListDevicesAfterError:        tc.listDevicesAfterError,
+					GetDeviceConnectionNameError: tc.getConnNameError,
+					WaitForDeviceChangesImpl: func() error {
+						if tc.ctxCancel {
+							cancel()
+							<-ctx.Done()
+							return ctx.Err()
+						}
+						// Introduces some asynchrony to the test.
+						<-time.After(50 * time.Millisecond)
+						return tc.waitError
+					},
+				}, nil
+			}
+
+			added := make(chan string, 1)
+			defer close(added)
+			callback := func(adapterNames []string) bool {
+				added <- adapterNames[0]
+				return false
+			}
+
+			n, err := daemon.Subscribe(ctx, callback, daemon.WithNetDevicesAPIProvider(initAPI))
+
+			if tc.wantErr {
+				require.Error(t, err, "Subscribe should have failed")
+				return
+			}
+			require.NoError(t, err, "Subscribe should have succeeded")
+
+			select {
+			case res := <-added:
+				require.Equal(t, tc.wantName, res, "unexpected new network adapter")
+			case <-time.After(200 * time.Millisecond):
+				if !tc.wantNoCallback {
+					require.Fail(t, "timeout waiting for new network adapter")
+				}
+			}
+
+			// Collect the error reported by the wait operation.
+			err = n.Stop()
+			if tc.waitError != nil || tc.wantNoCallback || tc.ctxCancel {
+				require.Error(t, err, "Stop should have failed")
+				return
+			}
+			require.NoError(t, err, "Stop should have succeeded")
+		})
+	}
+}

--- a/windows-agent/internal/daemon/netwatcher_test.go
+++ b/windows-agent/internal/daemon/netwatcher_test.go
@@ -43,21 +43,21 @@ func TestSubscribe(t *testing.T) {
 		startWithNoAdapters bool
 		devicesUnchanged    bool
 
-		wantErr        bool
-		wantNoCallback bool
 		wantName       string
+		wantNoCallback bool
+		wantErr        bool
 	}{
 		"Success": {},
 		"When the system starts with no adapters": {startWithNoAdapters: true, wantName: "conn0"},
-
-		"Cannot subscribe when initializing the API fails":    {initError: mockError, wantErr: true},
-		"Cannot subscribe when listing devices fails":         {listDevicesError: mockError, wantErr: true},
-		"Cannot subscribe when getting connection name fails": {getConnNameError: mockError, wantErr: true},
 
 		"Cannot notify when waiting for changes fails":                         {waitError: mockError, wantNoCallback: true},
 		"Cannot notify when the context is cancelled while waiting":            {ctxCancel: true, wantNoCallback: true},
 		"Cannot notify when OS triggers a notification without device changes": {devicesUnchanged: true, wantNoCallback: true},
 		"Cannot notify when listing devices on notification fails":             {listDevicesAfterError: mockError, wantNoCallback: true},
+
+		"Error to subscribe when initializing the API fails":    {initError: mockError, wantErr: true},
+		"Error to subscribe when listing devices fails":         {listDevicesError: mockError, wantErr: true},
+		"Error to subscribe when getting connection name fails": {getConnNameError: mockError, wantErr: true},
 	}
 
 	for name, tc := range testcases {

--- a/windows-agent/internal/daemon/networking.go
+++ b/windows-agent/internal/daemon/networking.go
@@ -15,30 +15,11 @@ import (
 	"github.com/ubuntu/decorate"
 )
 
-type options struct {
-	wslCmd               []string
-	wslCmdEnv            []string
-	getAdaptersAddresses getAdaptersAddressesFunc
-}
-
-var defaultOptions = options{
-	wslCmd:               []string{"wsl.exe"},
-	getAdaptersAddresses: getWindowsAdaptersAddresses,
-}
-
-// Option represents an optional function to override getWslIP default values.
-type Option func(*options)
-
 type getAdaptersAddressesFunc func(family uint32, flags uint32, reserved uintptr, adapterAddresses *ipAdapterAddresses, sizePointer *uint32) (errcode error)
 
 // getWslIP returns the loopback address if the networking mode is mirrored or iterates over the network adapters to find the IP address of the WSL one.
-func getWslIP(ctx context.Context, args ...Option) (ip net.IP, err error) {
+func getWslIP(ctx context.Context, opts options) (ip net.IP, err error) {
 	defer decorate.OnError(&err, "could not determine WSL IP address: ")
-
-	opts := defaultOptions
-	for _, arg := range args {
-		arg(&opts)
-	}
 
 	mode, err := networkingMode(ctx, opts.wslCmd, opts.wslCmdEnv)
 	if err != nil {

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -119,12 +119,17 @@ func checkFileExists(path string) func() bool {
 func TestRegisterGRPCServices(t *testing.T) {
 	t.Parallel()
 
+	defaultServices := []string{"agentapi.UI", "agentapi.WSLInstance"}
+
 	testCases := map[string]struct {
 		insecureClient bool
+		withoutWSLNet  bool
 
-		wantErr bool
+		wantServices []string
+		wantErr      bool
 	}{
-		"Success": {},
+		"Success with WSL net adapter":    {},
+		"Success without WSL net adapter": {withoutWSLNet: true, wantServices: []string{"agentapi.UI"}},
 
 		"Error with insecure requests": {insecureClient: true, wantErr: true},
 	}
@@ -132,6 +137,10 @@ func TestRegisterGRPCServices(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.wantServices == nil {
+				tc.wantServices = defaultServices
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
@@ -142,16 +151,15 @@ func TestRegisterGRPCServices(t *testing.T) {
 			require.NoError(t, err, "Setup: New should return no error")
 			defer s.Stop(ctx)
 
-			server := s.RegisterGRPCServices(context.Background(), true)
+			server := s.RegisterGRPCServices(context.Background(), !tc.withoutWSLNet)
 			info := server.GetServiceInfo()
 
-			_, ok := info["agentapi.UI"]
-			require.True(t, ok, "UI service should be registered after calling RegisterGRPCServices")
+			for _, service := range tc.wantServices {
+				_, ok := info[service]
+				require.True(t, ok, "%s service should be registered after calling RegisterGRPCServices", service)
+			}
 
-			_, ok = info["agentapi.WSLInstance"]
-			require.True(t, ok, "WSLInstance service should be registered after calling RegisterGRPCServices")
-
-			require.Lenf(t, info, 2, "Info should contain exactly two elements")
+			require.Lenf(t, info, len(tc.wantServices), "Info should contain exactly two elements")
 
 			// Run the server configured by RegisterGRPCServices.
 			var cfg net.ListenConfig

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -128,19 +128,15 @@ func TestRegisterGRPCServices(t *testing.T) {
 		wantServices []string
 		wantErr      bool
 	}{
-		"Success with WSL net adapter":    {},
+		"Success with WSL net adapter":    {wantServices: defaultServices},
 		"Success without WSL net adapter": {withoutWSLNet: true, wantServices: []string{"agentapi.UI"}},
 
-		"Error with insecure requests": {insecureClient: true, wantErr: true},
+		"Error with insecure requests": {insecureClient: true, wantServices: defaultServices, wantErr: true},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-
-			if tc.wantServices == nil {
-				tc.wantServices = defaultServices
-			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -142,7 +142,7 @@ func TestRegisterGRPCServices(t *testing.T) {
 			require.NoError(t, err, "Setup: New should return no error")
 			defer s.Stop(ctx)
 
-			server := s.RegisterGRPCServices(context.Background())
+			server := s.RegisterGRPCServices(context.Background(), true)
 			info := server.GetServiceInfo()
 
 			_, ok := info["agentapi.UI"]


### PR DESCRIPTION
The key of this PR is enable a sensible behaviour for the Windows agent when there is no WSL network adapter, which is also when there is no WSL instance registered. It's behaviour remain changed otherwise. When started under such condition:

- The proservices skip registering the WSL instance gRPC service
- The daemon subscribes to OS notifications related to additions of network interfaces
- If triggered with the WSL adapter in the list of new interfaces recently added, restarts itself, i.e.
  * stops the current gRPC server and 
  * creates a new one with all proservices enabled
  
A live demonstration of this huge patch on a fresh VM with the latest stable WSL and Ubuntu-24.04 from the package flight:

https://github.com/user-attachments/assets/e35f36b8-318b-4d98-b6ab-0b59f4b1fff1

The daemon was not meant to be restarted, thus a huge part of this diff is changing its internals while preserving its interface and most of its semantics. Clients (agent app) and collaborators (proservices) are mostly unaffected by such changes.

I implemented the OS notification component as a thin wrapper on top of the Windows registry relying on the stability of the network control set registry path. It's maintained by the operating system and match the behaviour observed with the virtual adapters (not removed when the last WSL instance is unregistered, until system reboot). When discussing WS035 we agreed in not exposing the registry as much looking into the possibility of reimplementing that layer using a more specific API. I didn't find yet any Win32 API suitable for use in Go without CGo that offers the flexibility I found in the registry.

As you can notice in the recording, the daemon is restarted much before the newly registered instance is ready, thus wsl-pro-service doesn't require any changes. By the time systemd kicks in, the agent is already listening. There was one line removal on the GUI side to prevent it from deleting the `.address` file upfront if it finds the agent non-responsive, which could be the case of the daemon restarting. The GUI attempts to read the `.address` file, if not found then it attempts to start the agent application. 

---

UDENG-3838