### PR TITLE
fix(windows-agent): Delegates `agent.WaitReady` to the daemon

### DIFF
--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent.go
@@ -186,6 +186,10 @@ func (a *App) Quit() {
 // Note: we need to use a pointer to not copy the App object before the daemon is ready, and thus, creates a data race.
 func (a *App) WaitReady() {
 	<-a.ready
+	if a.daemon == nil {
+		return
+	}
+	a.daemon.WaitReady()
 }
 
 // RootCmd returns a copy of the root command for the app. Shouldn't be in general necessary apart when running generators.

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/agent_test.go
@@ -431,8 +431,6 @@ func TestLogs(t *testing.T) {
 			}()
 
 			a.WaitReady()
-			// TODO: Implement the real fix for WaitReady() per UDENG-4900
-			<-time.After(1 * time.Second)
 
 			select {
 			case <-ch:

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -89,13 +89,13 @@ func (d *Daemon) Serve(ctx context.Context, args ...Option) error {
 	// Once this method leaves the daemon is done forever.
 	defer d.cleanup()
 
-	// let the world know we were requested to serve.
-	close(d.serving)
-
 	opts := defaultOptions
 	for _, opt := range args {
 		opt(&opts)
 	}
+
+	// let the world know we were requested to serve.
+	close(d.serving)
 
 	for {
 		err := d.tryServingOnce(ctx, opts)

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -68,6 +68,11 @@ var defaultOptions = options{
 	netMonitoringProvider: netmonitoring.DefaultAPIProvider,
 }
 
+// WaitReady blocks until the daemon is ready to serve, i.e. until Serve has been called.
+func (d *Daemon) WaitReady() {
+	<-d.serving
+}
+
 // Option represents an optional function to override getWslIP default values.
 type Option func(*options)
 


### PR DESCRIPTION
Since #896 the agent might sometimes close the `a.ready` channel too early, giving the possibility of a call to `a.WaitReady()` exiting before the daemon really starts serving, thus not really waiting.

The deamon knows best when is the most likely moment to be serving, thus this PR slightly modifies `a.WaitReady()` to check with the daemon, which had to implement its own `daemon.WaitReady()`.

The `a.ready` channel is still useful to synchronize the access to `a.daemon`, preventing nil pointer access when the deamon is not yet initialized. Checking for `nil` is still needed, as the `a.ready` channel may be closed without ever serving, such as on a failure case.

This adds a test for `daemon.WaitReady()`, but the agent tests don't need to change, as their "flakyness" reveal the problem.

---

UDENG-4900