### PR TITLE
fix: Adjust "Subscribe Now" button copy and hide by default

### DIFF
--- a/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
+++ b/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
@@ -97,7 +97,7 @@ Future<void> testPurchase(WidgetTester tester) async {
 
   // The "subscribe now page" is only shown if the GUI communicates with the background agent.
   var l10n = tester.l10n<SubscribeNowPage>();
-  final button = find.text(l10n.subscribeNow);
+  final button = find.text(l10n.getUbuntuPro);
   expect(button, findsOneWidget);
 
   await tester.tap(button);

--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -240,7 +240,7 @@ void main() {
 
           // The "subscribe now page" is only shown if the GUI communicates with the background agent.
           final l10n = tester.l10n<SubscribeNowPage>();
-          final button = find.text(l10n.subscribeNow);
+          final button = find.text(l10n.getUbuntuPro);
           expect(button, findsOneWidget);
 
           await tester.tap(button);
@@ -266,7 +266,7 @@ void main() {
 
           // The "subscribe now page" is only shown if the GUI communicates with the background agent.
           final l10n = tester.l10n<SubscribeNowPage>();
-          final button = find.text(l10n.subscribeNow);
+          final button = find.text(l10n.getUbuntuPro);
           expect(button, findsOneWidget);
 
           await tester.tap(button);

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -24,8 +24,7 @@
     "agentStateUnreachable": "Attempting to recover Ubuntu Pro background agent.",
 
     "proHeading": "Open source software security by the publishers\nof Ubuntu, now available on Windows.",
-    "subscribeNow": "Subscribe Now",
-    "subscribeNowTooltipDisabled": "Coming soon",
+    "getUbuntuPro": "Get Ubuntu Pro",
     "about": "About Ubuntu Pro",
 
     "subscriptionIsActive": "Your subscription is active!",

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
@@ -32,10 +32,8 @@ class SubscribeNowPage extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Tooltip(
-              message:
-                  model.purchaseAllowed ? '' : lang.subscribeNowTooltipDisabled,
-              child: ElevatedButton(
+            if (model.purchaseAllowed) ...[
+              ElevatedButton(
                 onPressed: model.purchaseAllowed
                     ? () async {
                         final subs = await model.purchaseSubscription();
@@ -66,10 +64,10 @@ class SubscribeNowPage extends StatelessWidget {
                         );
                       }
                     : null,
-                child: Text(lang.subscribeNow),
+                child: Text(lang.getUbuntuPro),
               ),
-            ),
-            const SizedBox(width: 8.0),
+              const SizedBox(width: 8.0),
+            ],
             OutlinedButton(
               onPressed: model.launchProWebPage,
               child: Text(lang.about),

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.dart
@@ -54,11 +54,10 @@ void main() {
 
       // check that's the right button
       final button = find.ancestor(
-        of: find.text(lang.subscribeNow),
+        of: find.text(lang.getUbuntuPro),
         matching: find.byType(ElevatedButton),
       );
-      expect(button, findsOneWidget);
-      expect(tester.widget<ElevatedButton>(button).enabled, isFalse);
+      expect(button, findsNothing);
     });
     testWidgets('enabled', (tester) async {
       final model = MockSubscribeNowModel();
@@ -70,7 +69,7 @@ void main() {
 
       // check that's the right button
       final button = find.ancestor(
-        of: find.text(lang.subscribeNow),
+        of: find.text(lang.getUbuntuPro),
         matching: find.byType(ElevatedButton),
       );
       expect(button, findsOneWidget);
@@ -94,7 +93,7 @@ void main() {
       final lang = AppLocalizations.of(context);
 
       expect(called, isFalse);
-      final button = find.text(lang.subscribeNow);
+      final button = find.text(lang.getUbuntuPro);
       await tester.tap(button);
       await tester.pump();
       expect(called, isTrue);
@@ -116,7 +115,7 @@ void main() {
       final lang = AppLocalizations.of(context);
 
       expect(called, isFalse);
-      final button = find.text(lang.subscribeNow);
+      final button = find.text(lang.getUbuntuPro);
       await tester.tap(button);
       await tester.pump();
       expect(find.byType(SnackBar), findsWidgets);


### PR DESCRIPTION
Changes the text of the "Subscribe Now" button to "Get Ubuntu Pro". Also, hides the button by default unless purchasing is allowed (instead of being greyed out).

---

UDENG-5283