### PR TITLE
docs: additional landing page structure

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -3,7 +3,7 @@
 # Explanation
 
 This section contains explanations that will help you develop a deeper
-understanding of how UP4W is designed.
+understanding of how Ubuntu Pro for WSL is designed.
 
 ```{toctree}
 :titlesonly:

--- a/docs/howto/index-contributing.md
+++ b/docs/howto/index-contributing.md
@@ -2,17 +2,31 @@
 
 # Contributing
 
-These how-to guides help you complete tasks when developing for UP4W.
+These how-to guides help you contribute to Ubuntu on WSL.
+
+## General guidelines for contributors
+
+If you are interested in contributing to code or docs, please read our
+guidelines.
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 General contribution guidelines <contributing>
-Install UP4W <02-install>
-Restart UP4W <03-restart>
-Access UP4W logs <06-access-the-logs>
-Enable opt-in features for UP4W <07-toggle-features>
-Reset UP4W <reset-factory>
 ```
 
+## Guides for developing Ubuntu Pro for WSL
+
+Useful guides when developing and testing Ubuntu Pro for WSL.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Install UP4W for development <02-install>
+Restart UP4W for development <03-restart>
+Access UP4W logs for development <06-access-the-logs>
+Enable features for development <07-toggle-features>
+Reset UP4W <reset-factory>
+```

--- a/docs/howto/index-gpu-and-graphics.md
+++ b/docs/howto/index-gpu-and-graphics.md
@@ -5,11 +5,25 @@
 These how-to guides explain how to use GPU acceleration and graphical apps with
 Ubuntu on WSL.
 
+## GPU acceleration
+
+If you are working on ML or AI, you can enable GPU acceleration for your projects:
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Enabling GPU acceleration with CUDA<gpu-cuda>
+```
+
+## Graphical applications
+
+Ubuntu on WSL is a terminal environment but it can also launch Linux-native
+graphical applications.
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 Use WSL for data science and visualise results graphically<data-science-and-engineering>
-Enabling GPU acceleration with CUDA<gpu-cuda>
 ```
-

--- a/docs/howto/index-remote-deployment.md
+++ b/docs/howto/index-remote-deployment.md
@@ -2,14 +2,29 @@
 
 # Remote deployment
 
-These how-to guides help you deploy and manage WSL instances with UP4W.
+These guides help you deploy and manage WSL instances using Ubuntu Pro for WSL
+with remote management tools.
+
+## Landscape
+
+Manage Ubuntu on WSL with Canonical's Landscape.
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
-Configure the Landscape client with UP4W  <set-up-landscape-client>
+Configure the Landscape client with UP4W <set-up-landscape-client>
 Create WSL instances on multiple Windows machines with the Landscape API <custom-rootfs-multiple-targets>
+```
+
+## Intune
+
+Manage Ubuntu on WSL with Microsoft's Intune.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Enforce the UP4W background agent startup remotely using the Windows Registry <enforce-agent-startup-remotely-registry>
 Start the UP4W background agent remotely <start-agent-remotely>
 ```

--- a/docs/howto/index-setup.md
+++ b/docs/howto/index-setup.md
@@ -2,7 +2,12 @@
 
 # Installation and setup
 
-These how-to guides show you how to set up Ubuntu on WSL.
+These guides show you how to set up WSL with an Ubuntu distribution and the
+Ubuntu Pro for WSL application.
+
+## The Ubuntu distribution
+
+Run a full Ubuntu development environment on Windows.
 
 ```{toctree}
 :titlesonly:
@@ -11,6 +16,16 @@ These how-to guides show you how to set up Ubuntu on WSL.
 Install Ubuntu on WSL <install-ubuntu-wsl2>
 Back up and restore Ubuntu WSL instances <backup-and-restore>
 Automatic setup of Ubuntu on WSL with cloud-init <cloud-init>
+```
+
+## The Ubuntu Pro for WSL application
+
+Secure and manage Ubuntu on WSL with an Ubuntu Pro subscription.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Install UP4W and add a Pro token <set-up-up4w>
 Verify Pro subscription and attachment <verify-subscribe-attach>
 Uninstalling UP4W, Ubuntu WSL apps and WSL <uninstalling>

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -2,10 +2,15 @@
 
 # How-to guides
 
-The guides in this section will help you quickly
-complete specific tasks with UP4W.
+The guides in this section will help you to complete specific tasks with Ubuntu
+on WSL.
 
-Install and set up of UP4W with the aid of these guides:
+They include guides on the Ubuntu distribution and the Ubuntu Pro for WSL
+application.
+
+## Installation and setup
+
+Get set up using Ubuntu on a Windows machine with WSL.
 
 ```{toctree}
 :titlesonly:
@@ -14,8 +19,9 @@ index-setup
 
 ```
 
-When remotely deploying and managing Ubuntu WSL instances, the following guides
-are helpful:
+## Remote deployment
+
+Use the Ubuntu Pro for WSL application to remotely manage Ubuntu on WSL.
 
 ```{toctree}
 :titlesonly:
@@ -24,7 +30,9 @@ index-remote-deployment
 
 ```
 
-The use of GPU acceleration and graphical apps are described in the following guides:
+## GPU and graphics
+
+Leverage GPU and graphical support with Ubuntu on WSL.
 
 ```{toctree}
 :titlesonly:
@@ -33,8 +41,9 @@ index-gpu-and-graphics
 
 ```
 
-If you are interested in contributing to UP4W as a developer, consult the
-guides below:
+## Contributing
+
+Contribute to the development of Ubuntu on WSL.
 
 ```{toctree}
 :titlesonly:
@@ -42,8 +51,10 @@ guides below:
 index-contributing
 
 ```
-If you want to run automated tests for an app that needs to run in Ubuntu on WSL,
-read our guide on running a WSL GitHub workflow on Azure:
+
+## Testing
+
+Automate the testing of applications for Ubuntu on WSL with GitHub workflows.
 
 ```{toctree}
 :titlesonly:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,17 @@ Windows Subsystem for Linux ([WSL](https://ubuntu.com/desktop/wsl)) enables
 developers to run a GNU/Linux environment on Windows. The Ubuntu distribution
 for WSL is tightly integrated with the Windows OS, supporting features
 including remote development with popular IDEs and cross-OS file management.
-Ubuntu on WSL provides a productive terminal environment that can also be used
-to launch Linux-native graphical applications.
+Ubuntu can be used as a terminal interface on Windows and can also
+launch Linux-native graphical applications.
 
-Ubuntu Pro for WSL (UP4W) is a powerful automation tool for managing instances
-of Ubuntu on WSL. If you are responsible for a fleet of Windows devices, UP4W
-will enable you to monitor, customise and secure Ubuntu WSL instances at scale.
+Ubuntu Pro for WSL (UP4W) is an in-development automation tool for managing
+instances of Ubuntu on WSL. If you are responsible for a fleet of Windows
+devices, UP4W will help you to monitor, customise and secure Ubuntu WSL
+instances at scale.
 
+Ubuntu on WSL provides a fully-featured Ubuntu experience on Windows, suitable
+for learning Linux, developing a personal open-source project or building for
+production in an enterprise environment.
 
 ## In this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,27 +11,27 @@ Ubuntu Pro for WSL (UP4W) is a powerful automation tool for managing instances
 of Ubuntu on WSL. If you are responsible for a fleet of Windows devices, UP4W
 will enable you to monitor, customise and secure Ubuntu WSL instances at scale.
 
-To start, read our tutorial on [quickly setting up an Ubuntu development
-environment on WSL](tutorials/develop-with-ubuntu-wsl). If you are interested in
-automatically Pro-attaching instances of Ubuntu on WSL, read the tutorial on
-[installing and configuring UP4W](tutorials/getting-started-with-up4w).
 
 ## In this documentation
 
 ````{grid} 1 1 2 2
 
 ```{grid-item-card} [Tutorials](tutorials/index)
-:link: tutorials/index
 :link-type: doc
 
-**Start here** with hands-on tutorials for new users, guiding you through your first-steps
+**Start here** and learn the basics of:
+
+* [Developing with Ubuntu on WSL](/tutorials/develop-with-ubuntu-wsl.md)
+* [Securing WSL with the Ubuntu Pro app](/tutorials/getting-started-with-up4w.md)
 ```
 
 ```{grid-item-card} [How-to guides](howto/index)
-:link: howto/index
 :link-type: doc
 
-**Follow step-by-step** instructions for key operations and common tasks
+**Follow guides** for common tasks, such as:
+
+* [Installing an Ubuntu distro on WSL](/howto/install-ubuntu-wsl2.md)
+* [Installing Ubuntu Pro for WSL](./howto/set-up-up4w.md)
 ```
 
 ````
@@ -39,18 +39,19 @@ automatically Pro-attaching instances of Ubuntu on WSL, read the tutorial on
 ````{grid} 1 1 2 2
 
 ```{grid-item-card} [Reference](reference/index)
-:link: reference/index
 :link-type: doc
 
-**Read technical descriptions** of important factual information
+**Find technical information**, including:
+
+* [Ubuntu distributions available for WSL](/reference/distributions.md)
 ```
 
 ```{grid-item-card} [Explanation](explanation/index)
-:link: explanation/index
 :link-type: doc
 
-**Read an explanation** of UP4W's system architecture and how it relates to
-Ubuntu on WSL
+**Build an understanding** of:
+
+* [The architecture of Ubuntu Pro for WSL](/explanation/ref-arch-explanation.md)
 ```
 
 ````

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,5 @@
 # Ubuntu on WSL
 
-```{note}
-This documentation includes reference to a future release of Ubuntu Pro for WSL (UP4W).
-UP4W is not yet generally available in the Microsoft Store.
-```
-
 Windows Subsystem for Linux ([WSL](https://ubuntu.com/desktop/wsl)) enables
 developers to run a GNU/Linux environment on Windows. The Ubuntu distribution
 for WSL is tightly integrated with the Windows OS, supporting features

--- a/docs/pro_content_notice.txt
+++ b/docs/pro_content_notice.txt
@@ -2,6 +2,8 @@
 ```{admonition} Pro feature
 :class: seealso
 This page refers to features that require an [Ubuntu Pro
-subscription](https://ubuntu.com/pro/subscribe).
+subscription](https://ubuntu.com/pro/subscribe) and access
+to the Ubuntu Pro for WSL application, which is currently
+under development.
 ```
 <!-- Include end pro -->

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,10 +2,12 @@
 
 # Reference
 
-This section contains concise references relating to how Ubuntu on WSL is designed,
-configured and developed.
+This section contains concise references relating to how Ubuntu on WSL is
+designed, configured and developed.
 
-For information on the Ubuntu distros that are available and supported for WSL, read here: 
+## The Ubuntu distribution on WSL
+
+Information on the Ubuntu distros that are available and supported on WSL.
 
 ```{toctree}
 :titlesonly:
@@ -21,7 +23,9 @@ If you are interested in automated testing of applications in Ubuntu WSL, read:
 GitHub actions for Ubuntu WSL <actions>
 ```
 
-A glossary of key UP4W system components can be found here:
+## Ubuntu Pro for WSL
+
+A glossary of key UP4W system components.
 
 ```{toctree}
 :titlesonly:
@@ -30,7 +34,7 @@ glossary_up4w_components
 ```
 
 Details on firewall configuration, Landscape setup and using the Windows
-registry can be found here:
+registry.
 
 ```{toctree}
 :titlesonly:
@@ -38,8 +42,7 @@ registry can be found here:
 index_system_configuration
 ```
 
-Information for contributors that is helpful for debugging code and ensuring
-code quality is outlined below:
+Information helpful for developers working on Ubuntu Pro for WSL.
 
 ```{toctree}
 :titlesonly:

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,11 +2,13 @@
 
 # Tutorials
 
-These tutorials guide you through setting up Ubuntu on WSL, using the Ubuntu Pro
-for WSL (UP4W) application and deploying Ubuntu WSL instances remotely with UP4W.
+These tutorials guide you through setting up Ubuntu on WSL and using the Ubuntu
+Pro for WSL (UP4W) application.
 
-First, learn how set up Ubuntu on WSL from scratch, integrate it with a
-Windows-based IDE and serve files to localhost:
+## The Ubuntu distribution on WSL
+
+Start by learning to set up a development environment with Ubuntu on WSL by
+building and testing a small web project.
 
 ```{toctree}
 :titlesonly:
@@ -14,8 +16,10 @@ Windows-based IDE and serve files to localhost:
 Develop with Ubuntu on WSL <develop-with-ubuntu-wsl>
 ```
 
-Then learn how to install UP4W and automatically Pro-attach your Ubuntu WSL
-instances:
+## Ubuntu Pro for WSL
+
+Then learn to automatically Pro-attach your Ubuntu WSL instances with the
+Ubuntu Pro for WSL application.
 
 ```{toctree}
 :titlesonly:
@@ -23,8 +27,8 @@ instances:
 Get started with Ubuntu Pro for WSL <getting-started-with-up4w>
 ```
 
-Next, learn how UP4W's Landscape integration can be used to deploy Ubuntu WSL
-instances remotely:
+If you are interested in remote management of WSL instances, you can also learn
+how UP4W's Landscape integration can be used to deploy Ubuntu WSL instances.
 
 ```{toctree}
 :titlesonly:


### PR DESCRIPTION
Includes changes to landing pages:

* improves structure of first-level landing pages (e.g., `how-to guides`), primarily with titles
* adds structure to second-level landing pages (e.g., `how-to guides > remote deployment`), primarily with titles
* not possible to remove top-level bullet point that links to landing pages themselves, but the linked page is made more useful with the additional structure
* in the process, tries to better surface specific content, like Landscape versus Intune for deployment.

Also includes changes to the homepage:

* Removes the UP4W/Pro notice: not good to have as first piece of information in the docs. That the app is in-development is mentioned in the text and in the (updated) Pro notice included on UP4W-specific pages
* Adds direct links to pages: links to specific content are included in the diataxis grid to guide users to specific content
* General improvements: clarity, flow, length

UDENG-5305