### PR TITLE
docs: Update distro ref

### DIFF
--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -1,8 +1,10 @@
 (reference::distros)=
 # Distributions
-Our flagship distribution is Ubuntu. This is the one that is installed by default when you install WSL for the first time. However, we develop several flavours. It may be the case that one or more of these flavours fits your needs better.
 
-Each of these flavours corresponds to a different application on the Microsoft Store, and once installed, they'll create different distros in your WSL. These are the applications we develop and maintain:
+Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. Several releases of the Ubuntu distro are available for WSL.
+
+Each release of Ubuntu for WSL is available as an application from the Microsoft Store. Once a release is [installed](https://documentation.ubuntu.com/wsl/en/latest/howto/install-ubuntu-wsl2/#method-1-microsoft-store-application), it will be available to use in your WSL environment.
+
 - [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS release of Ubuntu. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available.
 - [Ubuntu 18.04 LTS](https://apps.microsoft.com/detail/9PNKSF5ZN4SW?hl=en-us&gl=US), [Ubuntu 20.04 LTS](https://apps.microsoft.com/detail/9MTTCL66CPXJ?hl=en-us&gl=US), and [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) are the LTS versions of Ubuntu and receive updates for five years. Upgrades to future LTS releases will not be proposed.
 - [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu previewing new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -22,14 +22,16 @@ Interim releases of Ubuntu are currently not supported on WSL.
 (naming)=
 ## Naming
 
-Due to different limitations in different contexts, these applications will have different names in different contexts. Here is a table matching them.
+Depending on context, releases of Ubuntu are referred to by different names: 
 
-1. App name is the name you'll see in the Microsoft Store and Winget.
-2. AppxPackage is the name you'll see in `Get-AppxPackage`.
-3. Distro name is the name you'll see when doing `wsl -l -v` or `wsl -l --online`.
-4. Executable is the program you need to run to start the distro.
+1. **App name** is the name of the application for a specific Ubuntu release that you will see in the Microsoft Store.
+2. **AppxPackage name** is the name that can be passed to `Get-AppxPackage -Name` in PowerShell to get information about an installed package.
+3. **Distro name** is the name logged when you invoke `wsl -l -v` to list installed releases of Ubuntu.
+4. **Executable name** is the program you need to run to start the Ubuntu distro.
 
-| App name             | AppxPackage name                       | Distro name      | Executable          |
+These naming conventions are summarised in the table below:
+
+| App name             | AppxPackage name                       | Distro name      | Executable name     |
 | -------------------- | -------------------------------------- | ---------------- | ------------------- |
 | `Ubuntu`             | `CanonicalGroupLimited.Ubuntu`         | `Ubuntu`         | `ubuntu.exe`        |
 | `Ubuntu (Preview)`   | `CanonicalGroupLimited.UbuntuPreview`  | `Ubuntu-Preview` | `ubuntupreview.exe` |

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -36,3 +36,9 @@ These naming conventions are summarised in the table below:
 | `Ubuntu`             | `CanonicalGroupLimited.Ubuntu`         | `Ubuntu`         | `ubuntu.exe`        |
 | `Ubuntu (Preview)`   | `CanonicalGroupLimited.UbuntuPreview`  | `Ubuntu-Preview` | `ubuntupreview.exe` |
 | `Ubuntu XX.YY.Z LTS` | `CanonicalGroupLimited.UbuntuXX.YYLTS` | `Ubuntu-XX.YY`   | `ubuntuXXYY.exe`    |
+
+```{admonition} The WSL kernel
+:class: important
+The kernel used in WSL environments is maintained by Microsoft.
+Bug reports and support requests for the WSL kernel should be directed to the [official repository for the WSL kernel](https://github.com/microsoft/WSL2-Linux-Kernel).
+```

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -5,9 +5,19 @@ Our flagship distribution (distro) is Ubuntu. It is the default option when you 
 
 Each release of Ubuntu for WSL is available as an application from the Microsoft Store. Once a release is [installed](https://documentation.ubuntu.com/wsl/en/latest/howto/install-ubuntu-wsl2/#method-1-microsoft-store-application), it will be available to use in your WSL environment.
 
-- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS release of Ubuntu. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available.
-- [Ubuntu 18.04 LTS](https://apps.microsoft.com/detail/9PNKSF5ZN4SW?hl=en-us&gl=US), [Ubuntu 20.04 LTS](https://apps.microsoft.com/detail/9MTTCL66CPXJ?hl=en-us&gl=US), and [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) are the LTS versions of Ubuntu and receive updates for five years. Upgrades to future LTS releases will not be proposed.
-- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu previewing new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
+(reference::releases)=
+## Releases of Ubuntu on WSL
+
+These are the releases of Ubuntu that we support and that are available on the Microsoft Store:
+
+- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS (Long Term Support) release of Ubuntu. When new LTS versions are released, this release of Ubuntu can be upgraded once the first point release is available.
+- Numbered releases -- for example, [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) -- refer to specific Long Term Stability (LTS) releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
+- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu, which previews new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
+
+```{admonition} Interim releases
+:class: seealso
+Interim releases of Ubuntu are currently not supported on WSL.
+```
 
 (naming)=
 ## Naming


### PR DESCRIPTION
These changes include clarifications and fixups for the reference page on Ubuntu WSL distributions.

Main changes:

* Improved phrasing and made it more consistent. Example: we should not use "flavour" because it has another, common denotation in the context of Ubuntu.
* Clarified release section. Added a title to distinguish it from the rest of the text. More detail is now provided on upgrading and support for interim releases.
* Edits to Naming section. Fixed some difficult-to-read phrases. Added some examples for the different contexts to make them more tangible.
* Note on kernel support. Added a note that we do not maintain the kernel, with a link to the WSL kernel repo.

Special thanks to @davidekete for his excellent contributions to the reference through [this PR](https://github.com/canonical/open-documentation-academy/pull/167) in the Open Documentation Academy.

UDENG-1934