### PR TITLE
fix: Streamline token errors

### DIFF
--- a/gui/packages/ubuntupro/lib/core/pro_token.dart
+++ b/gui/packages/ubuntupro/lib/core/pro_token.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'base58_check.dart';
 
 /// The possible errors when parsing a candidate Pro token string.
-enum TokenError { empty, tooShort, tooLong, invalidPrefix, invalidEncoding }
+enum TokenError { empty, invalid }
 
 final _b58 = Base58();
 
@@ -12,18 +12,12 @@ TokenError? _validate(String? value) {
   if (value == null || value.isEmpty) {
     return TokenError.empty;
   }
-  if (value.length < ProToken.minLength) {
-    return TokenError.tooShort;
-  }
-  if (value.length > ProToken.maxLength) {
-    return TokenError.tooLong;
-  }
-  // For now only Contract tokens are expected.
-  if (value[0] != 'C') {
-    return TokenError.invalidPrefix;
-  }
-  if (_b58.checkDecode(value.substring(1, value.length)) != null) {
-    return TokenError.invalidEncoding;
+
+  if (value.length < ProToken.minLength ||
+      value.length > ProToken.maxLength ||
+      value[0] != 'C' ||
+      _b58.checkDecode(value.substring(1, value.length)) != null) {
+    return TokenError.invalid;
   }
 
   return null;

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -1,10 +1,7 @@
 {
     "appTitle": "Ubuntu Pro for WSL",
     "tokenErrorEmpty": "Token cannot be empty",
-    "tokenErrorTooShort": "Token is too short",
-    "tokenErrorTooLong": "Token is too long",
-    "tokenErrorInvalidPrefix": "Token prefix is invalid",
-    "tokenErrorInvalidEncoding": "Token is corrupted",
+    "tokenErrorInvalid": "Token invalid",
     "tokenInputTitle": "Already have a token?",
     "tokenInputHint": "Paste your Ubuntu Pro token here",
     "confirm": "Confirm",

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -129,20 +129,14 @@ class ProTokenValue extends EitherValueNotifier<TokenError, ProToken?> {
 
 extension TokenErrorl10n on TokenError {
   /// Allows representing the [TokenError] enum as a String.
-  String localize(AppLocalizations lang) {
+  String? localize(AppLocalizations lang) {
     switch (this) {
       case TokenError.empty:
-        return lang.tokenErrorEmpty;
-      case TokenError.tooShort:
-        return lang.tokenErrorTooShort;
-      case TokenError.tooLong:
-        return lang.tokenErrorTooLong;
-      case TokenError.invalidPrefix:
-        return lang.tokenErrorInvalidPrefix;
-      case TokenError.invalidEncoding:
-        return lang.tokenErrorInvalidEncoding;
-      default:
-        throw UnimplementedError(toString());
+        // empty cannot be submitted, but we don't need to display an error to
+        // the user, just return to original state
+        return null;
+      case TokenError.invalid:
+        return lang.tokenErrorInvalid;
     }
   }
 }

--- a/gui/packages/ubuntupro/test/core/pro_token_test.dart
+++ b/gui/packages/ubuntupro/test/core/pro_token_test.dart
@@ -1,27 +1,21 @@
 import 'package:dart_either/dart_either.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntupro/core/pro_token.dart';
+import '../utils/token_samples.dart' as tks;
 
 void main() {
   test('token errors', () async {
-    var token = ProToken.create('');
-    expect(token, const Left(TokenError.empty));
+    final proToken = ProToken.create('');
+    expect(proToken, const Left(TokenError.empty));
 
-    token = ProToken.create('ZmNb8uQn5zv');
-    expect(token, const Left(TokenError.tooShort));
-
-    token = ProToken.create('K2RYDcKfupxwXdWhSAxQPCeiULntKm63UXyx5MvEH2');
-    expect(token, const Left(TokenError.tooLong));
-
-    token = ProToken.create('K2RYDcKfupxwXdWhSAxQPCeiULntKm');
-    expect(token, const Left(TokenError.invalidPrefix));
-
-    token = ProToken.create('CK2RYDcKfupxwXdWhSAxQPCeiULntK');
-    expect(token, const Left(TokenError.invalidEncoding));
+    for (final token in tks.invalidTokens) {
+      final proToken = ProToken.create(token);
+      expect(proToken, const Left(TokenError.invalid));
+    }
   });
 
   test('simulates a valid token', () async {
-    final token = ProToken.create('CJd8MMN8wXSWsv7wJT8c8dDK');
-    expect(token.isRight, isTrue);
+    final proToken = ProToken.create(tks.good);
+    expect(proToken.isRight, isTrue);
   });
 }

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_model_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_model_test.dart
@@ -11,8 +11,8 @@ import 'package:ubuntupro/core/agent_api_client.dart';
 import 'package:ubuntupro/core/pro_token.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_model.dart';
 
+import '../../utils/token_samples.dart' as tks;
 import 'subscribe_now_model_test.mocks.dart';
-import 'token_samples.dart' as tks;
 
 @GenerateMocks([AgentApiClient])
 void main() {

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
@@ -13,9 +13,10 @@ import 'package:ubuntupro/pages/subscribe_now/subscribe_now_model.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_page.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+
 import '../../utils/build_multiprovider_app.dart';
+import '../../utils/token_samples.dart' as tks;
 import 'subscribe_now_page_test.mocks.dart';
-import 'token_samples.dart' as tks;
 
 @GenerateMocks([SubscribeNowModel])
 void main() {

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/token_samples.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/token_samples.dart
@@ -1,5 +1,0 @@
-const good = 'CJd8MMN8wXSWsv7wJT8c8dDK';
-const tooShort = 'ZmNb8uQn5zv';
-const tooLong = 'K2RYDcKfupxwXdWhSAxQPCeiULntKm63UXyx5MvEH2';
-const invalidPrefix = 'K2RYDcKfupxwXdWhSAxQPCeiULntKm';
-const invalidEncoding = 'CK2RYDcKfupxwXdWhSAxQPCeiULntK';

--- a/gui/packages/ubuntupro/test/utils/token_samples.dart
+++ b/gui/packages/ubuntupro/test/utils/token_samples.dart
@@ -1,0 +1,7 @@
+const good = 'CJd8MMN8wXSWsv7wJT8c8dDK';
+const invalidTokens = [
+  'CK2RYDcKfup', // too short
+  'CK2RYDcKfupxwXdWhSAxQPCeiULntK63UXyx5MvEH2', // too long
+  'K2RYDcKfupxwXdWhSAxQPCeiULntKm', // invalid prefix
+  'CK2RYDcKfupxwXdWhSAxQPCeiULntK', // invalid encoding
+];


### PR DESCRIPTION
Removes specific errors like "too short" or "too long". Also, removes any error message when the token field is cleared. This change also streamlines some of the tests so we test multiple cases of different kinds of invalid tokens, but now each results in the same error.

---

UDENG-5285