### PR TITLE
fix: Fix radio background

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
@@ -51,6 +51,7 @@ class _LandscapeSkipPageState extends State<LandscapeSkipPage> {
             groupValue = v!;
           }),
         ),
+        const SizedBox(height: 16),
         RadioTile(
           value: SkipEnum.register,
           title: lang.landscapeSkipRegister,

--- a/gui/packages/ubuntupro/lib/pages/widgets/radio_tile.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/radio_tile.dart
@@ -19,18 +19,37 @@ class RadioTile<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Adds a nice visual clue that the tile is selected.
-    return YaruSelectableContainer(
-      selected: groupValue == value,
-      selectionColor: Theme.of(context).colorScheme.tertiaryContainer,
-      child: YaruRadioListTile(
-        contentPadding: EdgeInsets.zero,
-        visualDensity: VisualDensity.comfortable,
-        dense: true,
-        title: Text(title),
-        subtitle: subtitle != null ? Text(subtitle!) : null,
-        value: value,
-        groupValue: groupValue,
-        onChanged: onChanged,
+    return YaruBorderContainer(
+      border: groupValue == value
+          ? Border.all(
+              color: Theme.of(context).colorScheme.primary,
+            )
+          : null,
+      // we specify this here since [YaruSelectableContainer] doesn't support a
+      // non-selected color
+      color: groupValue != value
+          ? Theme.of(context).colorScheme.onInverseSurface
+          : null,
+      child: YaruSelectableContainer(
+        selected: groupValue == value,
+        selectionColor:
+            Theme.of(context).colorScheme.tertiaryContainer.withOpacity(0.8),
+        padding: EdgeInsets.zero,
+        child: YaruRadioListTile(
+          contentPadding: const EdgeInsets.all(6),
+          visualDensity: VisualDensity.standard,
+          dense: true,
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+          ),
+          subtitle: subtitle != null ? Text(subtitle!) : null,
+          value: value,
+          groupValue: groupValue,
+          onChanged: onChanged,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Adds a border to the radio tiles, as well as a background to unselected tiles.

| | Dark | Light |
|-|------|-------|
| Existing | ![image](https://github.com/user-attachments/assets/2ef62668-b341-48b0-b263-4bfdd0283393) | ![image](https://github.com/user-attachments/assets/1c91dcf4-d825-47f7-8708-1c15a75d4273) |
| New | ![image](https://github.com/user-attachments/assets/584b61e2-19c1-4657-aa3c-349ed98008b9) | ![image](https://github.com/user-attachments/assets/72094385-06c9-46ca-b00e-bf1a8c223fa9) |

This is also based on https://github.com/canonical/ubuntu-pro-for-wsl/pull/997 and relies on it being merged first.

---

UDENG-5593