### PR TITLE
feat: Always show Pro token input

### DIFF
--- a/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
+++ b/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
@@ -7,7 +7,6 @@ import 'package:stack_trace/stack_trace.dart' as stack_trace;
 import 'package:ubuntupro/core/environment.dart';
 import 'package:ubuntupro/main.dart' as app;
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_page.dart';
-import 'package:ubuntupro/pages/subscribe_now/subscribe_now_widgets.dart';
 import 'package:ubuntupro/pages/subscription_status/subscription_status_page.dart';
 
 import '../test/utils/l10n_tester.dart';
@@ -62,11 +61,6 @@ Future<void> testManualTokenInput(WidgetTester tester) async {
 
   // The "subscribe now page" is only shown if the GUI communicates with the background agent.
   var l10n = tester.l10n<SubscribeNowPage>();
-
-  // expands the collapsed input field group
-  final toggle = find.byIcon(ProTokenInputField.expandIcon);
-  await tester.tap(toggle);
-  await tester.pumpAndSettle();
 
   // finds the pro token from the environment
   final goodToken = Environment()[proTokenEnv];

--- a/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
+++ b/gui/packages/ubuntupro/end_to_end/end_to_end_test.dart
@@ -82,7 +82,7 @@ Future<void> testManualTokenInput(WidgetTester tester) async {
   await tester.pumpAndSettle();
 
   // submits the input.
-  final button = find.text(l10n.confirm);
+  final button = find.text(l10n.attach);
   await tester.tap(button);
   await tester.pumpAndSettle();
 

--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -15,7 +15,6 @@ import 'package:ubuntupro/main.dart' as app;
 import 'package:ubuntupro/pages/landscape/landscape_page.dart';
 import 'package:ubuntupro/pages/startup/startup_page.dart';
 import 'package:ubuntupro/pages/subscribe_now/subscribe_now_page.dart';
-import 'package:ubuntupro/pages/subscribe_now/subscribe_now_widgets.dart';
 import 'package:ubuntupro/pages/subscription_status/subscription_status_page.dart';
 import 'package:yaru/widgets.dart';
 import 'package:yaru_test/yaru_test.dart';
@@ -118,10 +117,6 @@ void main() {
 
         // The "subscribe now page" is only shown if the GUI communicates with the background agent.
         var l10n = tester.l10n<SubscribeNowPage>();
-        // expands the collapsed input field group
-        final toggle = find.byIcon(ProTokenInputField.expandIcon);
-        await tester.tap(toggle);
-        await tester.pumpAndSettle();
 
         // enters a good token value
         final inputField = find.byType(TextField);
@@ -166,10 +161,6 @@ void main() {
 
         // The "subscribe now page" is only shown if the GUI communicates with the background agent.
         var l10n = tester.l10n<SubscribeNowPage>();
-        // expands the collapsed input field group
-        final toggle = find.byIcon(ProTokenInputField.expandIcon);
-        await tester.tap(toggle);
-        await tester.pumpAndSettle();
 
         // enters a good token value
         final inputField = find.byType(TextField);

--- a/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
+++ b/gui/packages/ubuntupro/integration_test/ubuntu_pro_for_wsl_test.dart
@@ -129,7 +129,7 @@ void main() {
         await tester.pump();
 
         // submits the input.
-        final button = find.text(l10n.confirm);
+        final button = find.text(l10n.attach);
         await tester.tap(button);
         await tester.pumpAndSettle();
 
@@ -177,7 +177,7 @@ void main() {
         await tester.pump();
 
         // submits the input.
-        final button = find.text(l10n.confirm);
+        final button = find.text(l10n.attach);
         await tester.tap(button);
         await tester.pumpAndSettle();
 

--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 /// The name of the file where the Agent's drop its service connection information.
 const kAddrFileName = '.ubuntupro/.address';
 
@@ -12,3 +14,5 @@ const kVersion = String.fromEnvironment(
   'UP4W_FULL_VERSION',
   defaultValue: 'Dev',
 );
+
+const kConfirmColor = Color(0xFF0E8420);

--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 /// The name of the file where the Agent's drop its service connection information.
 const kAddrFileName = '.ubuntupro/.address';
 
@@ -14,5 +12,3 @@ const kVersion = String.fromEnvironment(
   'UP4W_FULL_VERSION',
   defaultValue: 'Dev',
 );
-
-const kConfirmColor = Color(0xFF0E8420);

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -1,10 +1,11 @@
 {
     "appTitle": "Ubuntu Pro for WSL",
     "tokenErrorEmpty": "Token cannot be empty",
-    "tokenErrorInvalid": "Token invalid",
+    "tokenErrorInvalid": "Invalid token",
+    "tokenValid": "Valid token",
     "tokenInputTitle": "Already have a token?",
     "tokenInputHint": "Paste your Ubuntu Pro token here",
-    "confirm": "Confirm",
+    "attach": "Attach",
     "applyProToken": "Apply Pro Token",
     "applyingProToken": "Applying token {token}",
     "@applyingProToken": {

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:yaru/yaru.dart';
-import '../../constants.dart';
 import '../../core/either_value_notifier.dart';
 import '../../core/pro_token.dart';
 
@@ -93,16 +92,17 @@ class _ProTokenInputFieldState extends State<ProTokenInputField> {
                             padding: const EdgeInsets.only(top: 4),
                             child: Row(
                               children: [
-                                const Icon(
+                                Icon(
                                   Icons.cancel,
-                                  color: Colors.red,
+                                  color: YaruColors.of(context).error,
                                   size: 16.0,
                                 ),
                                 const SizedBox(width: 4),
                                 Text(
                                   _token.errorOrNull!.localize(lang)!,
-                                  style: theme.textTheme.bodySmall!
-                                      .copyWith(color: Colors.redAccent),
+                                  style: theme.textTheme.bodySmall!.copyWith(
+                                    color: YaruColors.of(context).error,
+                                  ),
                                 ),
                               ],
                             ),
@@ -113,16 +113,17 @@ class _ProTokenInputFieldState extends State<ProTokenInputField> {
                             padding: const EdgeInsets.only(top: 4),
                             child: Row(
                               children: [
-                                const Icon(
+                                Icon(
                                   Icons.check_circle,
-                                  color: kConfirmColor,
+                                  color: YaruColors.of(context).success,
                                   size: 16.0,
                                 ),
                                 const SizedBox(width: 4),
                                 Text(
                                   lang.tokenValid,
-                                  style: theme.textTheme.bodySmall!
-                                      .copyWith(color: Colors.green),
+                                  style: theme.textTheme.bodySmall!.copyWith(
+                                    color: YaruColors.of(context).success,
+                                  ),
                                 ),
                               ],
                             ),

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:yaru/yaru.dart';
+import '../../constants.dart';
 import '../../core/either_value_notifier.dart';
 import '../../core/pro_token.dart';
 
@@ -61,58 +62,95 @@ class _ProTokenInputFieldState extends State<ProTokenInputField> {
     final lang = AppLocalizations.of(context);
     final theme = Theme.of(context);
 
-    return YaruExpandable(
-      header: Text(
-        lang.tokenInputTitle,
-        style:
-            theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w100),
-      ),
-      expandIcon: Icon(
-        ProTokenInputField.expandIcon,
-        color: theme.textTheme.bodyMedium!.color,
-      ),
-      isExpanded: widget.isExpanded,
-      child: ValueListenableBuilder(
-        valueListenable: _token,
-        builder: (context, _, __) => Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: TextField(
-                inputFormatters: [
-                  // This ignores all sorts of (Unicode) whitespaces (not only at the ends).
-                  FilteringTextInputFormatter.deny(RegExp(r'\s')),
-                ],
-                autofocus: false,
-                controller: _controller,
-                decoration: InputDecoration(
-                  hintText: lang.tokenInputHint,
-                  errorText: _token.errorOrNull?.localize(lang),
-                  counterText: '',
-                ),
-                onChanged: _token.update,
-                onSubmitted: _onSubmitted,
-              ),
-            ),
-            const SizedBox(
-              width: 8.0,
-            ),
-            ElevatedButton(
-              onPressed: canSubmit ? _handleApplyButton : null,
-              child: Text(lang.confirm),
-            ),
-          ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          lang.tokenInputTitle,
+          style:
+              theme.textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w100),
         ),
-      ),
+        const SizedBox(
+          height: 8,
+        ),
+        ValueListenableBuilder(
+          valueListenable: _token,
+          builder: (context, _, __) => Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: TextField(
+                  inputFormatters: [
+                    // This ignores all sorts of (Unicode) whitespaces (not only at the ends).
+                    FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                  ],
+                  autofocus: false,
+                  controller: _controller,
+                  decoration: InputDecoration(
+                    hintText: lang.tokenInputHint,
+                    error: _token.errorOrNull?.localize(lang) != null
+                        ? Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Row(
+                              children: [
+                                const Icon(
+                                  Icons.cancel,
+                                  color: Colors.red,
+                                  size: 16.0,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  _token.errorOrNull!.localize(lang)!,
+                                  style: theme.textTheme.bodySmall!
+                                      .copyWith(color: Colors.redAccent),
+                                ),
+                              ],
+                            ),
+                          )
+                        : null,
+                    helper: _token.valueOrNull != null
+                        ? Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Row(
+                              children: [
+                                const Icon(
+                                  Icons.check_circle,
+                                  color: kConfirmColor,
+                                  size: 16.0,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  lang.tokenValid,
+                                  style: theme.textTheme.bodySmall!
+                                      .copyWith(color: Colors.green),
+                                ),
+                              ],
+                            ),
+                          )
+                        : null,
+                  ),
+                  onChanged: _token.update,
+                  onSubmitted: _onSubmitted,
+                ),
+              ),
+              const SizedBox(
+                width: 8.0,
+              ),
+              ElevatedButton(
+                onPressed: canSubmit ? _handleApplyButton : null,
+                child: Text(lang.attach),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
 
 /// A value-notifier for the [ProToken] with validation.
-/// Since we don't want to start the UI with an error due the text field being
-/// empty, this stores a nullable [ProToken] object
 class ProTokenValue extends EitherValueNotifier<TokenError, ProToken?> {
-  ProTokenValue() : super.ok(null);
+  ProTokenValue() : super.err(TokenError.empty);
 
   String? get token => valueOrNull?.value;
 

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -3,7 +3,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
-import '../../constants.dart';
 import '../widgets/page_widgets.dart';
 
 /// A page content widget built on top of the Dark styled landing page showing the current user active subscription
@@ -48,17 +47,18 @@ class SubscriptionStatus extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(16.0),
           decoration: BoxDecoration(
-            border: Border.all(color: kConfirmColor, width: 1.0),
-            color: const Color(0xFFE6F8E8),
+            border: Border.all(color: theme.colorScheme.success, width: 1.0),
+            color: theme.colorScheme.success
+                .copyWith(lightness: 0.94, saturation: 0.56),
             borderRadius: const BorderRadius.all(Radius.circular(4.0)),
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Icon(
+              Icon(
                 Icons.check_circle_outline_outlined,
-                color: kConfirmColor,
+                color: theme.colorScheme.success,
                 size: 24.0,
               ),
               const SizedBox(width: 8.0),

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
+import '../../constants.dart';
 import '../widgets/page_widgets.dart';
 
 /// A page content widget built on top of the Dark styled landing page showing the current user active subscription
@@ -47,7 +48,7 @@ class SubscriptionStatus extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(16.0),
           decoration: BoxDecoration(
-            border: Border.all(color: const Color(0xFF0E8420), width: 1.0),
+            border: Border.all(color: kConfirmColor, width: 1.0),
             color: const Color(0xFFE6F8E8),
             borderRadius: const BorderRadius.all(Radius.circular(4.0)),
           ),
@@ -57,7 +58,7 @@ class SubscriptionStatus extends StatelessWidget {
             children: [
               const Icon(
                 Icons.check_circle_outline_outlined,
-                color: Color(0xFF0E8420),
+                color: kConfirmColor,
                 size: 24.0,
               ),
               const SizedBox(width: 8.0),

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -47,8 +47,10 @@ class SubscriptionStatus extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(16.0),
           decoration: BoxDecoration(
-            border: Border.all(color: theme.colorScheme.success, width: 1.0),
-            color: theme.colorScheme.success
+            border:
+                Border.all(color: YaruColors.of(context).success, width: 1.0),
+            color: YaruColors.of(context)
+                .success
                 .copyWith(lightness: 0.94, saturation: 0.56),
             borderRadius: const BorderRadius.all(Radius.circular(4.0)),
           ),
@@ -58,7 +60,7 @@ class SubscriptionStatus extends StatelessWidget {
             children: [
               Icon(
                 Icons.check_circle_outline_outlined,
-                color: theme.colorScheme.success,
+                color: YaruColors.of(context).success,
                 size: 24.0,
               ),
               const SizedBox(width: 8.0),

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_widgets_test.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_widgets_test.dart
@@ -46,25 +46,6 @@ void main() {
   });
 
   group('pro token input', () {
-    testWidgets('collapsed by default', (tester) async {
-      final app = MaterialApp(
-        home: Scaffold(
-          body: ProTokenInputField(
-            onApply: (_) {},
-          ),
-        ),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-      );
-
-      await tester.pumpWidget(app);
-      expect(find.byType(TextField).hitTestable(), findsNothing);
-
-      final toggle = find.byType(IconButton);
-      await tester.tap(toggle);
-      await tester.pumpAndSettle();
-      expect(find.byType(TextField).hitTestable(), findsOneWidget);
-    });
-
     group('basic flow', () {
       final theApp = buildApp(onApply: (_) {}, isExpanded: true);
       testWidgets('starts with no error', (tester) async {
@@ -93,8 +74,11 @@ void main() {
           await tester.enterText(inputField, token);
           await tester.pump();
 
-          final input = tester.firstWidget<TextField>(inputField);
-          expect(input.decoration!.errorText, equals(lang.tokenErrorInvalid));
+          final errorText = find.descendant(
+            of: inputField,
+            matching: find.text(lang.tokenErrorInvalid),
+          );
+          expect(errorText, findsOne);
 
           final button =
               tester.firstWidget<ElevatedButton>(find.byType(ElevatedButton));
@@ -112,8 +96,11 @@ void main() {
         await tester.enterText(inputField, tks.invalidTokens[0]);
         await tester.pump();
 
-        var input = tester.firstWidget<TextField>(inputField);
-        expect(input.decoration!.errorText, equals(lang.tokenErrorInvalid));
+        final errorText = find.descendant(
+          of: inputField,
+          matching: find.text(lang.tokenErrorInvalid),
+        );
+        expect(errorText, findsOne);
 
         final button =
             tester.firstWidget<ElevatedButton>(find.byType(ElevatedButton));
@@ -122,20 +109,27 @@ void main() {
         // ...except when we delete the content we should have no more errors
         await tester.enterText(inputField, '');
         await tester.pump();
-        input = tester.firstWidget<TextField>(inputField);
-        expect(input.decoration!.errorText, isNull);
+        final input = tester.firstWidget<TextField>(inputField);
+        expect(input.decoration!.error, isNull);
         expect(button.enabled, isFalse);
       });
 
       testWidgets('good token', (tester) async {
         await tester.pumpWidget(theApp);
         final inputField = find.byType(TextField);
+        final context = tester.element(inputField);
+        final lang = AppLocalizations.of(context);
 
         await tester.enterText(inputField, tks.good);
         await tester.pump();
 
         final input = tester.firstWidget<TextField>(inputField);
-        expect(input.decoration!.errorText, isNull);
+        expect(input.decoration!.error, isNull);
+        final validText = find.descendant(
+          of: inputField,
+          matching: find.text(lang.tokenValid),
+        );
+        expect(validText, findsOne);
 
         final button =
             tester.firstWidget<ElevatedButton>(find.byType(ElevatedButton));


### PR DESCRIPTION
Shows the token input field always instead of being in a collapsible section. Also, adds messaging when a valid token or invalid token is added, with an icon.

A small detail I missed when adjusting the copy for errors previously: invalid tokens now show the string "Invalid token" instead of "Token invalid".

<details>
<summary>Screenshot of the default look</summary>

![image](https://github.com/user-attachments/assets/4ec8ff4f-67da-4a1e-9eb3-337048e1afd5)

</details>

<details>
<summary>Screenshot when an invalid token is entered</summary>

![image](https://github.com/user-attachments/assets/bdacf88c-3f4c-41e1-acd8-78267c5fed66)

</details>

<details>
<summary>Screenshot when a valid token is entered</summary>

![image](https://github.com/user-attachments/assets/0d9e8f65-3643-402c-8cfc-8e10d21d5f04)

</details>

Our designs in Figma include functionality that we do not have, so I took some creative liberties in adapting it to the current layout. Let me know if it needs any adjustments.

---

UDENG-5284