### PR TITLE
deps: Bump Yaru to 6.0.0

### DIFF
--- a/gui/packages/ubuntupro/pubspec.lock
+++ b/gui/packages/ubuntupro/pubspec.lock
@@ -1135,18 +1135,18 @@ packages:
     dependency: "direct main"
     description:
       name: yaru
-      sha256: afc659f78a0bef5e06ebbbd516979afceca7526b7703daa444bf419a54b2dc85
+      sha256: "5fb1886e15f736b26c717725e335e80af7dbc91d9324d1d3e6bd355deed448a0"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "6.0.0"
   yaru_test:
     dependency: "direct dev"
     description:
       name: yaru_test
-      sha256: d45f0099db88e997e69218d232fd27d9c024a4fe4d918371b3012b3b95b8e419
+      sha256: "88d692b821a31dd67de06264788bbf09e8282ba84f67d8a6e2f6c17fdd3a3d83"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   yaru_window:
     dependency: transitive
     description:

--- a/gui/packages/ubuntupro/pubspec.yaml
+++ b/gui/packages/ubuntupro/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   win32_registry: ^1.1.5
   windows_single_instance: ^1.0.1
   wizard_router: ^1.4.0
-  yaru: ^5.3.2
+  yaru: ^6.0.0
 
 dev_dependencies:
   build_runner: ^2.4.13
@@ -80,7 +80,7 @@ dev_dependencies:
   protobuf: ^3.1.0
   stack_trace: ^1.11.0
   url_launcher_platform_interface: ^2.3.2
-  yaru_test: ^0.2.0
+  yaru_test: ^0.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Bumps Yaru to 6.0.0 (and yaru_test to 0.3.0), which includes [my fix for the title bar](https://github.com/ubuntu/yaru.dart/pull/967), as pictured here:

![image](https://github.com/user-attachments/assets/3704a3c1-5e81-49c8-bc8a-73b131b4c438)

(Also note the new dark mode colors from Yaru 6)

---

UDENG-5691