### PR TITLE
feat(windows-agent): Landscape executor to install modern distros

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/snapcore/go-gettext v0.0.0-20230721153050-9082cdc2db05
 	github.com/stretchr/testify v1.10.0
-	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb
-	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
+	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
+	github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b
 	google.golang.org/grpc v1.70.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
 	google.golang.org/protobuf v1.36.5

--- a/common/go.sum
+++ b/common/go.sum
@@ -37,10 +37,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b h1:LnvVFBFZ8F9NCqr+oS+LMHBIWZyOcLoL4JidRnGuh8A=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel/metric v1.32.0 h1:xV2umtmNcThh2/a/aCP+h64Xx5wsj8qqnkYZktzNa0M=

--- a/end-to-end/go.mod
+++ b/end-to-end/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f
 	github.com/canonical/ubuntu-pro-for-wsl/mocks v0.0.0-20240909072650-75a32126b04f
 	github.com/stretchr/testify v1.10.0
-	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
+	github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/sys v0.30.0
 	google.golang.org/grpc v1.70.0
@@ -24,7 +24,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb // indirect
+	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a // indirect

--- a/end-to-end/go.sum
+++ b/end-to-end/go.sum
@@ -45,10 +45,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b h1:LnvVFBFZ8F9NCqr+oS+LMHBIWZyOcLoL4JidRnGuh8A=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel/metric v1.32.0 h1:xV2umtmNcThh2/a/aCP+h64Xx5wsj8qqnkYZktzNa0M=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -183,8 +183,8 @@ require (
 	github.com/timonwong/loggercheck v0.10.1 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.10.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
-	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb // indirect
-	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 // indirect
+	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 // indirect
+	github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b // indirect
 	github.com/ultraware/funlen v0.2.0 // indirect
 	github.com/ultraware/whitespace v0.2.0 // indirect
 	github.com/uudashr/gocognit v1.2.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -588,10 +588,10 @@ github.com/tomarrell/wrapcheck/v2 v2.10.0 h1:SzRCryzy4IrAH7bVGG4cK40tNUhmVmMDuJu
 github.com/tomarrell/wrapcheck/v2 v2.10.0/go.mod h1:g9vNIyhb5/9TQgumxQyOEqDHsmGYcGsVMOx/xGkqdMo=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+yU8u1Zw=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b h1:LnvVFBFZ8F9NCqr+oS+LMHBIWZyOcLoL4JidRnGuh8A=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=
 github.com/ultraware/funlen v0.2.0/go.mod h1:ZE0q4TsJ8T1SQcjmkhN/w+MceuatI6pBFSxxyteHIJA=
 github.com/ultraware/whitespace v0.2.0 h1:TYowo2m9Nfj1baEQBjuHzvMRbp19i+RCcRYrSWoFa+g=

--- a/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
+++ b/windows-agent/cmd/ubuntu-pro-agent/agent/export_test.go
@@ -40,10 +40,11 @@ func NewForTesting(t *testing.T, publicDir, privateDir string) *App {
 	return New(WithPrivateDir(privateDir), WithPublicDir(publicDir), WithRegistry(registry.NewMock()))
 }
 
+// DaemonConfig exports the internal daemonConfig struct for test purposes.
+type DaemonConfig = daemonConfig
+
 // Config returns the DaemonConfig for test purposes.
-//
-//nolint:revive
-func (a App) Config() daemonConfig {
+func (a App) Config() DaemonConfig {
 	return a.config
 }
 

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb
-	github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452
+	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
+	github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/sys v0.30.0
 	google.golang.org/grpc v1.70.0

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -77,10 +77,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb h1:8aYaLeK5kwneVflZ50XOnsE2zWnS3HCF58WV8JXge5U=
-github.com/ubuntu/decorate v0.0.0-20240425133904-a085253511fb/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452 h1:Fr0hzjkQNxXR1/9qqOcqFEa9OYnux1+MuaAgf44QxYc=
-github.com/ubuntu/gowsl v0.0.0-20241205225428-1dae59a1a452/go.mod h1:+iFGK9K9rSCgPevBqlGVIudoaVuTd0Djg6w9ZinDPrE=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
+github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b h1:LnvVFBFZ8F9NCqr+oS+LMHBIWZyOcLoL4JidRnGuh8A=
+github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel/metric v1.32.0 h1:xV2umtmNcThh2/a/aCP+h64Xx5wsj8qqnkYZktzNa0M=

--- a/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
+++ b/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
@@ -12,6 +12,10 @@ import (
 
 // executableInstallCommand mocks running the command '$executable install --root --ui=none'.
 func executableInstallCommand(ctx context.Context, executable string) ([]byte, error) {
+	if executable == "ubuntu0404.exe" {
+		return []byte("mocking executable not found\n  + FullyQualifiedErrorId : CommandNotFoundException"), fmt.Errorf("exit status 1")
+	}
+
 	if executable != "ubuntu2204.exe" {
 		return []byte("mock supports only ubuntu2204.exe"), fmt.Errorf("exit status 1")
 	}

--- a/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
+++ b/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
@@ -42,8 +42,7 @@ func addUserCommand(ctx context.Context, distro wsl.Distro, userName, userFullNa
 		return []byte("adduser: The user already exists."), errors.New("exit status 1")
 	}
 
-	markUserAsCreated(distro)
-	return []byte{}, nil
+	return []byte{}, markUserAsCreated(distro)
 }
 
 func addUserToGroupsCommand(ctx context.Context, distro wsl.Distro, userName string) ([]byte, error) {
@@ -89,11 +88,8 @@ func getUserIDCommand(ctx context.Context, distro wsl.Distro, userName string) (
 // markUserAsCreated is an ugly trick to store some persistent information.
 // It highjacks the DriveMountingEnabled Configuration to signal
 // userWasCreated whether it should return true or false.
-func markUserAsCreated(d wsl.Distro) {
-	err := d.DriveMountingEnabled(false)
-	if err != nil {
-		panic(err.Error())
-	}
+func markUserAsCreated(d wsl.Distro) error {
+	return d.DriveMountingEnabled(false)
 }
 
 // userWasCreated indicates wether the markUserAsCreated function was called.

--- a/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
+++ b/windows-agent/internal/proservices/landscape/distroinstall/distroinstall_gowslmock.go
@@ -11,21 +11,26 @@ import (
 )
 
 // executableInstallCommand mocks running the command '$executable install --root --ui=none'.
+// It intentionally fails for ubuntu0404.exe and ubuntu2404.exe, but it registers the latest, emulating the behaviour of a "modern" distro.
 func executableInstallCommand(ctx context.Context, executable string) ([]byte, error) {
-	if executable == "ubuntu0404.exe" {
-		return []byte("mocking executable not found\n  + FullyQualifiedErrorId : CommandNotFoundException"), fmt.Errorf("exit status 1")
+	switch executable {
+	case "ubuntu0404.exe":
+		return []byte("404: mock executable not found\n  + FullyQualifiedErrorId : CommandNotFoundException"), fmt.Errorf("exit status 1")
+	case "ubuntu2204.exe":
+		d := wsl.NewDistro(ctx, "Ubuntu-22.04")
+		if err := d.Register("."); err != nil {
+			return []byte(err.Error()), fmt.Errorf("exit status 1")
+		}
+		return []byte{}, nil
+	case "ubuntu2404.exe":
+		d := wsl.NewDistro(ctx, "Ubuntu-24.04")
+		if err := d.Register("."); err != nil {
+			return []byte(err.Error()), fmt.Errorf("exit status 1")
+		}
+		return []byte("mock executable not found: this is a tar-based distro\n  + FullyQualifiedErrorId : CommandNotFoundException"), fmt.Errorf("exit status 1")
+	default:
+		return []byte("mock supports only ubuntu2204.exe and ubuntu2404.exe"), fmt.Errorf("exit status 1")
 	}
-
-	if executable != "ubuntu2204.exe" {
-		return []byte("mock supports only ubuntu2204.exe"), fmt.Errorf("exit status 1")
-	}
-
-	d := wsl.NewDistro(ctx, "Ubuntu-22.04")
-	if err := d.Register("."); err != nil {
-		return []byte(err.Error()), fmt.Errorf("exit status 1")
-	}
-
-	return []byte{}, nil
 }
 
 func addUserCommand(ctx context.Context, distro wsl.Distro, userName, userFullName string) (out []byte, err error) {

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -343,7 +343,6 @@ func installFromURL(ctx context.Context, homeDir string, downloadDir string, dis
 	if err := touchdistro.WaitForCloudInit(ctx, distro.Name()); err != nil {
 		log.Infof(ctx, "cloud-init failed: %v", err)
 	}
-	_ = distro.Terminate()
 	log.Debugf(ctx, "Distro %s installed successfully", distro.Name())
 	return nil
 }

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -17,6 +17,7 @@ import (
 
 	landscapeapi "github.com/canonical/landscape-hostagent-api"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	d "github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro/touchdistro"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/landscape/distroinstall"
 	"github.com/ubuntu/decorate"
@@ -229,6 +230,10 @@ func (e executor) install(ctx context.Context, cmd *landscapeapi.Command_Install
 		if err = installFromWSLOnlineDistros(ctx, distro); err != nil {
 			return err
 		}
+	}
+
+	if _, err = e.database().GetDistroAndUpdateProperties(ctx, distro.Name(), d.Properties{}); err != nil {
+		return fmt.Errorf("could not initialize the distro properties in the database: %v", err)
 	}
 
 	sleep := distro.Command(ctx, "sleep 5")

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -158,6 +158,7 @@ func TestInstall(t *testing.T) {
 		distroAlreadyInstalled bool
 		distroName             string
 		wslInstallErr          bool
+		wslRegisterErr         bool
 		wslLaunchErr           bool
 		appxDoesNotExist       bool
 		nonResponsiveServer    bool
@@ -187,6 +188,7 @@ func TestInstall(t *testing.T) {
 		"Error when the distro is already installed":  {distroAlreadyInstalled: true, wantInstalled: true},
 		"Error when the distro fails to install":      {wslInstallErr: true},
 		"Error when cannot write cloud-init file":     {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
+		"Error when registration fails":               {isTarBased: true, wslRegisterErr: true, wantInstalled: false},
 		"Error when default user cannot be retrieved": {isTarBased: true, getDefaultUserErr: true, wantInstalled: false},
 		"Error when default user cannot be set":       {isTarBased: true, setDefaultUserErr: true, wantInstalled: false},
 
@@ -278,6 +280,10 @@ func TestInstall(t *testing.T) {
 
 					if tc.wslInstallErr {
 						testBed.wslMock.InstallError = true
+					}
+
+					if tc.wslRegisterErr {
+						testBed.wslMock.WslRegisterDistributionError = true
 					}
 
 					if tc.wslLaunchErr {

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -165,6 +165,7 @@ func TestInstall(t *testing.T) {
 		breakTarFile           bool
 		breakTempDir           bool
 		cloudInitExecFailure   bool
+		isTarBased             bool
 
 		sendRootfsURL    string
 		missingChecksums bool
@@ -173,6 +174,7 @@ func TestInstall(t *testing.T) {
 		wantInstalled            bool
 	}{
 		"From the store":                    {wantInstalled: true, wantCloudInitWriteCalled: true},
+		"From a tar-based distro":           {isTarBased: true, wantInstalled: true, wantCloudInitWriteCalled: true},
 		"From a rootfs URL with a checksum": {sendRootfsURL: "goodfile", wantInstalled: true},
 		"With no cloud-init":                {noCloudInit: true, wantCloudInitWriteCalled: true, wantInstalled: true},
 		"With no checksum file":             {missingChecksums: true, sendRootfsURL: "goodfile", wantInstalled: true},
@@ -210,7 +212,6 @@ func TestInstall(t *testing.T) {
 			}
 
 			if tc.appxDoesNotExist || tc.sendRootfsURL != "" {
-				// WSLMock Install only accepts ubuntu-22.04
 				switch tc.distroName {
 				case "-":
 					settings.name = ""
@@ -219,6 +220,10 @@ func TestInstall(t *testing.T) {
 				default:
 					settings.name = tc.distroName
 				}
+			}
+
+			if tc.isTarBased {
+				settings.name = "Ubuntu-24.04"
 			}
 
 			if tc.distroAlreadyInstalled {

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -166,6 +166,8 @@ func TestInstall(t *testing.T) {
 		breakTempDir           bool
 		cloudInitExecFailure   bool
 		isTarBased             bool
+		setDefaultUserErr      bool
+		getDefaultUserErr      bool
 
 		sendRootfsURL    string
 		missingChecksums bool
@@ -180,11 +182,13 @@ func TestInstall(t *testing.T) {
 		"With no checksum file":             {missingChecksums: true, sendRootfsURL: "goodfile", wantInstalled: true},
 		"With cloud-init failure":           {sendRootfsURL: "goodfile", cloudInitExecFailure: true, wantInstalled: true},
 
-		"Error when the distroname is empty":         {distroName: "-"},
-		"Error when the Appx does not exist":         {appxDoesNotExist: true},
-		"Error when the distro is already installed": {distroAlreadyInstalled: true, wantInstalled: true},
-		"Error when the distro fails to install":     {wslInstallErr: true},
-		"Error when cannot write cloud-init file":    {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
+		"Error when the distroname is empty":          {distroName: "-"},
+		"Error when the Appx does not exist":          {appxDoesNotExist: true},
+		"Error when the distro is already installed":  {distroAlreadyInstalled: true, wantInstalled: true},
+		"Error when the distro fails to install":      {wslInstallErr: true},
+		"Error when cannot write cloud-init file":     {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
+		"Error when default user cannot be retrieved": {isTarBased: true, getDefaultUserErr: true, wantInstalled: false},
+		"Error when default user cannot be set":       {isTarBased: true, setDefaultUserErr: true, wantInstalled: false},
 
 		"Error when launching the new distro fails":                       {wslLaunchErr: true, sendRootfsURL: "goodfile", wantInstalled: false},
 		"Error when the distro ID is reserved (Ubuntu)":                   {sendRootfsURL: "goodfile", distroName: "Ubuntu", wantInstalled: false},
@@ -283,6 +287,14 @@ func TestInstall(t *testing.T) {
 
 					if tc.cloudInitExecFailure {
 						testBed.wslMock.WslLaunchInteractiveError = true
+					}
+
+					if tc.getDefaultUserErr {
+						testBed.wslMock.WslGetDistributionConfigurationError = true
+					}
+
+					if tc.setDefaultUserErr {
+						testBed.wslMock.WslConfigureDistributionError = true
 					}
 
 					var cloudInit string


### PR DESCRIPTION
I think this is better reviewed commit by commit, as there are some "peasant fixes" along the way which do not exactly strictly meet the core of this PR, but they were small enough to not deserve a new PR (I think :) ).

This "feature" addresses one specific problem made more evident now that the latest stable version of WSL handles "modern distros" (those whose distribution model no longer relies on MS Store nor Windows application packages). The problem is: when Landscape sends a message to install an instance, we execute `wsl --install` if that's a stock Ubuntu release. That used to install an APPX, so we'd later run the distro launcher to provision the new instance. But now, `wsl --install Ubuntu` or `wsl --install Ubuntu-24.04` would install the modern, tar-based, distro, which no longer has a launcher to subprocess. So we replace the launcher invocation with just subprocessing `cloud-init status --wait` to wait for the complete provisioning and later check if the default user was created or not, creating one behind the scenes (preserving the current behaviour).

To make the error condition of launcher not found distinguishable I create a specific error type. PowerShell always exits 1 for any error, so that's not enough to determine which error was. Instead we need to look into it's output. There is a bunch of small test-related shenanigans I had to do to exercise some error paths along the way.

---

UDENG-5929