### PR TITLE
fix(gui-ubuntupro): Add filters for cert files in file picker

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -381,7 +381,7 @@ class _SelfHostedForm extends StatelessWidget {
             hint: 'C:\\landscape.pem',
             inputlabel: lang.landscapeSSLKeyLabel,
             onChanged: model.setSslKeyPath,
-            allowedExtensions: ['cer', 'crt', 'der', 'pem'],
+            allowedExtensions: const ['cer', 'crt', 'der', 'pem'],
           ),
         ),
       ],

--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -381,6 +381,7 @@ class _SelfHostedForm extends StatelessWidget {
             hint: 'C:\\landscape.pem',
             inputlabel: lang.landscapeSSLKeyLabel,
             onChanged: model.setSslKeyPath,
+            allowedExtensions: ['cer', 'crt', 'der', 'pem'],
           ),
         ),
       ],
@@ -417,11 +418,13 @@ class _FilePickerField extends StatefulWidget {
     required this.hint,
     required this.inputlabel,
     required this.onChanged,
+    this.allowedExtensions,
   });
 
   final String buttonLabel, inputlabel;
   final String? errorText, hint;
   final Function(String?) onChanged;
+  final List<String>? allowedExtensions;
 
   @override
   State<_FilePickerField> createState() => _FilePickerFieldState();
@@ -462,7 +465,12 @@ class _FilePickerFieldState extends State<_FilePickerField> {
         ),
         FilledButton(
           onPressed: () async {
-            final result = await FilePicker.platform.pickFiles();
+            final result = await FilePicker.platform.pickFiles(
+              allowedExtensions: widget.allowedExtensions,
+              type: widget.allowedExtensions == null
+                  ? FileType.any
+                  : FileType.custom,
+            );
             if (result != null) {
               final file = File(result.files.single.path!);
               txt.text = file.path;

--- a/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
@@ -27,7 +27,7 @@ void main() {
   // This should be resolved so that we don't have to specify a manual text scale factor.
   // See more: https://github.com/flutter/flutter/issues/108726#issuecomment-1205035859
   binding.platformDispatcher.textScaleFactorTestValue = 0.6;
-  FilePicker.platform = FakeFilePicker([ca_cert]);
+  FilePicker.platform = FakeFilePicker([caCert]);
 
   group('input sections', () {
     testWidgets('default state', (tester) async {
@@ -156,7 +156,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final fileInput = find.ancestor(
-        of: find.text(ca_cert),
+        of: find.text(caCert),
         matching: find.byType(TextField),
       );
       expect(fileInput, findsOne);
@@ -164,7 +164,7 @@ void main() {
       await tester.tap(fileInput);
       await tester.pump();
 
-      await tester.enterText(fileInput, client_cert);
+      await tester.enterText(fileInput, clientCert);
       await tester.pump();
 
       await tester.tap(continueButton);
@@ -278,7 +278,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final fileInput = find.ancestor(
-        of: find.text(ca_cert),
+        of: find.text(caCert),
         matching: find.byType(TextField),
       );
       expect(fileInput, findsOne);
@@ -404,8 +404,8 @@ Widget buildApp(
 
 const customConf = './test/testdata/landscape/custom.conf';
 const notFoundPath = './test/testdata/landscape/notfound.txt';
-const ca_cert = './test/testdata/certs/ca_cert.pem';
-const client_cert = './test/testdata/certs/client_cert.pem';
+const caCert = './test/testdata/certs/ca_cert.pem';
+const clientCert = './test/testdata/certs/client_cert.pem';
 
 class FakeFilePicker extends FilePicker {
   /// Fake [FilePicker] that always returns the given `paths`.

--- a/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
@@ -148,11 +148,7 @@ void main() {
       await tester.enterText(fqdnInput, 'test.l.com');
       await tester.pump();
 
-      final chooseFileButton = find.ancestor(
-        of: find.text(lang.landscapeFilePicker),
-        matching: find.byType(FilledButton),
-      );
-      await tester.tap(chooseFileButton);
+      await tester.tap(find.text(lang.landscapeFilePicker));
       await tester.pumpAndSettle();
 
       final fileInput = find.ancestor(
@@ -270,11 +266,7 @@ void main() {
       final fqdnErrorText = find.text(lang.landscapeFQDNError);
       expect(fqdnErrorText, findsOne);
 
-      final chooseFileButton = find.ancestor(
-        of: find.text(lang.landscapeFilePicker),
-        matching: find.byType(FilledButton),
-      );
-      await tester.tap(chooseFileButton);
+      await tester.tap(find.text(lang.landscapeFilePicker));
       await tester.pumpAndSettle();
 
       final fileInput = find.ancestor(
@@ -427,11 +419,8 @@ class FakeFilePicker extends FilePicker {
     bool withReadStream = false,
     bool lockParentWindow = false,
     bool readSequential = false,
-  }) {
-    return Future(
-      () async => FilePickerResult(
+  }) async =>
+      FilePickerResult(
         paths.map((p) => PlatformFile(name: p, path: p, size: 0)).toList(),
-      ),
-    );
-  }
+      );
 }

--- a/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/landscape/landscape_page_test.dart
@@ -145,6 +145,17 @@ void main() {
 
       await tester.enterText(fqdnInput, 'test.l.com');
       await tester.pump();
+
+      final fileInput = find.ancestor(
+        of: find.text(lang.landscapeSSLKeyLabel),
+        matching: find.byType(TextField),
+      );
+      await tester.tap(fileInput);
+      await tester.pump();
+
+      await tester.enterText(fileInput, cert);
+      await tester.pump();
+
       await tester.tap(continueButton);
       await tester.pump();
       expect(applied, isTrue);
@@ -245,8 +256,21 @@ void main() {
       await tester.enterText(fqdnInput, '::');
       await tester.pump();
 
-      final errorText = find.text(lang.landscapeFQDNError);
-      expect(errorText, findsOne);
+      final fqdnErrorText = find.text(lang.landscapeFQDNError);
+      expect(fqdnErrorText, findsOne);
+
+      final fileInput = find.ancestor(
+        of: find.text(lang.landscapeSSLKeyLabel),
+        matching: find.byType(TextField),
+      );
+      await tester.tap(fileInput);
+      await tester.pump();
+
+      await tester.enterText(fileInput, notFoundPath);
+      await tester.pump();
+
+      final fileErrorText = find.text(lang.landscapeFileNotFound);
+      expect(fileErrorText, findsOne);
     });
 
     testWidgets('custom config', (tester) async {
@@ -360,3 +384,4 @@ Widget buildApp(
 
 const customConf = './test/testdata/landscape/custom.conf';
 const notFoundPath = './test/testdata/landscape/notfound.txt';
+const cert = './test/testdata/certs/ca_cert.pem';


### PR DESCRIPTION
The file picker for Landscape configuration certificates now filters to only .cer, .crt, .der, and .pem file types.

![image](https://github.com/user-attachments/assets/fcd96598-1338-45c7-a23e-e2b7868d0d84)

Fixes https://github.com/canonical/ubuntu-pro-for-wsl/issues/878

---

UDENG-5110