### PR TITLE
fix(windows-agent): Check that IPs are convertible to ipv4

### DIFF
--- a/windows-agent/internal/daemon/daemontestutils/networking_mock.go
+++ b/windows-agent/internal/daemon/daemontestutils/networking_mock.go
@@ -144,7 +144,7 @@ func getLocalPrivateIP() net.IP {
 		return nil
 	}
 	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.IsPrivate() {
+		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.IsPrivate() && ipnet.IP.To4() != nil {
 			return ipnet.IP
 		}
 	}

--- a/windows-agent/internal/daemon/daemontestutils/networking_mock.go
+++ b/windows-agent/internal/daemon/daemontestutils/networking_mock.go
@@ -57,7 +57,7 @@ func NewHostIPConfigMock(state MockIPAdaptersState) MockIPConfig {
 	}
 
 	// prefer not to listen on public interfaces if possible.
-	localIP := getLocalPrivateIP()
+	localIP := getLocalPrivateIPv4()
 	if localIP == nil {
 		localIP = net.IPv4(0, 0, 0, 0)
 	}
@@ -137,8 +137,8 @@ func fillBufferFromTemplate(adaptersAddresses *IPAdapterAddresses, sizePointer *
 	return nil
 }
 
-// getLocalPrivateIP returns one non loopback local private IP of the host.
-func getLocalPrivateIP() net.IP {
+// getLocalPrivateIPv4 returns one non loopback local private IPv4 of the host.
+func getLocalPrivateIPv4() net.IP {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return nil


### PR DESCRIPTION
If the system receives an IPv6 address, then running the agent with mocks (for example, when running integration tests) can result in panics. This fixes that issue by checking if the IP is convertible to Ipv4.

For context, this came up when I attempted to run the Flutter integration tests on a network and host that technically support IPv6.