### PR TITLE
fix: Set a minimum size for the window

### DIFF
--- a/gui/packages/ubuntupro/lib/main.dart
+++ b/gui/packages/ubuntupro/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:window_manager/window_manager.dart';
 import 'package:windows_single_instance/windows_single_instance.dart';
 import 'package:yaru/widgets.dart';
+
 import 'app.dart';
 import 'constants.dart';
 import 'core/agent_api_client.dart';
@@ -16,6 +18,9 @@ Future<void> main() async {
     [],
     'UP4W_SINGLE_INSTANCE_GUI',
   );
+  WidgetsFlutterBinding.ensureInitialized();
+  await windowManager.ensureInitialized();
+
   final agentMonitor = AgentStartupMonitor(
     addrFileName: kAddrFileName,
     agentLauncher: launch,
@@ -26,6 +31,16 @@ Future<void> main() async {
   final settings = Environment()['UP4W_INTEGRATION_TESTING'] != null
       ? Settings.withOptions(Options.withAll)
       : Settings(SettingsRepository());
+
+  final windowOptions = const WindowOptions(
+    size: Size(900, 550),
+    minimumSize: Size(900, 550),
+    center: true,
+  );
+  await windowManager.waitUntilReadyToShow(windowOptions, () async {
+    await windowManager.show();
+    await windowManager.focus();
+  });
 
   runApp(Pro4WSLApp(agentMonitor, settings));
 }

--- a/gui/packages/ubuntupro/pubspec.lock
+++ b/gui/packages/ubuntupro/pubspec.lock
@@ -1084,7 +1084,7 @@ packages:
     source: hosted
     version: "1.1.5"
   window_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: window_manager
       sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"

--- a/gui/packages/ubuntupro/pubspec.yaml
+++ b/gui/packages/ubuntupro/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   url_launcher: ^6.3.1
   win32: ^5.10.0
   win32_registry: ^1.1.5
+  window_manager: ^0.4.3
   windows_single_instance: ^1.0.1
   wizard_router: ^1.4.0
   yaru: ^6.0.0


### PR DESCRIPTION
Sets a minimum window size to the current default size. The window may be resized to be larger but cannot be resized to be smaller. This also centers the window on the screen when it opens instead of being in the top left corner.

This works, but it might be worth considering an update to https://github.com/ubuntu/yaru_window.dart to include a `setMinimumSize` and `setMaximumSize` method to `YaruWindow` instead of having to use `window_manager` directly.

---

UDENG-5682