### PR TITLE
fix(windows-agent): Can't find config file inside the public dir

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
@@ -32,7 +33,7 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 		vip.SetConfigName(name)
 		vip.AddConfigPath("./")
 		vip.AddConfigPath("$HOME")
-		vip.AddConfigPath(fmt.Sprintf("$HOME/%s", common.UserProfileDir))
+		vip.AddConfigPath(filepath.Join("$HOME", common.UserProfileDir))
 	}
 
 	// Load the config


### PR DESCRIPTION
`%USERPROFILE%\.ubuntupro`.

The fix I'm proposing here is the simplest but maybe less correct if we consider that the public dir could point to anywhere else other than the default (`%USERPROFILE%\.ubuntupro` when in production). 

The issue is: when configuring viper we added `$HOME/.ubuntupro` to the config paths. Since `$HOME` is not defined on Windows nor `/` is the default path separator, that addition never worked. By ensuring we use the correct path separator, we allow viper to consider `%HOMEDRIVE%` , `%HOMEPATH%` and `%USERPROFILE%`  for `$HOME` (viper's implementation details).

The test case `"When the config is in user's public directory"` would only fail on Windows.