### PR TITLE
fix: Add option to use non-elevated buttons for navigation

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
@@ -64,7 +64,7 @@ class _LandscapeSkipPageState extends State<LandscapeSkipPage> {
       navigationRow: NavigationRow(
         onBack: wizard.back,
         onNext: () => wizard.next(arguments: groupValue),
-        nextIsElevated: false,
+        nextIsAction: false,
       ),
     );
   }

--- a/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape_skip/landscape_skip_page.dart
@@ -64,6 +64,7 @@ class _LandscapeSkipPageState extends State<LandscapeSkipPage> {
       navigationRow: NavigationRow(
         onBack: wizard.back,
         onNext: () => wizard.next(arguments: groupValue),
+        nextIsElevated: false,
       ),
     );
   }

--- a/gui/packages/ubuntupro/lib/pages/widgets/navigation_row.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/navigation_row.dart
@@ -9,6 +9,7 @@ class NavigationRow extends StatelessWidget {
     this.nextText,
     this.showBack = true,
     this.showNext = true,
+    this.nextIsElevated = true,
     super.key,
   });
 
@@ -18,6 +19,7 @@ class NavigationRow extends StatelessWidget {
   final void Function()? onNext;
   final String? nextText;
   final bool showNext;
+  final bool nextIsElevated;
 
   @override
   Widget build(BuildContext context) {
@@ -32,10 +34,15 @@ class NavigationRow extends StatelessWidget {
           ),
         if (showNext) ...[
           const Spacer(),
-          ElevatedButton(
-            onPressed: onNext,
-            child: Text(nextText ?? lang.buttonNext),
-          ),
+          nextIsElevated
+              ? ElevatedButton(
+                  onPressed: onNext,
+                  child: Text(nextText ?? lang.buttonNext),
+                )
+              : OutlinedButton(
+                  onPressed: onNext,
+                  child: Text(nextText ?? lang.buttonNext),
+                ),
         ],
       ],
     );

--- a/gui/packages/ubuntupro/lib/pages/widgets/navigation_row.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/navigation_row.dart
@@ -9,7 +9,7 @@ class NavigationRow extends StatelessWidget {
     this.nextText,
     this.showBack = true,
     this.showNext = true,
-    this.nextIsElevated = true,
+    this.nextIsAction = true,
     super.key,
   });
 
@@ -19,7 +19,7 @@ class NavigationRow extends StatelessWidget {
   final void Function()? onNext;
   final String? nextText;
   final bool showNext;
-  final bool nextIsElevated;
+  final bool nextIsAction;
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +34,7 @@ class NavigationRow extends StatelessWidget {
           ),
         if (showNext) ...[
           const Spacer(),
-          nextIsElevated
+          nextIsAction
               ? ElevatedButton(
                   onPressed: onNext,
                   child: Text(nextText ?? lang.buttonNext),


### PR DESCRIPTION
Adds an option to use elevated or outlined buttons for "next" navigation. Non-action buttons should be outlined instead of elevated.

![image](https://github.com/user-attachments/assets/00828a08-5968-49ff-afaf-6e5ef41b8f04)
*Note "Next" is outlined instead of green*