### PR TITLE
fix: Handle potentially long translation strings

### DIFF
--- a/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/delayed_text_field.dart
@@ -63,6 +63,8 @@ class _DelayedTextField extends State<DelayedTextField>
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return ListenableBuilder(
       listenable: debouncer,
       builder: (context, _) {
@@ -84,6 +86,12 @@ class _DelayedTextField extends State<DelayedTextField>
             helper: widget.helper,
             helperText: widget.helperText,
             hintText: widget.hintText,
+            hintMaxLines: 3,
+            errorMaxLines: 3,
+            helperMaxLines: 3,
+            labelStyle: theme.inputDecorationTheme.labelStyle?.copyWith(
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         );
       },

--- a/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
+++ b/gui/packages/ubuntupro/lib/pages/widgets/page_widgets.dart
@@ -95,41 +95,47 @@ class CenteredPage extends StatelessWidget {
           children: [
             Expanded(
               child: Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 540.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      RichText(
-                        text: TextSpan(
-                          children: [
-                            WidgetSpan(
-                              child: SvgPicture.asset(
-                                svgAsset,
-                                height: 70,
+                child: SingleChildScrollView(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 540.0),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        RichText(
+                          text: TextSpan(
+                            children: [
+                              WidgetSpan(
+                                child: SvgPicture.asset(
+                                  svgAsset,
+                                  height: 70,
+                                ),
                               ),
-                            ),
-                            const WidgetSpan(
-                              child: SizedBox(
-                                width: 8,
+                              const WidgetSpan(
+                                child: SizedBox(
+                                  width: 8,
+                                ),
                               ),
-                            ),
-                            TextSpan(
-                              text: title,
-                              style: theme.textTheme.displaySmall
-                                  ?.copyWith(fontWeight: FontWeight.w100),
-                            ),
-                          ],
+                              TextSpan(
+                                text: title,
+                                style: theme.textTheme.displaySmall
+                                    ?.copyWith(fontWeight: FontWeight.w100),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 16),
-                      ...children,
-                    ],
+                        const SizedBox(height: 16),
+                        ...children,
+                      ],
+                    ),
                   ),
                 ),
               ),
             ),
-            if (footer != null) footer!,
+            if (footer != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 16.0),
+                child: footer!,
+              ),
           ],
         ),
       ),
@@ -181,47 +187,53 @@ class ColumnPage extends StatelessWidget {
                     children: [
                       // Left column
                       Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            RichText(
-                              text: TextSpan(
-                                children: [
-                                  WidgetSpan(
-                                    child: SvgPicture.asset(
-                                      svgAsset,
-                                      height: 70,
+                        child: SingleChildScrollView(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              RichText(
+                                text: TextSpan(
+                                  children: [
+                                    WidgetSpan(
+                                      child: SvgPicture.asset(
+                                        svgAsset,
+                                        height: 70,
+                                      ),
                                     ),
-                                  ),
-                                  const WidgetSpan(
-                                    child: SizedBox(
-                                      width: 8,
+                                    const WidgetSpan(
+                                      child: SizedBox(
+                                        width: 8,
+                                      ),
                                     ),
-                                  ),
-                                  TextSpan(
-                                    text: title,
-                                    style: theme.textTheme.displaySmall
-                                        ?.copyWith(fontWeight: FontWeight.w100),
-                                  ),
-                                ],
+                                    TextSpan(
+                                      text: title,
+                                      style: theme.textTheme.displaySmall
+                                          ?.copyWith(
+                                        fontWeight: FontWeight.w100,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
-                            ),
-                            const SizedBox(height: 24),
-                            ...left,
-                          ],
+                              const SizedBox(height: 24),
+                              ...left,
+                            ],
+                          ),
                         ),
                       ),
                       // Spacer
                       const SizedBox(width: 32),
                       // Right column
                       Expanded(
-                        child: Column(
-                          mainAxisAlignment: rightIsCentered
-                              ? MainAxisAlignment.center
-                              : MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: right,
+                        child: SingleChildScrollView(
+                          child: Column(
+                            mainAxisAlignment: rightIsCentered
+                                ? MainAxisAlignment.center
+                                : MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: right,
+                          ),
                         ),
                       ),
                     ],


### PR DESCRIPTION
Some strings for other languages could overflow the GUI, so this accounts for vertical increases in the layout of each page by wrapping the content in a scrollable container. The CenteredPage widget used for the status page should never realistically overflow, but its scrollable just in case :) (and it will be expanded in the future).

Also allows more than 1 line for error/hint messages, and truncates long label texts.

<details>
<summary>Label truncation and multiline error example (PL translations)</summary>

![image](https://github.com/user-attachments/assets/2c9db3dd-e973-42a6-b509-0933e54fbb9c)
</details>

---

UDENG-5996