### PR TITLE
fix(gui-ubuntupro): Remove popup feedback when applying a token

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
@@ -83,15 +83,6 @@ class SubscribeNowPage extends StatelessWidget {
         ProTokenInputField(
           onApply: (token) {
             model.applyProToken(token).then(onSubscriptionUpdate);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                width: 400.0,
-                behavior: SnackBarBehavior.floating,
-                content: Text(
-                  lang.applyingProToken(token.value),
-                ),
-              ),
-            );
           },
         ),
       ],

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
@@ -11,11 +11,9 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntupro/core/agent_api_client.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_model.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_page.dart';
-import 'package:ubuntupro/pages/subscribe_now/subscribe_now_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
 import '../../utils/build_multiprovider_app.dart';
 import 'subscribe_now_page_test.mocks.dart';
-import 'token_samples.dart' as tks;
 
 @GenerateMocks([SubscribeNowModel])
 void main() {

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
@@ -125,35 +125,6 @@ void main() {
       expect(called, isFalse);
     });
   });
-  testWidgets('feedback when applying token', (tester) async {
-    final model = MockSubscribeNowModel();
-    when(model.purchaseAllowed).thenReturn(true);
-    when(model.applyProToken(any)).thenAnswer((_) async {
-      return SubscriptionInfo()..ensureUser();
-    });
-    final app = buildApp(model, onSubscribeNoop);
-    await tester.pumpWidget(app);
-
-    // expands the collapsed input field group
-    final toggle = find.byIcon(ProTokenInputField.expandIcon);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-
-    // enters a good token value
-    final inputField = find.byType(TextField);
-    await tester.enterText(inputField, tks.good);
-    await tester.pump();
-
-    // submits the input.
-    final context = tester.element(find.byType(SubscribeNowPage));
-    final lang = AppLocalizations.of(context);
-    final button = find.text(lang.confirm);
-    await tester.tap(button);
-    await tester.pump();
-
-    // asserts that feedback is shown
-    expect(find.byType(SnackBar), findsOneWidget);
-  });
 
   testWidgets('purchase status enum l10n', (tester) async {
     final model = MockSubscribeNowModel();


### PR DESCRIPTION
Removes the popup as well as the test that asserts its existence. The tests for the pro token field that already exist should be enough to test error functionality.

---

UDENG-5286