### PR TITLE
feat(windows-agent): cloudinit module to defer Landscape registration

### DIFF
--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -219,6 +219,13 @@ func landscapeModule(c Config, out map[string]interface{}) error {
 		landscapeModule.Client[keyName] = section.Key(keyName).String()
 	}
 
+	// Enforcing a deferred registration with Landscape.
+	landscapeModule.Client["no_start"] = ""
+	landscapeModule.Client["skip_registration"] = ""
+
+	// Adding a placeholder computer title to prevent cloud-init schema warnings.
+	landscapeModule.Client["computer_title"] = "wsl"
+
 	out["landscape"] = landscapeModule
 	return nil
 }

--- a/windows-agent/internal/cloudinit/cloudinit.go
+++ b/windows-agent/internal/cloudinit/cloudinit.go
@@ -219,11 +219,11 @@ func landscapeModule(c Config, out map[string]interface{}) error {
 		landscapeModule.Client[keyName] = section.Key(keyName).String()
 	}
 
-	// Enforcing a deferred registration with Landscape.
+	// Enforce a deferred registration with Landscape.
 	landscapeModule.Client["no_start"] = ""
 	landscapeModule.Client["skip_registration"] = ""
 
-	// Adding a placeholder computer title to prevent cloud-init schema warnings.
+	// Add a placeholder computer title to prevent cloud-init schema warnings.
 	landscapeModule.Client["computer_title"] = "wsl"
 
 	out["landscape"] = landscapeModule

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_landscape_config
@@ -2,7 +2,10 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         data: This is an old data field
         info: This is the old configuration
+        no_start: ""
+        skip_registration: ""
 ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_obtaining_pro_token
@@ -2,7 +2,10 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         data: This is an old data field
         info: This is the old configuration
+        no_start: ""
+        skip_registration: ""
 ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_when_the_temp_file_cannot_be_written
@@ -2,7 +2,10 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         data: This is an old data field
         info: This is the old configuration
+        no_start: ""
+        skip_registration: ""
 ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/error_with_erroneous_landscape_config
@@ -2,7 +2,10 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         data: This is an old data field
         info: This is the old configuration
+        no_start: ""
+        skip_registration: ""
 ubuntu_pro:
     token: OLD_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/success
@@ -2,8 +2,11 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         hostagent_uid: landscapeUID1234
         info: This is the new configuration
+        no_start: ""
+        skip_registration: ""
         url: www.example.com/new/rickroll
 ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_hostagent_uid
@@ -2,7 +2,10 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         info: This is the new configuration
+        no_start: ""
+        skip_registration: ""
         url: www.example.com/new/rickroll
 ubuntu_pro:
     token: NEW_PRO_TOKEN

--- a/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_pro_token
+++ b/windows-agent/internal/cloudinit/testdata/TestUpdate/golden/without_pro_token
@@ -2,6 +2,9 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         hostagent_uid: landscapeUID1234
         info: This is the new configuration
+        no_start: ""
+        skip_registration: ""
         url: www.example.com/new/rickroll

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_don't_contain_[host]_section/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_don't_contain_[host]_section/agent.yaml
@@ -2,6 +2,8 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
-        computer_title: another
+        computer_title: wsl
         hostagent_uid: landscapeUID
+        no_start: ""
+        skip_registration: ""
         tags: wsl

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_only_contains_[client]_section)/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_only_contains_[client]_section)/agent.yaml
@@ -2,6 +2,8 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
-        computer_title: another
+        computer_title: wsl
         hostagent_uid: landscapeUID
+        no_start: ""
+        skip_registration: ""
         tags: wsl

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_default_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_default_tags/agent.yaml
@@ -2,6 +2,8 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
-        computer_title: another
+        computer_title: wsl
         hostagent_uid: landscapeUID
+        no_start: ""
+        skip_registration: ""
         tags: wsl

--- a/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_supplied_tags/agent.yaml
+++ b/windows-agent/internal/proservices/landscape/testdata/TestNotifyConfigUpdateWithAgentYaml/task_and_agent.yaml_with_supplied_tags/agent.yaml
@@ -2,5 +2,8 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
         hostagent_uid: landscapeUID
+        no_start: ""
+        skip_registration: ""
         tags: another

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_config_cannot_check_if_it_is_read-only
@@ -2,6 +2,9 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
+        no_start: ""
+        skip_registration: ""
         tags: wsl
         user: JohnDoe
 ubuntu_pro:

--- a/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
+++ b/windows-agent/internal/proservices/testdata/TestNew/golden/when_the_subscription_stays_empty
@@ -2,6 +2,9 @@
 # This file was generated automatically and must not be edited
 landscape:
     client:
+        computer_title: wsl
+        no_start: ""
+        skip_registration: ""
         tags: wsl
         user: JohnDoe
 ubuntu_pro:


### PR DESCRIPTION
And prevent schema warnings.

Following the prescription of the spec WS040, I'm adding the three fields to the serialized Landscape client config into `agent.yaml` so that when cloud-init invokes `landscape-config`, instead of attempting a new registration right away, it will just write the client configuration file, possibly incomplete at this point in time.

`wsl-pro-service` is already prepared to complete that configuration file and issue the registration request.

---
UDENG-5888