### PR TITLE
fix: Move about link and fix broken link

### DIFF
--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -24,9 +24,15 @@
     "agentStateQuerying": "Checking Ubuntu Pro background agent's state.",
     "agentStateUnreachable": "Attempting to recover Ubuntu Pro background agent.",
 
-    "proHeading": "Open source software security by the publishers\nof Ubuntu, now available on Windows.",
+    "proHeading": "Open source software security by the publishers of Ubuntu, now available on Windows. {aboutLink}",
+    "@proHeading": {
+        "placeholders": {
+            "aboutLink": {
+                "type": "String"
+            }
+        }
+    },
     "getUbuntuPro": "Get Ubuntu Pro",
-    "about": "About Ubuntu Pro",
 
     "subscriptionIsActive": "Your subscription is active!",
     "storeManaged": "This subscription is managed through Microsoft Store.",

--- a/gui/packages/ubuntupro/lib/l10n/app_en.arb
+++ b/gui/packages/ubuntupro/lib/l10n/app_en.arb
@@ -33,6 +33,7 @@
         }
     },
     "getUbuntuPro": "Get Ubuntu Pro",
+    "learnMore": "Learn more",
 
     "subscriptionIsActive": "Your subscription is active!",
     "storeManaged": "This subscription is managed through Microsoft Store.",

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_model.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_model.dart
@@ -2,7 +2,6 @@ import 'package:agentapi/agentapi.dart';
 import 'package:dart_either/dart_either.dart';
 import 'package:flutter/foundation.dart';
 import 'package:p4w_ms_store/p4w_ms_store.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '/core/agent_api_client.dart';
 import '/core/pro_token.dart';
 
@@ -14,10 +13,6 @@ class SubscribeNowModel {
 
   Future<SubscriptionInfo> applyProToken(ProToken token) {
     return client.applyProToken(token.value);
-  }
-
-  void launchProWebPage() {
-    launchUrl(Uri.https('ubuntu.com/pro'));
   }
 
   /// Triggers a purchase transaction via MS Store.

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
@@ -36,7 +36,8 @@ class SubscribeNowPage extends StatelessWidget {
         SizedBox(
           width: 400,
           child: MarkdownBody(
-            data: lang.proHeading('[Learn more](https://ubuntu.com/pro)'),
+            data:
+                lang.proHeading('[${lang.learnMore}](https://ubuntu.com/pro)'),
             onTapLink: (_, href, __) => launchUrlString(href!),
             styleSheet: linkStyle,
           ),

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_page.dart
@@ -1,9 +1,11 @@
 import 'package:agentapi/agentapi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:p4w_ms_store/p4w_ms_store.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 import 'package:wizard_router/wizard_router.dart';
 
 import '/core/agent_api_client.dart';
@@ -21,12 +23,23 @@ class SubscribeNowPage extends StatelessWidget {
     final model = context.watch<SubscribeNowModel>();
     final lang = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final linkStyle = MarkdownStyleSheet.fromTheme(
+      theme.copyWith(
+        textTheme: theme.textTheme.copyWith(
+          bodyMedium: theme.textTheme.bodyLarge,
+        ),
+      ),
+    );
+
     return LandingPage(
       children: [
-        Text(
-          lang.proHeading,
-          style:
-              theme.textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.w100),
+        SizedBox(
+          width: 400,
+          child: MarkdownBody(
+            data: lang.proHeading('[Learn more](https://ubuntu.com/pro)'),
+            onTapLink: (_, href, __) => launchUrlString(href!),
+            styleSheet: linkStyle,
+          ),
         ),
         const SizedBox(height: 16),
         Row(
@@ -68,10 +81,6 @@ class SubscribeNowPage extends StatelessWidget {
               ),
               const SizedBox(width: 8.0),
             ],
-            OutlinedButton(
-              onPressed: model.launchProWebPage,
-              child: Text(lang.about),
-            ),
           ],
         ),
         const Padding(

--- a/gui/packages/ubuntupro/pubspec.lock
+++ b/gui/packages/ubuntupro/pubspec.lock
@@ -964,7 +964,7 @@ packages:
     source: hosted
     version: "3.2.0"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/gui/packages/ubuntupro/pubspec.yaml
+++ b/gui/packages/ubuntupro/pubspec.yaml
@@ -79,6 +79,7 @@ dev_dependencies:
   nested: ^1.0.0
   protobuf: ^3.1.0
   stack_trace: ^1.11.0
+  url_launcher_platform_interface: ^2.3.2
   yaru_test: ^0.2.0
 
 # For information on the generic Dart part of this file, see the

--- a/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.mocks.dart
+++ b/gui/packages/ubuntupro/test/pages/subcribe_now/subscribe_now_page_test.mocks.dart
@@ -99,15 +99,6 @@ class MockSubscribeNowModel extends _i1.Mock implements _i5.SubscribeNowModel {
       ) as _i6.Future<_i3.SubscriptionInfo>);
 
   @override
-  void launchProWebPage() => super.noSuchMethod(
-        Invocation.method(
-          #launchProWebPage,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
   _i6.Future<_i4.Either<_i8.PurchaseStatus, _i3.SubscriptionInfo>>
       purchaseSubscription() => (super.noSuchMethod(
             Invocation.method(


### PR DESCRIPTION
Moves the About Ubuntu Pro button functionality to a Learn More link in the above copy. Also fixes the issue of the link not opening.

![Screenshot of change](https://github.com/user-attachments/assets/d332a31d-b52e-46c0-b335-3afec1edbf63)

---

UDENG-5282