### PR TITLE
fix: Set a maximum size of page contents

### DIFF
--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -1,6 +1,12 @@
 /// The name of the file where the Agent's drop its service connection information.
 const kAddrFileName = '.ubuntupro/.address';
 
+/// Default window width.
+const kWindowWidth = 900.0;
+
+/// Default window height.
+const kWindowHeight = 550.0;
+
 /// The default border margin.
 const kDefaultMargin = 32.0;
 

--- a/gui/packages/ubuntupro/lib/main.dart
+++ b/gui/packages/ubuntupro/lib/main.dart
@@ -33,8 +33,8 @@ Future<void> main() async {
       : Settings(SettingsRepository());
 
   final windowOptions = const WindowOptions(
-    size: Size(900, 550),
-    minimumSize: Size(900, 550),
+    size: Size(kWindowWidth, kWindowHeight),
+    minimumSize: Size(kWindowWidth, kWindowHeight),
     center: true,
   );
   await windowManager.waitUntilReadyToShow(windowOptions, () async {

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -27,6 +27,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:yaru/yaru.dart';
 
+import '/constants.dart';
 import 'navigation_row.dart';
 import 'status_bar.dart';
 
@@ -167,53 +168,57 @@ class ColumnPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Expanded(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  // Left column
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        RichText(
-                          text: TextSpan(
-                            children: [
-                              WidgetSpan(
-                                child: SvgPicture.asset(
-                                  svgAsset,
-                                  height: 70,
+              child: ConstrainedBox(
+                constraints:
+                    const BoxConstraints(maxWidth: kWindowWidth - 64.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    // Left column
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          RichText(
+                            text: TextSpan(
+                              children: [
+                                WidgetSpan(
+                                  child: SvgPicture.asset(
+                                    svgAsset,
+                                    height: 70,
+                                  ),
                                 ),
-                              ),
-                              const WidgetSpan(
-                                child: SizedBox(
-                                  width: 8,
+                                const WidgetSpan(
+                                  child: SizedBox(
+                                    width: 8,
+                                  ),
                                 ),
-                              ),
-                              TextSpan(
-                                text: title,
-                                style: theme.textTheme.displaySmall
-                                    ?.copyWith(fontWeight: FontWeight.w100),
-                              ),
-                            ],
+                                TextSpan(
+                                  text: title,
+                                  style: theme.textTheme.displaySmall
+                                      ?.copyWith(fontWeight: FontWeight.w100),
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: 24),
-                        ...left,
-                      ],
+                          const SizedBox(height: 24),
+                          ...left,
+                        ],
+                      ),
                     ),
-                  ),
-                  // Spacer
-                  const SizedBox(width: 32),
-                  // Right column
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: right,
+                    // Spacer
+                    const SizedBox(width: 32),
+                    // Right column
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: right,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
             if (navigationRow != null) navigationRow!,


### PR DESCRIPTION
Sets a maximum width for page content, equal to their current effective width.

Here's a comparison for this change (maximized on a 1440p screen):

| Old | New |
|-----|-----|
| ![image](https://github.com/user-attachments/assets/623d1d22-84d7-4c66-8580-f0b0cfd38f66) | ![image](https://github.com/user-attachments/assets/5a78057f-c684-4a57-a988-cd70268aad1b) |

The default size of the app remains unchanged.

*This diff is really just the content being wrapped with a new widget, nothing else changed*

---

UDENG-5684