### PR TITLE
fix: Fix spacing between fields with errors

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
+++ b/gui/packages/ubuntupro/lib/pages/landscape/landscape_page.dart
@@ -52,6 +52,7 @@ class LandscapePage extends StatelessWidget {
     return ColumnPage(
       svgAsset: 'assets/Landscape-tag.svg',
       title: kLandscapeTitle,
+      rightIsCentered: false,
       left: [
         MarkdownBody(
           data: lang.landscapeHeading(
@@ -62,6 +63,7 @@ class LandscapePage extends StatelessWidget {
         ),
       ],
       right: [
+        const SizedBox(height: 24),
         LandscapeConfigForm(model),
       ],
       navigationRow: NavigationRow(

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -63,6 +63,7 @@ class ProTokenInputField extends StatelessWidget {
           errorText: model.tokenError?.localize(lang),
           onChanged: model.updateToken,
           onSubmitted: (_) => onSubmit?.call(),
+          helper: const SizedBox(height: 16),
         ),
       ],
     );

--- a/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/subscribe_now/subscribe_now_widgets.dart
@@ -51,7 +51,7 @@ class ProTokenInputField extends StatelessWidget {
           onTapLink: (_, href, __) => launchUrlString(href!),
           styleSheet: linkStyle,
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 16),
         DelayedTextField(
           inputFormatters: [
             // This ignores all sorts of (Unicode) whitespaces (not only at the ends).

--- a/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
@@ -81,7 +81,7 @@ class _DelayedTextField extends State<DelayedTextField>
             error: showError ? widget.error : null,
             errorText: showError ? widget.errorText : null,
             label: widget.label,
-            helper: widget.helper ?? const SizedBox(height: 16),
+            helper: widget.helper,
             helperText: widget.helperText,
             hintText: widget.hintText,
           ),

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -148,6 +148,7 @@ class ColumnPage extends StatelessWidget {
     this.svgAsset = 'assets/Ubuntu-tag.svg',
     this.title = 'Ubuntu Pro',
     this.navigationRow,
+    this.rightIsCentered = true,
     super.key,
   });
 
@@ -156,6 +157,7 @@ class ColumnPage extends StatelessWidget {
   final String svgAsset;
   final String title;
   final NavigationRow? navigationRow;
+  final bool rightIsCentered;
 
   @override
   Widget build(BuildContext context) {
@@ -168,56 +170,62 @@ class ColumnPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Expanded(
-              child: ConstrainedBox(
-                constraints:
-                    const BoxConstraints(maxWidth: kWindowWidth - 64.0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    // Left column
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          RichText(
-                            text: TextSpan(
-                              children: [
-                                WidgetSpan(
-                                  child: SvgPicture.asset(
-                                    svgAsset,
-                                    height: 70,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: kWindowWidth - 64.0,
+                    maxHeight: kWindowHeight - 196.0,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      // Left column
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            RichText(
+                              text: TextSpan(
+                                children: [
+                                  WidgetSpan(
+                                    child: SvgPicture.asset(
+                                      svgAsset,
+                                      height: 70,
+                                    ),
                                   ),
-                                ),
-                                const WidgetSpan(
-                                  child: SizedBox(
-                                    width: 8,
+                                  const WidgetSpan(
+                                    child: SizedBox(
+                                      width: 8,
+                                    ),
                                   ),
-                                ),
-                                TextSpan(
-                                  text: title,
-                                  style: theme.textTheme.displaySmall
-                                      ?.copyWith(fontWeight: FontWeight.w100),
-                                ),
-                              ],
+                                  TextSpan(
+                                    text: title,
+                                    style: theme.textTheme.displaySmall
+                                        ?.copyWith(fontWeight: FontWeight.w100),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                          const SizedBox(height: 24),
-                          ...left,
-                        ],
+                            const SizedBox(height: 24),
+                            ...left,
+                          ],
+                        ),
                       ),
-                    ),
-                    // Spacer
-                    const SizedBox(width: 32),
-                    // Right column
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: right,
+                      // Spacer
+                      const SizedBox(width: 32),
+                      // Right column
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: rightIsCentered
+                              ? MainAxisAlignment.center
+                              : MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: right,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixes the spacing for the Landscape page by aligning the page to the top so errors push the fields down, instead of being aligned center and pushing the entire page.

Also, increases the spacing slightly above the token input field.

New token field spacing:
![image](https://github.com/user-attachments/assets/93de0e10-e3a8-46ed-85a7-73e239095877)

New Landscape page spacing:
![image](https://github.com/user-attachments/assets/5f2117e4-031f-4daa-bd71-af05719916e9)

For reviewers: note this should work when the window is maximized as well

---

UDENG-5853