### PR TITLE
docs: add edit button to docs pages

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -48,6 +48,13 @@ html_title = project + " documentation"
 #   -H 'Accept: application/vnd.github.v3.raw' \
 #   https://api.github.com/repos/canonical/<REPO> | jq '.created_at'
 
+# This adds an edit button to the top of each page
+html_theme_options = {
+    "source_repository": "https://github.com/canonical/ubuntu-pro-for-wsl/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}
+
 copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 
 ## Open Graph configuration - defines what is displayed as a link preview


### PR DESCRIPTION
It's common for docs that are open to user contributions to have an edit icon at the top of the page.
This is more immediate than the edit-this-page text, which is currently buried at the bottom of each page.

![image](https://github.com/user-attachments/assets/280e2298-a8ef-4b38-be34-17521b57dc05)

The change is a simple way to encourage small contributions.

UDENG-6061
