### PR TITLE
fix(gui-ubuntupro): Add placeholder padding to text fields to prevent jittering

### DIFF
--- a/gui/packages/ubuntupro/lib/constants.dart
+++ b/gui/packages/ubuntupro/lib/constants.dart
@@ -5,7 +5,7 @@ const kAddrFileName = '.ubuntupro/.address';
 const kWindowWidth = 900.0;
 
 /// Default window height.
-const kWindowHeight = 550.0;
+const kWindowHeight = 600.0;
 
 /// The default border margin.
 const kDefaultMargin = 32.0;

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -4,7 +4,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
-import 'package:yaru/yaru.dart';
 
 import '/core/pro_token.dart';
 import '/pages/widgets/delayed_text_field.dart';
@@ -61,17 +60,7 @@ class ProTokenInputField extends StatelessWidget {
           autofocus: false,
           controller: controller,
           label: Text(lang.tokenInputHint),
-          error: model.tokenError?.localize(lang) != null
-              ? Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Text(
-                    model.tokenError!.localize(lang)!,
-                    style: theme.textTheme.bodySmall!.copyWith(
-                      color: YaruColors.of(context).error,
-                    ),
-                  ),
-                )
-              : null,
+          errorText: model.tokenError?.localize(lang),
           onChanged: model.updateToken,
           onSubmitted: (_) => onSubmit?.call(),
         ),

--- a/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
@@ -13,6 +13,8 @@ class DelayedTextField extends StatefulWidget {
     this.controller,
     this.error,
     this.errorText,
+    this.helper,
+    this.helperText,
     this.hintText,
     this.inputFormatters,
     this.label,
@@ -26,6 +28,8 @@ class DelayedTextField extends StatefulWidget {
   final bool enabled;
   final Widget? error;
   final String? errorText;
+  final Widget? helper;
+  final String? helperText;
   final String? hintText;
   final List<TextInputFormatter>? inputFormatters;
   final Widget? label;
@@ -76,6 +80,9 @@ class _DelayedTextField extends State<DelayedTextField>
             error: showError ? widget.error : null,
             errorText: showError ? widget.errorText : null,
             label: widget.label,
+            helper: widget.helper ?? const SizedBox(height: 16),
+            helperText: widget.helperText,
+            hintText: widget.hintText,
           ),
         );
       },

--- a/gui/packages/ubuntupro/test/utils/build_multiprovider_app.dart
+++ b/gui/packages/ubuntupro/test/utils/build_multiprovider_app.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:ubuntupro/core/agent_connection.dart';
 import 'package:ubuntupro/core/agent_monitor.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru/yaru.dart';
 
 /// Simplifies creating app widgets which don't care about the behavior of status bar (majority of test cases).
 Widget buildMultiProviderWizardApp({
@@ -19,11 +20,15 @@ Widget buildMultiProviderWizardApp({
             create: (_) => _MockAgentConnection(),
           ),
         ],
-    child: MaterialApp(
-      home: Wizard(
-        routes: routes,
+    child: YaruTheme(
+      builder: (_, yaru, __) => MaterialApp(
+        theme: yaru.theme,
+        darkTheme: yaru.darkTheme,
+        home: Wizard(
+          routes: routes,
+        ),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
       ),
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
     ),
   );
 }
@@ -39,9 +44,13 @@ Widget buildSingleRouteMultiProviderApp({
             create: (_) => _MockAgentConnection(),
           ),
         ],
-    child: MaterialApp(
-      home: child,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
+    child: YaruTheme(
+      builder: (_, yaru, __) => MaterialApp(
+        theme: yaru.theme,
+        darkTheme: yaru.darkTheme,
+        home: child,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+      ),
     ),
   );
 }

--- a/gui/packages/ubuntupro/windows/runner/main.cpp
+++ b/gui/packages/ubuntupro/windows/runner/main.cpp
@@ -23,7 +23,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
-  Win32Window::Size size(900, 550);
+  Win32Window::Size size(900, 600);
   if (!window.Create(L"ubuntupro", origin, size)) {
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
When entering text into a text field that may display an error, the text field and other content on the page will move to accomodate the error text. This change adds a SizedBox when there is no error to prevent this movement. As a result, page content is naturally longer, so the default window height has been increased by 50 pixels.

![image](https://github.com/user-attachments/assets/3caf0ec5-b878-4ad0-9e04-eceba85d9565)

*Depends on https://github.com/canonical/ubuntu-pro-for-wsl/pull/1043*

---

UDENG-5680