### PR TITLE
docs: Better headers and metas

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -128,8 +128,6 @@ slug = ""
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
 
-# NOTE: content from these tutorials will be reworked for inclusion in other tutorials
-# for now we can link to the versions available on the original GitHub repo
 redirects = {
     # deprecated tutorials that will be reworked into new content
     "tutorials/dotnet-systemd": "https://github.com/ubuntu/WSL/blob/main/docs/tutorials/dotnet-systemd.md",
@@ -139,18 +137,26 @@ redirects = {
     "tutorials/data-science-and-engineering": "../../howto/data-science-and-engineering",
     "tutorials/gpu-cuda": "../../howto/gpu-cuda",
     "tutorials/vscode": "../../tutorials/develop-with-ubuntu-wsl",
-    # the term "guides" was used in the original repo
+    # change in diataxis names
+    "guides/": "../../howto/",
     "guides/contributing": "../../howto/contributing",
     "guides/install-ubuntu-wsl2": "../../howto/install-ubuntu-wsl2",
     "guides/run-workflows-azure": "../../howto/run-workflows-azure",
-    # improved url
+    "explanations/": "../../explanation/",
+    "explanations/ref-arch-explanation": "../../explanation/ref-arch-explanation",
+    # improved url to account for merging of distro and UP4W app docs
     "tutorials/getting-started": "../../tutorials/getting-started-with-up4w",
     # account for old use of "tutorial/"
     "tutorial/": "../../tutorials/",
     "tutorial/getting-started": "../../tutorials/getting-started-with-up4w",
     "tutorial/deployment": "../../tutorials/deployment",
-    # redundant after merge
-    "explanations/up4w": "../../",
+    # ... even for URLs that never existed
+    "tutorial/getting-started-with-up4w": "../../tutorials/getting-started-with-up4w",
+    "tutorial/develop-with-ubuntu-wsl": "../../tutorials/develop-with-ubuntu-wsl",
+    # old UP4W explainer is redundant so redirect to arch explanation
+    "explanations/up4w": "../../explanation/ref-arch-explanation",
+    # deprecated feature so point users to relevant doc
+    "guides/autoinstall": "../../howto/cloud-init",
 }
 
 ############################################################

--- a/docs/dev_docs_notice.txt
+++ b/docs/dev_docs_notice.txt
@@ -1,0 +1,8 @@
+<!-- Include start dev -->
+```{admonition} Developer documentation
+:class: important
+This page contains information of relevance to the
+development, testing and debugging of the Ubuntu Pro
+for WSL application and is not intended for general use.
+```
+<!-- Include end dev -->

--- a/docs/explanation/ref-arch-explanation.md
+++ b/docs/explanation/ref-arch-explanation.md
@@ -1,4 +1,11 @@
-# UP4W architecture
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "The different components of Ubuntu Pro for WSL work together to support automatic securing of WSL instances and integration with remote management tools."
+---
+
+# Architecture of Ubuntu Pro for WSL
 
 This page describes the different components of UP4W and how they integrate
 together to form the software architecture.

--- a/docs/howto/02-install.md
+++ b/docs/howto/02-install.md
@@ -1,4 +1,12 @@
-# How to install UP4W
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "For developers who are testing, debugging or developing the application."
+---
+
+# Install individual components of Ubuntu Pro for WSL for development
+
 
 This guide will show you how to install UP4W for local development and testing.
 

--- a/docs/howto/02-install.md
+++ b/docs/howto/02-install.md
@@ -7,6 +7,10 @@ myst:
 
 # Install individual components of Ubuntu Pro for WSL for development
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
 
 This guide will show you how to install UP4W for local development and testing.
 

--- a/docs/howto/02-install.md
+++ b/docs/howto/02-install.md
@@ -20,7 +20,7 @@ This guide will show you how to install UP4W for local development and testing.
   - Either Ubuntu, Ubuntu 22.04, or Ubuntu (Preview)
 - The Windows Subsystem for Windows optional feature enabled
 
-## 1. Download the Windows Agent and the  WSL Pro Service
+## 1. Download the Windows Agent and the WSL Pro Service
 <!-- TODO: Update when we change were artifacts are hosted -->
 1. Go to the [repository actions page](https://github.com/canonical/ubuntu-pro-for-wsl/actions/workflows/qa-azure.yaml?query=branch%3Amain+).
 2. Click the latest successful workflow run.

--- a/docs/howto/03-restart.md
+++ b/docs/howto/03-restart.md
@@ -7,6 +7,10 @@ myst:
 
 # Restart Ubuntu Pro for WSL during development
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
 
 Some configuration changes only apply when you restart UP4W. Here is a guide on how to restart it. There are two options.
 

--- a/docs/howto/03-restart.md
+++ b/docs/howto/03-restart.md
@@ -1,4 +1,12 @@
-# How to restart UP4W
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "For developers who are testing, debugging or developing the application."
+---
+
+# Restart Ubuntu Pro for WSL during development
+
 
 Some configuration changes only apply when you restart UP4W. Here is a guide on how to restart it. There are two options.
 

--- a/docs/howto/06-access-the-logs.md
+++ b/docs/howto/06-access-the-logs.md
@@ -7,6 +7,10 @@ myst:
 
 # Access Ubuntu Pro for WSL logs for debugging
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
 
 At some point you may want to read the UP4W logs, most likely for debugging purposes. The agent and the service store their logs separately. This guide shows you where to find each of the logs.
 

--- a/docs/howto/06-access-the-logs.md
+++ b/docs/howto/06-access-the-logs.md
@@ -1,4 +1,12 @@
-# How to access UP4W logs
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "For developers who are testing, debugging or developing the application."
+---
+
+# Access Ubuntu Pro for WSL logs for debugging
+
 
 At some point you may want to read the UP4W logs, most likely for debugging purposes. The agent and the service store their logs separately. This guide shows you where to find each of the logs.
 

--- a/docs/howto/07-toggle-features.md
+++ b/docs/howto/07-toggle-features.md
@@ -7,6 +7,10 @@ myst:
 
 # Enable opt-in features of Ubuntu Pro for WSL during development
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
 
 Some features in UP4W are opt-in or can be toggled on and off via the Windows Registry.
 While the code is arranged such that CI always tests with those features enabled,

--- a/docs/howto/07-toggle-features.md
+++ b/docs/howto/07-toggle-features.md
@@ -1,4 +1,12 @@
-# How to enable opt-in features
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "For developers who are testing, debugging or developing the application."
+---
+
+# Enable opt-in features of Ubuntu Pro for WSL during development
+
 
 Some features in UP4W are opt-in or can be toggled on and off via the Windows Registry.
 While the code is arranged such that CI always tests with those features enabled,

--- a/docs/howto/07-toggle-features.md
+++ b/docs/howto/07-toggle-features.md
@@ -23,7 +23,7 @@ The next time you open the GUI you'll find the button to subscribe to Ubuntu
 Pro via the Microsoft Store.
 
 ```{warning}
-Beware that can incur in real charges if you proceed with the purchase.
+This can incur real charges if you proceed with the purchase.
 ```
 
 ## Disable Landscape configuration in the GUI

--- a/docs/howto/backup-and-restore.md
+++ b/docs/howto/backup-and-restore.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Create backups of Ubuntu WSL instances that can be restored later or duplicated into unique instances."
+---
+
 # Back up, restore and duplicate Ubuntu WSL instances
 
 ## Motivation

--- a/docs/howto/cloud-init.md
+++ b/docs/howto/cloud-init.md
@@ -1,4 +1,11 @@
-# Automatic setup with cloud-init
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Preconfigure Ubuntu on WSL using cloud-init to automate the creation of custom instances."
+---
+
+# Automatic setup of Ubuntu on WSL with cloud-init
 
 Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
 Ubuntu WSL users can now leverage it to perform an automatic setup to get a working instance with minimal touch.

--- a/docs/howto/contributing.md
+++ b/docs/howto/contributing.md
@@ -1,4 +1,11 @@
-# General contribution guidelines
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "General guidelines for contributing to the development of Ubuntu on WSL."
+---
+
+# Contributing to Ubuntu on WSL
 
 % Include content from [../CONTRIBUTING.md](../CONTRIBUTING.md)
 ```{include} ../../CONTRIBUTING.md

--- a/docs/howto/custom-rootfs-multiple-targets.md
+++ b/docs/howto/custom-rootfs-multiple-targets.md
@@ -1,4 +1,11 @@
-# How-to deploy a custom rootfs across multiple Windows machines with the Landscape API
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Scale up your deployment of a custom rootfs using Ubuntu Pro for WSL's Landscape integration."
+---
+
+# Deploy a custom rootfs to multiple Windows machines with Ubuntu Pro for WSL and the Landscape API
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/howto/data-science-and-engineering.md
+++ b/docs/howto/data-science-and-engineering.md
@@ -1,4 +1,11 @@
-# Use WSL for data science and engineering
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Do data science on Ubuntu on WSL with a graphical application and visualise the results."
+---
+
+# Use Ubuntu on WSL for data science and engineering
 
 WSL is an ideal platform to run your Linux workflows while using your Windows machines. Here we show an example of how to set up GNU octave and run a toy program.
 

--- a/docs/howto/enforce-agent-startup-remotely-registry.md
+++ b/docs/howto/enforce-agent-startup-remotely-registry.md
@@ -1,4 +1,11 @@
-# How to enforce the UP4W background agent startup remotely using the Windows Registry
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Use Landscape to enforce startup of the Ubuntu Pro for WSL background agent to support zero-touch deployment at scale."
+---
+
+# Remotely enforce startup of the Ubuntu Pro for WSL background agent using the Windows Registry
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/howto/gpu-cuda.md
+++ b/docs/howto/gpu-cuda.md
@@ -12,7 +12,7 @@ While WSL's default setup allows you to develop cross-platform applications with
 ## What you will learn
 
 * How to install a Windows graphical device driver compatible with WSL2
-* How to install the NVIDIA CUDA toolkit for WSL 2 on Ubuntu
+* How to install the NVIDIA CUDA toolkit for WSL2 on Ubuntu
 * How to compile and run a sample CUDA application on Ubuntu on WSL2
 
 ## What you will need

--- a/docs/howto/gpu-cuda.md
+++ b/docs/howto/gpu-cuda.md
@@ -1,4 +1,11 @@
-# Enabling GPU acceleration with the NVIDIA CUDA Platform
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Enable GPU acceleration with NVIDIA CUDA for Ubuntu on WSL, to support AI, ML and other computationally-intensive projects."
+---
+
+# Enable GPU acceleration for Ubuntu on WSL with the NVIDIA CUDA Platform
 
 While WSL's default setup allows you to develop cross-platform applications without leaving Windows, enabling GPU acceleration inside WSL provides users with direct access to the hardware. This provides support for GPU-accelerated AI/ML training and the ability to develop and test applications built on top of technologies, such as OpenVINO, OpenGL, and CUDA that target Ubuntu while staying on Windows.
 

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Install the latest version of Ubuntu on WSL using different methods."
+---
+
 # Install Ubuntu on WSL2
 
 ## What you will learn

--- a/docs/howto/reset-factory.md
+++ b/docs/howto/reset-factory.md
@@ -7,6 +7,10 @@ myst:
 
 # How to reset Ubuntu Pro for WSL back to factory settings
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
 
 You can reset Ubuntu Pro for WSL to factory settings following these steps:
 

--- a/docs/howto/reset-factory.md
+++ b/docs/howto/reset-factory.md
@@ -1,4 +1,12 @@
-# How to reset UP4W back to factory settings
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "For developers who are testing, debugging or developing the application."
+---
+
+# How to reset Ubuntu Pro for WSL back to factory settings
+
 
 You can reset Ubuntu Pro for WSL to factory settings following these steps:
 

--- a/docs/howto/run-workflows-azure.md
+++ b/docs/howto/run-workflows-azure.md
@@ -1,4 +1,12 @@
-# How to run your WSL GitHub workflow on Azure
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "To support testing of software for Ubuntu on WSL, you can use WSL GitHub workflows on Azure."
+---
+
+# Run your own WSL GitHub workflow for Ubuntu on Azure
+
 > Read more: [How we improved testing Ubuntu on WSL – and how you can too!](https://ubuntu.com/blog/improved-testing-ubuntu-wsl)
 
 Most of the time, what works on Ubuntu desktop works on WSL as well. However, there are some exceptions. Furthermore, you may want to test software that lives both on Windows and inside WSL. In these cases, you may want to run your automated testing on a Windows machine with WSL rather than a regular ubuntu machine.

--- a/docs/howto/set-up-landscape-client.md
+++ b/docs/howto/set-up-landscape-client.md
@@ -1,4 +1,11 @@
-# Configure the Landscape client with UP4W
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "The Landscape client in Ubuntu on WSL instances can be configured with Ubuntu Pro for WSL to support remote management and deployment."
+---
+
+# Configure the Landscape client with Ubuntu Pro for WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/howto/set-up-up4w.md
+++ b/docs/howto/set-up-up4w.md
@@ -1,4 +1,11 @@
-# Install UP4W and add a Pro token
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Ubuntu Pro for WSL is a Windows application that automatically attaches your Ubuntu Pro subscription to instances of Ubuntu on WSL."
+---
+
+# Install Ubuntu Pro for WSL and add a Pro token
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/howto/start-agent-remotely.md
+++ b/docs/howto/start-agent-remotely.md
@@ -1,4 +1,11 @@
-# How to start the agent remotely
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Use Intune to enforce startup of the Ubuntu Pro for WSL background agent to support zero-touch deployment at scale."
+---
+
+# Start the Ubuntu Pro for WSL background agent remotely with Intune
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/howto/uninstalling.md
+++ b/docs/howto/uninstalling.md
@@ -1,4 +1,11 @@
-# Uninstall UP4W, Ubuntu WSL and WSL
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Follow the steps to uninstall the Ubuntu Pro for WSL Windows application, Ubuntu on WSL instances and WSL itself."
+---
+
+# Uninstall Ubuntu Pro for WSL, Ubuntu on WSL and WSL
 
 Uninstalling UP4W, Ubuntu WSL apps and WSL generally only requires finding
 the relevant application in the Windows Start Menu and clicking **Uninstall**,

--- a/docs/howto/verify-subscribe-attach.md
+++ b/docs/howto/verify-subscribe-attach.md
@@ -1,4 +1,11 @@
-# Verify active Pro subscription and Pro attachment
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Ubuntu Pro for WSL automatically attaches your Pro subscription to instances of Ubuntu on WSL. It's easy to confirm that your subscription is active and that instances are Pro-attaching."
+---
+
+# Verify active Pro subscription and automatic Pro attachment with Ubuntu Pro for WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "A complete Ubuntu environment on Windows using WSL, with enhanced security and remote management provided by Ubuntu Pro for WSL."
+---
+
 # Ubuntu on WSL
 
 Windows Subsystem for Linux ([WSL](https://ubuntu.com/desktop/wsl)) enables

--- a/docs/reference/07-windows-agent-command-line-reference.md
+++ b/docs/reference/07-windows-agent-command-line-reference.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Command line reference for Ubuntu Pro for WSL's Windows agent."
+---
+
 # Windows Agent CLI
 
 > See first: [UP4W - Windows Agent](ref::up4w-windows-agent)

--- a/docs/reference/07-windows-agent-command-line-reference.md
+++ b/docs/reference/07-windows-agent-command-line-reference.md
@@ -7,6 +7,11 @@ myst:
 
 # Windows Agent CLI
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
+
 > See first: [UP4W - Windows Agent](ref::up4w-windows-agent)
 
 

--- a/docs/reference/08-wsl-pro-service-command-line-reference.md
+++ b/docs/reference/08-wsl-pro-service-command-line-reference.md
@@ -7,6 +7,11 @@ myst:
 
 # WSL Pro Service CLI
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
+
 > See first: [UP4W - WSL Pro Service](ref::up4w-wsl-pro-service)
 
 ## Usage

--- a/docs/reference/08-wsl-pro-service-command-line-reference.md
+++ b/docs/reference/08-wsl-pro-service-command-line-reference.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Command line reference for Ubuntu Pro for WSL's WSL Pro Service."
+---
+
 # WSL Pro Service CLI
 
 > See first: [UP4W - WSL Pro Service](ref::up4w-wsl-pro-service)

--- a/docs/reference/09-qa-process-reference.md
+++ b/docs/reference/09-qa-process-reference.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Reference information on the QA process used in the development of Ubuntu pro for WSL."
+---
+
 # QA Process
 
 ## Generalities

--- a/docs/reference/09-qa-process-reference.md
+++ b/docs/reference/09-qa-process-reference.md
@@ -7,6 +7,11 @@ myst:
 
 # QA Process
 
+```{include} ../dev_docs_notice.txt
+    :start-after: <!-- Include start dev -->
+    :end-before: <!-- Include end dev -->
+```
+
 ## Generalities
 
 ```{note}

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -1,5 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Reference information on GitHub actions available for Ubuntu on WSL."
+---
+
 (reference::actions)=
-# GitHub actions
+# GitHub actions for Ubuntu on WSL
 
 (reference::actions::download-rootfs)=
 ## Download rootfs

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -1,5 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Multiple distributions of Ubuntu are available for WSL, including the latest Ubuntu LTS release and the latest development version which previews new features."
+---
+
 (reference::distros)=
-# Distributions
+# Distributions of Ubuntu on WSL
 
 Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. Several releases of the Ubuntu distro are available for WSL.
 

--- a/docs/reference/firewall_requirements.md
+++ b/docs/reference/firewall_requirements.md
@@ -1,4 +1,11 @@
-# Firewall requirements
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Reference information on firewall rules required for the operation of Ubuntu Pro for WSL."
+---
+
+# Firewall requirements for Ubuntu on WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/reference/glossary_up4w_components.md
+++ b/docs/reference/glossary_up4w_components.md
@@ -1,5 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "The Ubuntu Pro for WSL applications consists of multiple components: a GUI front end, Landscape client, Ubuntu Pro client, Windows agent, and WSL Pro service."
+---
+
 (ref::glossary-up4w-components)=
-# Glossary of UP4W components
+# Glossary of Ubuntu Pro for WSL components
 
 The architecture of UP4W and how its components integrate together is covered in our detailed [explanation article](../explanation/ref-arch-explanation.md).
 This glossary includes concise descriptions of the components for reference.

--- a/docs/reference/landscape_config.md
+++ b/docs/reference/landscape_config.md
@@ -1,5 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Reference information for configuring the Landscape client for Ubuntu on WSL."
+---
+
 (ref::landscape-config)=
-# Landscape configuration schema
+# Landscape configuration schema for Ubuntu on WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/reference/windows_registry.md
+++ b/docs/reference/windows_registry.md
@@ -1,5 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "The Windows registry can be used in combination with Ubuntu Pro for WSL when remotely managing Ubuntu on WSL instances."
+---
+
 (windows-registry)=
-# Windows registry
+# The Windows registry and Ubuntu Pro for WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -1,4 +1,11 @@
-# Deploy WSL instances with UP4W and Landscape
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Use the Ubuntu Pro for WSL application to deploy Ubuntu on WSL to remote Windows machines from a Landscape server."
+---
+
+# Deploy WSL instances remotely with Ubuntu Pro for WSL and Landscape
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Set up an Ubuntu development environment on Windows using WSL, with Visual Studio Code for remote development and local testing in the browser."
+---
+
 # Develop with Ubuntu on WSL
 
 The easiest way to access your Ubuntu development environment in WSL is by using Visual Studio Code via the built-in `Remote` extension.

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -1,4 +1,11 @@
-# Get started with UP4W
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Ubuntu Pro for WSL is a Windows application that automatically attaches your Ubuntu Pro subscription to every Ubuntu instance created on WSL."
+---
+
+# Get started with Ubuntu Pro for WSL
 
 ```{include} ../pro_content_notice.txt
     :start-after: <!-- Include start pro -->


### PR DESCRIPTION
Search results for these docs are primarily determined by the top-level header and the meta descriptions used.
We currently don't set meta descriptions, so the first line of text after the title is used in search results.

For example, here is search result for installing Ubuntu Pro for WSL. It is possible that a user reads the title (from the title of the page) and description (defaulting to first line after title) and thinks "what is UP4W?"

![Screenshot from 2025-02-24 10-08-00](https://github.com/user-attachments/assets/221f89a6-0f7d-4769-b192-ce1903eac51d)

In this example, it would be difficult to tell that this page even relates to WSL, unless someone looks carefully at the URL:

![Screenshot from 2025-02-24 10-06-58](https://github.com/user-attachments/assets/45ae172d-bcb0-4236-980b-a0e7a8cd52d1)


The changes in this PR attempt to add more descriptive titles to individual pages, which will be more informative when read as an isolated search result; in addition, meta descriptions are added so that we have more control over how pages are described in these search results.

The markdown meta information included at the top of a given markdown pages gets converted into html, like so:

```html
<meta content="A complete Ubuntu environment on Windows using WSL, with enhanced security and remote management provided by Ubuntu Pro for WSL." lang="en" name="description" xml:lang="en" />
```

Other changes:

* Dev docs notice: adds a notice when a page is primarily intended for a developer audience, to better account for a scenario where a user ends up on the installation guide for developers, for example
* Redirects: added some more redirects to account for the recent merge and based on a survey of 404 frequency for the documentation.
* Fixups: spacing, wording and other small issues


UDENG-6053