### PR TITLE
fix(windows-agent): Wait 5s after installing a distro per Landscape request

### DIFF
--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -231,6 +231,11 @@ func (e executor) install(ctx context.Context, cmd *landscapeapi.Command_Install
 		}
 	}
 
+	sleep := distro.Command(ctx, "sleep 5")
+	if err := sleep.Run(); err != nil {
+		return fmt.Errorf("could not wait for distro to start: %v", err)
+	}
+
 	if cmd.GetCloudinit() != "" {
 		return nil
 	}

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -791,7 +791,7 @@ func testReceiveCommand(t *testing.T, distrosettings distroSettings, homedir str
 	require.NoError(t, err, "Setup: Connect should return no errors")
 
 	tb.clientService = clientService
-	context.AfterFunc(ctx, func() { tb.clientService.Stop(ctx) })
+	t.Cleanup(func() { tb.clientService.Stop(ctx) })
 
 	require.Eventually(t, func() bool {
 		return clientService.Connected() && tb.conf.landscapeAgentUID != "" && service.IsConnected(tb.conf.landscapeAgentUID)

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -158,6 +158,7 @@ func TestInstall(t *testing.T) {
 		distroAlreadyInstalled bool
 		distroName             string
 		wslInstallErr          bool
+		wslLaunchErr           bool
 		appxDoesNotExist       bool
 		nonResponsiveServer    bool
 		breakVhdxDir           bool
@@ -183,6 +184,7 @@ func TestInstall(t *testing.T) {
 		"Error when the distro fails to install":     {wslInstallErr: true},
 		"Error when cannot write cloud-init file":    {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
 
+		"Error when launching the new distro fails":                       {wslLaunchErr: true, sendRootfsURL: "goodfile", wantInstalled: false},
 		"Error when the distro ID is reserved (Ubuntu)":                   {sendRootfsURL: "goodfile", distroName: "Ubuntu", wantInstalled: false},
 		"Error when the distro ID is reserved (Preview)":                  {sendRootfsURL: "goodfile", distroName: "Ubuntu-Preview", wantInstalled: false},
 		"Error when the distro ID is reserved (case sensitiveness)":       {sendRootfsURL: "goodfile", distroName: "ubuntu-preview", wantInstalled: false},
@@ -267,6 +269,11 @@ func TestInstall(t *testing.T) {
 
 					if tc.wslInstallErr {
 						testBed.wslMock.InstallError = true
+					}
+
+					if tc.wslLaunchErr {
+						testBed.wslMock.WslLaunchInteractiveError = true
+						testBed.wslMock.WslLaunchError = true
 					}
 
 					if tc.cloudInitExecFailure {


### PR DESCRIPTION
WS040 explains the other alternatives. We chose the simplest. We assume that cloud-init won't register the instance with Landscape. Instead, wsl-pro-service will do it at some point after cloud-init finishes. Thus just waiting on cloud-init is not enough.

Adding this wait revealed a bug in how we test receiving commands from a mocked Landscape server. The fix is much shorter than the explanation.

[Here CI shows the bug](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/13053345773/job/36418338768#step:7:1025). We panic because the Landscape component inside the agent is still running and trying to assemble a host info message to send to the server, but the context used by the internal distros database was already cancelled, so the database caused the panic. That happens because the Landscape service component should have stopped at this point but it didn't. Here's the fix https://github.com/canonical/ubuntu-pro-for-wsl/pull/1092/commits/6aaab005b7ea5ccec0dc05712af6934aa8a222fc : 

```diff
diff --git a/windows-agent/internal/proservices/landscape/executor_test.go b/windows-agent/internal/proservices/landscape/executor_test.go
index af95e5af..83357bcf 100644
--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -791,7 +791,7 @@ func testReceiveCommand(t *testing.T, distrosettings distroSettings, homedir str
        require.NoError(t, err, "Setup: Connect should return no errors")

        tb.clientService = clientService
-       context.AfterFunc(ctx, func() { tb.clientService.Stop(ctx) })
+       t.Cleanup(func() { tb.clientService.Stop(ctx) })

        require.Eventually(t, func() bool {
                return clientService.Connected() && tb.conf.landscapeAgentUID != "" && service.IsConnected(tb.conf.landscapeAgentUID)
```
With `context.AfterFunc(ctx, func() { tb.clientService.Stop(ctx) })` we would pass a cancelled context to the Landscape service `Stop()` method, wihch is implemented as:

```go
// Stop terminates the connection and deallocates resources.
func (s *Service) Stop(ctx context.Context) {
	log.Infof(ctx, "Landscape: stopping")

	s.cancel()
	s.connRetrier.Stop()

	select {
	case <-s.running:
	case <-ctx.Done():
	}
}
```

This function returns immediately without waiting on `<-s.running` because `ctx` is already done.

So instead of using `context.AfterFunc()`  we need to use `t.Cleanup()`, which piles up the functions we pass to it in a LIFO order, so we're sure to call `tb.clientService.Stop(ctx)` before `ctx` gets cancelled.

---
UDENG-5889