### PR TITLE
fix(windows-agent): Run cloud-init when installing from a tarball

### DIFF
--- a/windows-agent/internal/distros/distro/touchdistro/touch_distro_gowslmock.go
+++ b/windows-agent/internal/distros/distro/touchdistro/touch_distro_gowslmock.go
@@ -1,8 +1,8 @@
 //go:build gowslmock
 
 // Package touchdistro exists to provide multiple, mockable implementations
-// for the action of touching a distro, i.e. sending a short-lived command so
-// as to wake it up.
+// for the actions of touching a distro, i.e. sending a short-lived command so
+// as to wake it up, and waiting for distro initialisation with cloud-init.
 package touchdistro
 
 import (
@@ -24,6 +24,23 @@ func Touch(ctx context.Context, distroName string) error {
 
 	if err := d.Shell(wsl.WithCommand("exit 0")); err != nil {
 		return fmt.Errorf("could not run 'exit 0': %v", err)
+	}
+
+	return nil
+}
+
+// WaitForCloudInit sends a "exit 0" command to a distro because tests are not really interested in details of a cloud-init run.
+func WaitForCloudInit(ctx context.Context, distroName string) error {
+	d := wsl.NewDistro(ctx, distroName)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if err := d.Shell(wsl.WithCommand("exit 0")); err != nil {
+		return fmt.Errorf("could not pretend to run 'cloud-init': %v", err)
 	}
 
 	return nil

--- a/windows-agent/internal/distros/distro/touchdistro/touch_distro_linux.go
+++ b/windows-agent/internal/distros/distro/touchdistro/touch_distro_linux.go
@@ -1,8 +1,8 @@
 //go:build !gowslmock
 
 // Package touchdistro exists to provide multiple, mockable implementations
-// for the action of touching a distro, i.e. sending a short-lived command so
-// as to wake it up.
+// for the actions of touching a distro, i.e. sending a short-lived command so
+// as to wake it up, and waiting for distro initialisation with cloud-init.
 package touchdistro
 
 import (
@@ -12,4 +12,9 @@ import (
 // Touch is a stub function panics. Use the gowslmock in order to use it in Linux.
 func Touch(ctx context.Context, distroName string) error {
 	panic("Touch: this function can only be run on Windows")
+}
+
+// WaitForCloudInit is a stub function panics. Use the gowslmock in order to use it in Linux.
+func WaitForCloudInit(ctx context.Context, distroName string) error {
+	panic("WaitForCloudInit: this function can only be run on Windows")
 }

--- a/windows-agent/internal/distros/distro/touchdistro/touch_distro_windows.go
+++ b/windows-agent/internal/distros/distro/touchdistro/touch_distro_windows.go
@@ -1,8 +1,8 @@
 //go:build !gowslmock
 
 // Package touchdistro exists to provide multiple, mockable implementations
-// for the action of touching a distro, i.e. sending a short-lived command so
-// as to wake it up.
+// for the actions of touching a distro, i.e. sending a short-lived command so
+// as to wake it up, and waiting for distro initialisation with cloud-init.
 package touchdistro
 
 import (
@@ -14,6 +14,25 @@ import (
 
 // Touch sends a "exit 0" command to a distro in order to wake it up.
 func Touch(ctx context.Context, distroName string) error {
+	cmd := wslCmd(ctx, distroName, "exit", "0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("could not run 'exit 0': %v. Output: %s", err, out)
+	}
+
+	return nil
+}
+
+// WaitForCloudInit blocks the caller until cloud-init has finished initialising the distro.
+func WaitForCloudInit(ctx context.Context, distroName string) error {
+	cmd := wslCmd(ctx, distroName, "cloud-init", "status", "--wait")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("could not run 'cloud-init': %v. Output: %s", err, out)
+	}
+
+	return nil
+}
+
+func wslCmd(ctx context.Context, distroName string, args ...string) *exec.Cmd {
 	// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 	//
 	// CREATE_NO_WINDOW:
@@ -22,15 +41,11 @@ func Touch(ctx context.Context, distroName string) error {
 	// application is not set.
 	const createNoWindow = 0x08000000
 
-	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", distroName, "--", "exit", "0")
+	cmd := exec.CommandContext(ctx, "wsl.exe", append([]string{"-d", distroName, "--"}, args...)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,
 		CreationFlags: createNoWindow,
 	}
 
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("could not run 'exit 0': %v. Output: %s", err, out)
-	}
-
-	return nil
+	return cmd
 }

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -270,9 +270,9 @@ func installFromURL(ctx context.Context, homeDir string, downloadDir string, dis
 		}
 		return err
 	}
-	// If import was successful, let's launch cloud-init and wait for it to finish:
+	// If import was successful, let's wait for cloud-init to finish:
 	if err := touchdistro.WaitForCloudInit(ctx, distro.Name()); err != nil {
-		log.Infof(ctx, "failed to run cloud-init: %v", err)
+		log.Infof(ctx, "cloud-init failed: %v", err)
 	}
 	_ = distro.Terminate()
 	log.Debugf(ctx, "Distro %s installed successfully", distro.Name())

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -269,6 +269,13 @@ func installFromURL(ctx context.Context, homeDir string, downloadDir string, dis
 		}
 		return err
 	}
+	// If import was successful, let's launch cloud-init:
+	cmd := distro.Command(ctx, "cloud-init status --wait")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Infof(ctx, "failed to run cloud-init: %v\n%s", err, string(out))
+	}
+	_ = distro.Terminate()
+	log.Debugf(ctx, "Distro %s installed successfully", distro.Name())
 	return nil
 }
 

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -17,6 +17,7 @@ import (
 
 	landscapeapi "github.com/canonical/landscape-hostagent-api"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro/touchdistro"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/landscape/distroinstall"
 	"github.com/ubuntu/decorate"
 	"github.com/ubuntu/gowsl"
@@ -269,10 +270,9 @@ func installFromURL(ctx context.Context, homeDir string, downloadDir string, dis
 		}
 		return err
 	}
-	// If import was successful, let's launch cloud-init:
-	cmd := distro.Command(ctx, "cloud-init status --wait")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Infof(ctx, "failed to run cloud-init: %v\n%s", err, string(out))
+	// If import was successful, let's launch cloud-init and wait for it to finish:
+	if err := touchdistro.WaitForCloudInit(ctx, distro.Name()); err != nil {
+		log.Infof(ctx, "failed to run cloud-init: %v", err)
 	}
 	_ = distro.Terminate()
 	log.Debugf(ctx, "Distro %s installed successfully", distro.Name())

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -165,19 +165,19 @@ func TestInstall(t *testing.T) {
 		sendRootfsURL    string
 		missingChecksums bool
 
-		wantCouldInitWriteCalled bool
+		wantCloudInitWriteCalled bool
 		wantInstalled            bool
 	}{
-		"From the store":                    {wantInstalled: true, wantCouldInitWriteCalled: true},
+		"From the store":                    {wantInstalled: true, wantCloudInitWriteCalled: true},
 		"From a rootfs URL with a checksum": {sendRootfsURL: "goodfile", wantInstalled: true},
-		"With no cloud-init":                {noCloudInit: true, wantCouldInitWriteCalled: true, wantInstalled: true},
+		"With no cloud-init":                {noCloudInit: true, wantCloudInitWriteCalled: true, wantInstalled: true},
 		"With no checksum file":             {missingChecksums: true, sendRootfsURL: "goodfile", wantInstalled: true},
 
 		"Error when the distroname is empty":         {distroName: "-"},
 		"Error when the Appx does not exist":         {appxDoesNotExist: true},
 		"Error when the distro is already installed": {distroAlreadyInstalled: true, wantInstalled: true},
 		"Error when the distro fails to install":     {wslInstallErr: true},
-		"Error when cannot write cloud-init file":    {cloudInitWriteErr: true, wantCouldInitWriteCalled: true},
+		"Error when cannot write cloud-init file":    {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
 
 		"Error when the distro ID is reserved (Ubuntu)":                   {sendRootfsURL: "goodfile", distroName: "Ubuntu", wantInstalled: false},
 		"Error when the distro ID is reserved (Preview)":                  {sendRootfsURL: "goodfile", distroName: "Ubuntu-Preview", wantInstalled: false},
@@ -315,7 +315,7 @@ func TestInstall(t *testing.T) {
 						require.False(t, distroExists, "Distro should not have been registered")
 					}
 
-					if tc.wantCouldInitWriteCalled {
+					if tc.wantCloudInitWriteCalled {
 						require.True(t, testBed.cloudInit.writeCalled.Load(), "Cloud-init should have been called to write the user data file")
 					}
 				})

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -161,6 +161,7 @@ func TestInstall(t *testing.T) {
 		breakVhdxDir           bool
 		breakTarFile           bool
 		breakTempDir           bool
+		cloudInitExecFailure   bool
 
 		sendRootfsURL    string
 		missingChecksums bool
@@ -172,6 +173,7 @@ func TestInstall(t *testing.T) {
 		"From a rootfs URL with a checksum": {sendRootfsURL: "goodfile", wantInstalled: true},
 		"With no cloud-init":                {noCloudInit: true, wantCloudInitWriteCalled: true, wantInstalled: true},
 		"With no checksum file":             {missingChecksums: true, sendRootfsURL: "goodfile", wantInstalled: true},
+		"With cloud-init failure":           {sendRootfsURL: "goodfile", cloudInitExecFailure: true, wantInstalled: true},
 
 		"Error when the distroname is empty":         {distroName: "-"},
 		"Error when the Appx does not exist":         {appxDoesNotExist: true},
@@ -263,6 +265,10 @@ func TestInstall(t *testing.T) {
 
 					if tc.wslInstallErr {
 						testBed.wslMock.InstallError = true
+					}
+
+					if tc.cloudInitExecFailure {
+						testBed.wslMock.WslLaunchInteractiveError = true
 					}
 
 					var cloudInit string


### PR DESCRIPTION
This PR augments the touchdistro package to provide a function that waits on cloud-init. Whether it errors or not only affect logging, thus we can provide simpler mocks. The important part is: we need to run the new function when installing a distro from a custom rootfs, when there is no distro launcher to do so.

----

UDENG-4066