### PR TITLE
maint: Add additional files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ wsl-pro-service/debian/wsl-pro-service
 # Visual Studio and CMake
 .vs/
 out/
+
+# Visual Studio Code
+.vscode/

--- a/gui/packages/ubuntupro/.gitignore
+++ b/gui/packages/ubuntupro/.gitignore
@@ -1,2 +1,3 @@
 # Applications should include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
 !pubspec.lock
+devtools_options.yaml


### PR DESCRIPTION
At the top level, .vscode/ gets generated any time a custom vscode setting is set for the workspace, leading to changes that don't necessarily need committed (for example, my spell checker that I add spelling exceptions to).

In gui/ubuntupro/, devtools_options.yaml gets generated any time you open VS Code's devtools. Since we don't use any custom options here, I think this can be ignored.