### PR TITLE
fix(docs): Explicits the agent's requirement on the server SSL public key

### DIFF
--- a/docs/howto/set-up-landscape-client.md
+++ b/docs/howto/set-up-landscape-client.md
@@ -57,25 +57,25 @@ When you continue a status screen will appear confirming that configuration is c
 
 ![Configuration is complete](../assets/status-complete.png)
 
-### Note on SSL public key
+```
 
-If the machine running the server is not trusted on your network you may need to
-explicitly reference a path to the SSL public key on a Windows host machine.
+````
+
+```{warning}
+Until version 0.1.15 of Ubuntu Pro for WSL, the app explicitly requires referencing a path
+to the SSL certificate on a Windows host machine.
+Newer versions completely follow the Windows OS certificate stores, only requiring reference
+to that certificate if the machine running the Landscape server is not trusted on your network.
 
 For example, if you followed the [Landscape Quickstart](https://ubuntu.com/landscape/docs/quickstart-deployment)
 installation, the auto-generated self-signed certificate can be found at `/etc/ssl/certs/landscape_server.pem`.
 
 This can be copied to a Windows machine:
 
-  C:\Users\\<YOUR_WINDOWS_USER_NAME>\landscape_server.pem
+>  C:\Users\\<YOUR_WINDOWS_USER_NAME>\landscape_server.pem
 
 The path can then be referenced during Landscape configuration in the UP4W Windows app.
-If necessary, the SSL public key can be added after the Windows host has first
-been registered in Landscape.
-
 ```
-
-````
 
 (howto::config-landscape-client)=
 ## Configuring the landscape client

--- a/docs/reference/landscape_config.md
+++ b/docs/reference/landscape_config.md
@@ -33,4 +33,13 @@ This section contains settings used by both clients. Most keys in this section b
 - `computer_title`: This key will be ignored. Instead, each WSL instance will use its Distro name as computer title.
 - `hostagent_uid`: This key will be ignored.
 
+```{warning}
+The certificate referred to by the `ssl_public_key` key is used for both the
+Landscape client inside the WSL instances as well as the Windows background agent.
+Until version 0.1.15 of Ubuntu Pro for WSL, the app explicitly requires referencing a path
+to the SSL certificate on a Windows host machine.
+Newer versions completely follow the Windows OS certificate stores, only requiring reference
+to that certificate if the machine running the Landscape server is not trusted on your network.
+```
+
 > See more: [GitHub | Landscape client configuration schema](https://github.com/canonical/landscape-client/blob/master/example.conf)


### PR DESCRIPTION
Until version 0.1.15 (the current version tag) of Ubuntu Pro for WSL, the app explicitly requires referencing a path to the SSL certificate on a Windows host machine.

The fix was implemented in #995. Now the agent completely follows the Windows OS certificate stores, only requiring reference to that certificate if the machine running the Landscape server is not trusted on a particular network. But we didn't issue a new release since then. So, to avoid a new release so close to the end-of-year holidays, let's update the docs in an atomic way, so we can easily revert if we deem worth it after the new year and a new release comes out.

The changes herein introduced look like the following:

![image](https://github.com/user-attachments/assets/7cb8c7e4-6047-4915-b178-b36ef3419224)

and

![image](https://github.com/user-attachments/assets/1d94396c-3526-4588-a51c-e20c29e15345)

---

UDENG-5654