### PR TITLE
maint(windows-agent): Investigate skipping distros

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/snapcore/go-gettext v0.0.0-20230721153050-9082cdc2db05
 	github.com/stretchr/testify v1.10.0
 	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb
-	github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53
+	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
 	google.golang.org/grpc v1.68.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
 	google.golang.org/protobuf v1.35.2
@@ -24,7 +24,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/common/go.sum
+++ b/common/go.sum
@@ -35,15 +35,11 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
 golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=

--- a/common/go.sum
+++ b/common/go.sum
@@ -37,11 +37,15 @@ github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVfl
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
 golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 h1:pPJltXNxVzT4pK9yD8vR9X75DaWYYmLGMsEvBfFQZzQ=

--- a/end-to-end/go.mod
+++ b/end-to-end/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f
 	github.com/canonical/ubuntu-pro-for-wsl/mocks v0.0.0-20240909072650-75a32126b04f
 	github.com/stretchr/testify v1.10.0
-	github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53
+	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sys v0.28.0
 	google.golang.org/grpc v1.68.1

--- a/end-to-end/go.sum
+++ b/end-to-end/go.sum
@@ -43,8 +43,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=

--- a/end-to-end/go.sum
+++ b/end-to-end/go.sum
@@ -45,6 +45,8 @@ github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVfl
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/tomarrell/wrapcheck/v2 v2.9.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
 	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb // indirect
-	github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 // indirect
+	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 // indirect
 	github.com/ultraware/funlen v0.1.0 // indirect
 	github.com/ultraware/whitespace v0.1.1 // indirect
 	github.com/uudashr/gocognit v1.1.3 // indirect
@@ -203,7 +203,7 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -580,6 +580,8 @@ github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVfl
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 github.com/ultraware/funlen v0.1.0 h1:BuqclbkY6pO+cvxoq7OsktIXZpgBSkYTQtmwhAK81vI=
 github.com/ultraware/funlen v0.1.0/go.mod h1:XJqmOQja6DpxarLj6Jj1U7JuoS8PvL4nEqDaQhy22p4=
 github.com/ultraware/whitespace v0.1.1 h1:bTPOGejYFulW3PkcrqkeQwOd6NKOOXvmGD9bo/Gk8VQ=
@@ -795,6 +797,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7 h1:FemxDzfMUcK2f3YY4H+05K9CDzbSVr2+q/JKN45pey0=
 golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -578,8 +578,6 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 github.com/ultraware/funlen v0.1.0 h1:BuqclbkY6pO+cvxoq7OsktIXZpgBSkYTQtmwhAK81vI=
@@ -795,8 +793,6 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
-golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7 h1:FemxDzfMUcK2f3YY4H+05K9CDzbSVr2+q/JKN45pey0=

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb
-	github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53
+	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sys v0.28.0
 	google.golang.org/grpc v1.68.1

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -84,6 +84,8 @@ github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVfl
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
 github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
+github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -82,8 +82,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
 github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53 h1:oP5UldDfHJsg8tJuYqWzEfGTmOqsb5gtLEisUYaIoB4=
-github.com/ubuntu/gowsl v0.0.0-20240709100851-bc766d3dbd53/go.mod h1:h7p0dcWeNrhTV3bM+fdVSAfpWepPOqZk4bX5YdmIhRc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
 github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/windows-agent/internal/proservices/landscape/utils.go
+++ b/windows-agent/internal/proservices/landscape/utils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	landscapeapi "github.com/canonical/landscape-hostagent-api"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
@@ -202,7 +203,12 @@ func (e newInstanceInfoMinorError) Error() string {
 func newInstanceInfo(d *distro.Distro) (info *landscapeapi.HostAgentInfo_InstanceInfo, err error) {
 	state, err := d.State()
 	if err != nil {
-		return info, err
+		// Try again
+		<-time.After(1 * time.Second)
+		state, err = d.State()
+		if err != nil {
+			return info, fmt.Errorf("WSL internal error after retry: %v", err)
+		}
 	}
 
 	var instanceState landscapeapi.InstanceState


### PR DESCRIPTION

```
time=2024-07-24T12:17:10-07:00 level=error msg=Landscape:  skipping distro "Ubuntu-24.04" from landscape info: could not get distro "Ubuntu-24.04"'s state: could not get states of distros: exit status 1. Stdout: . Stderr:
```

That happens during construction of the status message sent to Landscape. If we skip a distro, Landscape understands it doesn't exist anymore and removes it from the dashboard. But that happens sometimes when an existing distro. It seems a WSL internal error.

https://github.com/ubuntu/GoWSL/pull/120 should prevent the stdout and stderr messages to come empty as shown above.
Thus I'm updating GoWSL here.

That doesn't prevent the issue itself.

I couldn’t reproduce this outside of UP4W. I attempted building a small binary in Go doing the same steps as GoWSL does and put it to run during system startup in loop, rebooted the OS many times but no success. The few times I’ve seen this happening in the logs were early during app startup, so I suspect it may happen because some WSL internal component is not yet ready. Thus this PR: adding one-time retry if an error happens when attempting to retrieve a distro state.

Either that will prevent the issue once for all or at least give us more context about what causes that error.

---

UDENG-3722