### PR TITLE
fix: Use YaruInfoBox for notification boxes

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -34,8 +34,9 @@ class SubscriptionStatus extends StatelessWidget {
         ),
       ),
     ).copyWith(
-      a: const TextStyle(
+      a: TextStyle(
         decoration: TextDecoration.underline,
+        color: theme.colorScheme.onSurface,
       ),
     );
 

--- a/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscription_status/subscription_status_widgets.dart
@@ -30,62 +30,27 @@ class SubscriptionStatus extends StatelessWidget {
         textTheme: theme.textTheme.copyWith(
           bodyMedium: theme.textTheme.bodyMedium?.copyWith(
             fontWeight: FontWeight.w100,
-            color: YaruColors.jet,
           ),
         ),
       ),
     ).copyWith(
       a: const TextStyle(
         decoration: TextDecoration.underline,
-        color: YaruColors.jet,
       ),
     );
 
     return LandingPage(
       centered: true,
       children: [
-        Container(
-          padding: const EdgeInsets.all(16.0),
-          decoration: BoxDecoration(
-            border:
-                Border.all(color: YaruColors.of(context).success, width: 1.0),
-            color: YaruColors.of(context)
-                .success
-                .copyWith(lightness: 0.94, saturation: 0.56),
-            borderRadius: const BorderRadius.all(Radius.circular(4.0)),
+        const SizedBox(height: 16.0),
+        YaruInfoBox(
+          title: Text(lang.subscriptionIsActive),
+          subtitle: MarkdownBody(
+            data: caption,
+            onTapLink: (_, href, __) => launchUrlString(href!),
+            styleSheet: linkStyle,
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(
-                Icons.check_circle_outline_outlined,
-                color: YaruColors.of(context).success,
-                size: 24.0,
-              ),
-              const SizedBox(width: 8.0),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      lang.subscriptionIsActive,
-                      style: theme.textTheme.bodyLarge!.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: YaruColors.darkJet,
-                      ),
-                    ),
-                    const SizedBox(height: 4.0),
-                    MarkdownBody(
-                      data: caption,
-                      onTapLink: (_, href, __) => launchUrlString(href!),
-                      styleSheet: linkStyle,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
+          yaruInfoType: YaruInfoType.success,
         ),
         if (actionButtons != null)
           Center(


### PR DESCRIPTION
This effectively aligns the colors correctly with what is used by Yaru for info boxes, which you can see at https://ubuntu.github.io/yaru.dart under the "YaruInfo" tab. Our colors in light mode were identical to Yaru, but dark mode colors were not. This fixes that issue and simplifies the widget code significantly by just using the `YaruInfoBox`.

This page still needs more changes in the future, but this should be sufficient for notification colors for the time being.

| | Dark | Light |
|-|------|-------|
| Existing | ![image](https://github.com/user-attachments/assets/31c464f3-90f5-4914-80ef-8f7734c65d0d)| ![image](https://github.com/user-attachments/assets/cca4c2a4-5374-4795-804f-ba5ccf116e31) |
| New | ![image](https://github.com/user-attachments/assets/2cf363ef-d4c8-4a8b-a053-7a68d4260ad6) | ![image](https://github.com/user-attachments/assets/c62815b9-aa2e-43f1-a410-a6d646593148) |

---

UDENG-5590
