### PR TITLE
fix: Remove accidental inclusion of an unused import

### DIFF
--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
@@ -14,7 +14,6 @@ import 'package:ubuntupro/pages/subscribe_now/subscribe_now_page.dart';
 import 'package:wizard_router/wizard_router.dart';
 
 import '../../utils/build_multiprovider_app.dart';
-import '../../utils/token_samples.dart' as tks;
 import 'subscribe_now_page_test.mocks.dart';
 
 @GenerateMocks([SubscribeNowModel])


### PR DESCRIPTION
This happened because #967 removed a test that was no longer needed (as well as this import), but was not removed in main before the branch for #968 was created. Since the import had to change for the relocation of common tokens, git didn't merge the changes quite correctly.