### PR TITLE
ci: Do not run end to end tests for translation changes

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - docs/**
       - "*.md"
+      - "gui/packages/ubuntupro/lib/l10n/app_*.arb"
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
End to End tests can't run when translations are submitted via Weblate, so just skip running those workflows when the only files that change are translations

---

UDENG-266