### PR TITLE
fix(wsl-pro-service): Prevents unnecessary re-registration with Landscape 

### DIFF
--- a/wsl-pro-service/internal/system/landscape.go
+++ b/wsl-pro-service/internal/system/landscape.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
-	"unicode"
 
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/ubuntu/decorate"
@@ -61,13 +59,13 @@ func (s *System) fixAndEnableLandscapeFromConfig(ctx context.Context, landscapeC
 		return fmt.Errorf("could not parse config: %v", err)
 	}
 
-	modifiedLandscapeConfig, err := normalizeLandscapeConfig(ctx, s, iniFile)
+	modifiedLandscapeConfig, didChange, err := normalizeLandscapeConfig(ctx, s, iniFile)
 	if err != nil {
 		return err
 	}
 
 	// No change to do, do not rewrite config
-	if !enableUnconditionally && areConfigsEqual(modifiedLandscapeConfig, landscapeConfig) {
+	if !enableUnconditionally && !didChange {
 		log.Debug(ctx, "Landscape configuration is already valid")
 		return nil
 	}
@@ -83,16 +81,6 @@ func (s *System) fixAndEnableLandscapeFromConfig(ctx context.Context, landscapeC
 	}
 
 	return nil
-}
-
-func areConfigsEqual(a, b string) bool {
-	fieldsFunc := func(r rune) bool {
-		return unicode.IsSpace(r) || r == '='
-	}
-	// Reduces a and b to slices of strings not containing spaces nor '='.
-	aFields := strings.FieldsFunc(a, fieldsFunc)
-	bFields := strings.FieldsFunc(b, fieldsFunc)
-	return slices.Equal(aFields, bFields)
 }
 
 func (s *System) writeConfig(landscapeConfig string) (err error) {
@@ -135,65 +123,71 @@ func (s *System) writeConfig(landscapeConfig string) (err error) {
 
 // normalizeLandscapeConfig ensures that the landscape config has the expected computer_title and SSL certificate path
 // transformed in a Linux path.
-func normalizeLandscapeConfig(ctx context.Context, s *System, iniFile *ini.File) (modifiedLandscapeConfig string, err error) {
+func normalizeLandscapeConfig(ctx context.Context, s *System, iniFile *ini.File) (modifiedLandscapeConfig string, didChange bool, err error) {
 	clientSection, err := iniFile.GetSection("client")
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	// Add or refresh computer title
 	distroName, err := s.WslDistroName(ctx)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
+	titleChanged := false
 	oldComputerTitle, err := clientSection.GetKey("computer_title")
 	if err != nil {
 		if _, err = clientSection.NewKey("computer_title", distroName); err != nil {
-			return "", err
+			return "", false, err
 		}
+		titleChanged = true
 	} else if oldComputerTitle.String() != distroName {
 		oldComputerTitle.SetValue(distroName)
+		titleChanged = true
 	}
 
 	// Refresh SSL certificate path if any
-	if err := overrideSSLCertificate(ctx, s, clientSection); err != nil {
-		return "", fmt.Errorf("could not override SSL certificate path: %v", err)
+	certChanged, err := overrideSSLCertificate(ctx, s, clientSection)
+	if err != nil {
+		return "", false, fmt.Errorf("could not override SSL certificate path: %v", err)
 	}
 
 	// Return the modified config as a string.
 	w := &bytes.Buffer{}
 	if _, err := iniFile.WriteTo(w); err != nil {
-		return "", fmt.Errorf("could not regenerate modified config: %v", err)
+		return "", false, fmt.Errorf("could not regenerate modified config: %v", err)
 	}
 
-	return w.String(), nil
+	didChange = titleChanged || certChanged
+	return w.String(), didChange, nil
 }
 
 // overrideComputerTitle converts the ssl_public_key field in the Landscape config
-// from a Windows path to a Linux path.
-func overrideSSLCertificate(ctx context.Context, s *System, section *ini.Section) error {
+// from a Windows path to a Linux path. Returns true if the value was changed.
+func overrideSSLCertificate(ctx context.Context, s *System, section *ini.Section) (bool, error) {
 	const key = "ssl_public_key"
 
 	k, err := section.GetKey(key)
 	if err != nil {
 		// No certificate: nothing to transform
-		return nil
+		return false, nil
 	}
 
 	pathWindows := k.String()
 
 	if len(pathWindows) == 0 {
 		// Empty paths are translated by wslpath as the current working directory, which is not what we want.
-		return nil
+		return false, nil
 	}
 
 	cmd := s.backend.WslpathExecutable(ctx, "-ua", pathWindows)
 	out, err := runCommand(cmd)
 	if err != nil {
-		return fmt.Errorf("could not translate SSL certificate path %q to a WSL path: %v", pathWindows, err)
+		return false, fmt.Errorf("could not translate SSL certificate path %q to a WSL path: %v", pathWindows, err)
 	}
 
 	pathLinux := s.Path(strings.TrimSpace(string(out)))
 	k.SetValue(pathLinux)
-	return nil
+
+	return pathWindows != pathLinux, nil
 }

--- a/wsl-pro-service/internal/system/landscape.go
+++ b/wsl-pro-service/internal/system/landscape.go
@@ -77,7 +77,7 @@ func (s *System) fixAndEnableLandscapeFromConfig(ctx context.Context, landscapeC
 	}
 
 	// TODO: check foreground/background
-	cmd := s.backend.LandscapeConfigExecutable(ctx, "--config", landscapeConfigPath, "--silent")
+	cmd := s.backend.LandscapeConfigExecutable(ctx, "--config", landscapeConfigPath, "--silent", "--register-if-needed")
 	if _, err := runCommand(cmd); err != nil {
 		return fmt.Errorf("could not enable Landscape: %v", err)
 	}

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -682,6 +682,7 @@ func TestEnsureValidLandscapeConfig(t *testing.T) {
 		"Reformat Landscape config to proper ini": {systemLandscapeConfigFile: "regular_with_weird_format.conf"},
 
 		"Do not rerun landscape without modifications":                             {systemLandscapeConfigFile: "no_change_needed.conf", wantNoLandscapeConfigCmd: true},
+		"Do not rerun landscape due whitespace changes":                            {systemLandscapeConfigFile: "no_change_due_spaces.conf", wantNoLandscapeConfigCmd: true},
 		"No Landscape configuration means no landscape command nor config created": {systemLandscapeConfigFile: "-", wantNoLandscapeConfigCmd: true, wantNoLandscapeConfig: true},
 
 		"Error when the config file cannot be read":              {breakWriteConfig: true, wantErr: true},

--- a/wsl-pro-service/internal/system/testdata/TestEnsureValidLandscapeConfig/golden/do_not_rerun_landscape_due_whitespace_changes
+++ b/wsl-pro-service/internal/system/testdata/TestEnsureValidLandscapeConfig/golden/do_not_rerun_landscape_due_whitespace_changes
@@ -1,0 +1,4 @@
+[client]
+extra_spaces         = no_problem
+ssl_public_key = /idempotent/path/to/linux/certificate
+computer_title = TEST_DISTRO

--- a/wsl-pro-service/internal/system/testdata/landscape.conf.d/no_change_due_spaces.conf
+++ b/wsl-pro-service/internal/system/testdata/landscape.conf.d/no_change_due_spaces.conf
@@ -1,0 +1,4 @@
+[client]
+extra_spaces         = no_problem
+ssl_public_key = /idempotent/path/to/linux/certificate
+computer_title = TEST_DISTRO

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -404,8 +404,8 @@ func LandscapeConfigMock(t *testing.T) {
 			}
 
 			return exitOk
-		case 3:
-			// landscape-config [--config|-c] FILENAME --silent
+		case 4:
+			// landscape-config [--config|-c] FILENAME --silent --register-if-needeed
 			if argv[0] != "-c" && argv[0] != "--config" {
 				fmt.Fprintf(os.Stderr, "Mock not implemented for arg %q\n", argv[0])
 				return exitBadUsage
@@ -413,6 +413,11 @@ func LandscapeConfigMock(t *testing.T) {
 
 			if argv[2] != "--silent" {
 				fmt.Fprintf(os.Stderr, "Mock not implemented for arg %q\n", argv[2])
+				return exitBadUsage
+			}
+
+			if argv[3] != "--register-if-needed" {
+				fmt.Fprintf(os.Stderr, "Mock not implemented for arg %q\n", argv[3])
 				return exitBadUsage
 			}
 


### PR DESCRIPTION
This is a two-fold fix.

## Re-registration due whitespace changes

I noticed that wsl-pro-service was causing the machine to re-register with Landscape at every startup. There is an early routine that checks for the validity of the Landscape client config file contents, amending it if necessary and re-running landscape-config **if anything changed**. The current implementation also considers whitespace changes as a valid reason to re-run landscape-config, which shouldn't be the case.

An instrumented build to diff the contents before and after that routine revealed that we're taking whitespace changes too seriously.

```
n@mib01:~$ sudo /mnt/d/wsl-pro-service -vvv
INFO Starting WSL Pro Service version Dev
INFO /home/cn/Dev/1_Work/up4w/wsl-pro-service/cmd/wsl-pro-service/service/config.go:48 initViperConfig() No configuration file: Config File "wsl-pro-service" Not Found in "[/home/n /root /etc /mnt/d]"
DEBUG /home/cn/Dev/1_Work/up4w/wsl-pro-service/cmd/wsl-pro-service/service/service.go:64 New.func1() Debug mode is enabled
DEBUG /home/cn/Dev/1_Work/up4w/wsl-pro-service/internal/system/landscape.go:74 (*System).fixAndEnableLandscapeFromConfig() Landscape: something changed.
 [client]
-account_name = standalone
-url = https://lg4070.olivec.dev/message-system
-ping_url = http://lg4070.olivec.dev/ping
-log_level = info
+account_name     = standalone
+url              = https://lg4070.olivec.dev/message-system
+ping_url         = http://lg4070.olivec.dev/ping
+log_level        = info
 registration_key = 123
-tags = wsl
-hostagent_uid = 36589e24a0e24eecaaea3c04eee2afd4
-computer_title = Ubuntu-22.04
+tags             = wsl
+hostagent_uid    = 36589e24a0e24eecaaea3c04eee2afd4
+computer_title   = Ubuntu-22.04
```

## landscape-config would always create a new registration

Secondly, re-running landscape-config would always create a new registration, even if the client configuration change is minor and unrelated to the server, such as the client debug level. 

landscape-client (24.08+git6375-0ubuntu0) added the new --register-if-needed flag for landscape-config, allowing it to refresh an existing registration instead of unconditionally creating a new one for a computer already registered with Landscape. There are situations when wsl-pro-service subprocesses lansdcape-config on an already registered computer. That creates a new registration and, even though Landscape server has some logic to detect that the new registration belongs to an existing computer, it loses data that takes long to recover, such as package version information.

Since the landscape-client version in the latest-stable PPA is already over that version we should be able to add this flag to wsl-pro-service and prevent that behaviour.

---

UDENG-5761