### PR TITLE
fix: Vertically center window title bar controls

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -59,6 +59,7 @@ class Pro4WSLPage extends StatelessWidget {
       appBar: showTitleBar
           ? YaruWindowTitleBar(
               title: Text(lang.appTitle),
+              buttonPadding: EdgeInsets.zero,
             )
           : null,
       body: body,


### PR DESCRIPTION
Centers the title bar control buttons, but they will not be the full height of the title bar until Yaru is updated to include https://github.com/ubuntu/yaru.dart/pull/967 (will require a version bump on our end in the future).

| Existing | Current state of this PR | With the Yaru update |
|----------|--------------------------|----------------------|
| ![image](https://github.com/user-attachments/assets/0aa75361-b065-4abf-b734-64c5936a6a00) | ![image](https://github.com/user-attachments/assets/eebb0dee-656a-4443-93d2-c954a45bb8c7) | ![image](https://github.com/user-attachments/assets/63aa2cbf-d027-4caf-bed7-1be1d07621e2) |

---

UDENG-5289