### PR TITLE
ci: Ignore CLA for Weblate PRs

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   cla-check:
     name: Check if CLA is signed
+    if: contains(fromJson('["weblate"]'), github.event.pull_request.user.login) == false
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed


### PR DESCRIPTION
Skips running the CLA check if the PR is opened by Weblate, since we can't guarantee verification.

Same as https://github.com/ubuntu/app-center/blob/main/.github/workflows/pr.yaml#L7C5-L7C89

Example of a failing Weblate PR for reference: https://github.com/canonical/ubuntu-pro-for-wsl/pull/1079

---

UDENG-266