### PR TITLE
ci: Creates a workflow to publish the MSIX automatically

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     description: "Configure mode publication. Should be either production or end_to_end_tests"
     default: "production"
+  package-mode:
+    required: true
+    description: "Configure package mode. Should be either 'StoreUpload' or 'SideloadOnly'"
+    default: "SideloadOnly"
   certificate:
     required: true
     description: "certificate to pass to sign the msix"
@@ -67,8 +71,7 @@ runs:
           -property:Configuration=${{ inputs.mode == 'production' && 'Release' || 'Debug'}} `
           -property:AppxBundle=Always                                                       `
           -property:AppxBundlePlatforms=x64                                                 `
-          -property:UapAppxPackageBuildMode=SideloadOnly                                    `
-          -property:Version=0.0.1+${{ github.sha }}                                         `
+          -property:UapAppxPackageBuildMode=${{ inputs.package-mode }}                      `
           -property:UP4W_END_TO_END=${{ inputs.mode == 'end_to_end_tests' }}                `
           -nologo                                                                           `
           -verbosity:normal

--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -1,0 +1,44 @@
+name: Publish MSIX app to the Microsoft Store
+concurrency: publish-msix
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-msix:
+    name: Publish MSIX app to the Microsoft Store
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Build MSIX app
+        uses: ./.github/actions/build-msix
+        with:
+          certificate: ${{ secrets.CERTIFICATE }}
+          certificate_password: ${{ secrets.CERTIFICATE_PASSWORD }}
+
+      - name: Install Store Broker
+        shell: powershell
+        run: |
+          Install-Module -Name StoreBroker -AcceptLicense -Force -Scope CurrentUser -Verbose
+      - name: Submit to Microsoft Store
+        shell: powershell
+        run: |
+          New-Item -ItemType directory -Path store -Force
+
+          # Authenticate against the store
+          $pass = ConvertTo-SecureString -String '${{ secrets.PRO_APP_PUBLICATION_APPKEY }}' -AsPlainText -Force
+          $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ${{ secrets.AZUREAD_APPID }},$pass
+          Set-StoreBrokerAuthentication -TenantId '${{ secrets.AZUREAD_TENANTID }}' -Credential $cred
+
+          # Set store app ID for AppID
+          $appid = "9PD1WZNBDXKZ"
+
+          # Prepare and submit to the Store
+          New-SubmissionPackage -ConfigPath .\msix\SBConfig.json
+          Update-ApplicationSubmission -AppId $appid -SubmissionDataPath "out\appstore-submission.json" -PackagePath "out\appstore-submission.zip" -Force -Autocommit -ReplacePackages

--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           certificate: ${{ secrets.CERTIFICATE }}
           certificate_password: ${{ secrets.CERTIFICATE_PASSWORD }}
+          package-mode: StoreUpload
 
       - name: Install Store Broker
         shell: powershell

--- a/msix/SBConfig.json
+++ b/msix/SBConfig.json
@@ -1,0 +1,50 @@
+﻿{
+  "packageParameters": {
+    "PDPRootPath": "",
+    "Release": "",
+    "PDPInclude": [],
+    "PDPExclude": [],
+    "LanguageExclude": [
+      "default"
+    ],
+    "ImagesRootPath": "",
+    "MediaFallbackLanguage": "",
+    "AppxPath": "./msix/UbuntuProForWSL/AppPackages/UbuntuProForWSL_*.msixupload",
+    "OutPath": "out",
+    "OutName": "appstore-submission",
+    "DisableAutoPackageNameFormatting": false
+  },
+  "appSubmission": {
+    "appId": "9PD1WZNBDXKZ",
+    "targetPublishMode": "Manual",
+    "visibility": "Private",
+    "pricing": {
+      "priceId": "Free",
+      "trialPeriod": "NoFreeTrial",
+      "marketSpecificPricings": {
+        "EH": "NotAvailable"
+      },
+      "sales": []
+    },
+    "allowTargetFutureDeviceFamilies": {
+      "Xbox": false,
+      "Team": false,
+      "Holographic": false,
+      "Desktop": true,
+      "Mobile": false
+    },
+    "allowMicrosoftDecideAppAvailabilityToFutureDeviceFamilies": true,
+    "enterpriseLicensing": "OnlineAndOffline",
+    "applicationCategory": "DeveloperTools",
+    "hardwarePreferences": "Keyboard",
+    "hasExternalInAppProducts": false,
+    "meetAccessibilityGuidelines": false,
+    "canInstallOnRemovableMedia": true,
+    "automaticBackupEnabled": true,
+    "isGameDvrEnabled": false,
+    "gamingOptions": [
+      {}
+    ],
+    "notesForCertification": "- Removed obsolete packages\n\n---\nThis is still for internal testing."
+  }
+}

--- a/tools/build/compute_version.go
+++ b/tools/build/compute_version.go
@@ -47,7 +47,7 @@ func computeNumericVersion() string {
 		os.Exit(1)
 	}
 
-	expr := regexp.MustCompile(`(\d+\.\d+\.\d+)-`)
+	expr := regexp.MustCompile(`(\d+\.\d+\.\d+)`)
 	matches := expr.FindStringSubmatch(tag)
 	if len(matches) != 2 {
 		fmt.Fprintf(os.Stderr, "Error: tag %s does not match the expected format\n", tag)


### PR DESCRIPTION
This reuses the MSIX build action and relies on the StoreBroker PowerShell module to push the updates to the Partner Center.

I'm tagging this commit as a "fake release" so we can see the workflow in action bumping the package version.

## Important note about versioning

We only track package versioning in Git, the MSIX version is declared in the appx manifest as 0.0.0.0 and should remain like that as we compute the version dynamically from the closest Git tag and edit the appx manifest on the fly as part of the CI job. Similarly the binaries have a full version string computed in the same way, just more descriptive as they also contain a build number and the commit short SHA-1 (remember the last (fourth) section of the version number [is reserved for Store use and must be left as 0](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msix/app-package-requirements#version-numbering-for-windows10-and-11-packages) ).

--- 


UDENG-2267