### PR TITLE
fix: Rounds all buttons and removes custom button styles

### DIFF
--- a/gui/packages/ubuntupro/lib/app.dart
+++ b/gui/packages/ubuntupro/lib/app.dart
@@ -36,8 +36,8 @@ class Pro4WSLApp extends StatelessWidget {
           ],
           child: MaterialApp(
             title: 'Ubuntu Pro',
-            theme: customize(yaru.theme),
-            darkTheme: customize(yaru.darkTheme),
+            theme: yaru.theme,
+            darkTheme: yaru.darkTheme,
             debugShowCheckedModeBanner: false,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -106,51 +106,4 @@ class Pro4WSLApp extends StatelessWidget {
       },
     );
   }
-}
-
-ThemeData? customize(ThemeData? theme) {
-  if (theme == null) return null;
-  const padding = WidgetStatePropertyAll<EdgeInsetsGeometry>(
-    EdgeInsets.symmetric(vertical: 20.0, horizontal: 16.0),
-  );
-  const shape = WidgetStatePropertyAll<RoundedRectangleBorder>(
-    RoundedRectangleBorder(
-      borderRadius: BorderRadius.zero,
-    ),
-  );
-  final textStyle = WidgetStatePropertyAll<TextStyle>(
-    theme.textTheme.bodySmall!.copyWith(fontWeight: FontWeight.normal),
-  );
-  final filledButtonTheme = FilledButtonThemeData(
-    style: theme.filledButtonTheme.style?.copyWith(
-      shape: shape,
-      padding: padding,
-      textStyle: textStyle,
-    ),
-  );
-  final elevatedButtonTheme = ElevatedButtonThemeData(
-    style: theme.elevatedButtonTheme.style?.copyWith(
-      shape: shape,
-      padding: padding,
-      textStyle: textStyle,
-    ),
-  );
-  final outlinedButtonTheme = OutlinedButtonThemeData(
-    style: theme.outlinedButtonTheme.style?.copyWith(
-      shape: shape,
-      padding: padding,
-      textStyle: textStyle,
-    ),
-  );
-  final buttonTheme = theme.buttonTheme.copyWith(
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.zero,
-    ),
-  );
-  return theme.copyWith(
-    buttonTheme: buttonTheme,
-    filledButtonTheme: filledButtonTheme,
-    elevatedButtonTheme: elevatedButtonTheme,
-    outlinedButtonTheme: outlinedButtonTheme,
-  );
 }


### PR DESCRIPTION
This change reverts back to using the Yaru themes as-is instead of injecting our own styles for buttons. This matches the rounded nature of Yaru buttons, as well as the more bold text in them.

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/1e3e4b90-b284-4b88-a262-3e3d1a6aec96)

![image](https://github.com/user-attachments/assets/8bab7892-0ad3-4934-96a6-ffe6f2db9442)

![image](https://github.com/user-attachments/assets/4093ac1a-cbdb-42a2-8e59-43f7f736bd3d)

![image](https://github.com/user-attachments/assets/0d0a4eb4-cda9-435d-895f-37e952e86946)

</details>

---

UDENG-5281