### PR TITLE
fix(wsl-pro-service): wait for cloud-init before fixing Landscape client.conf

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -90,7 +90,9 @@ jobs:
       - name: Set up Ubuntu
         uses: Ubuntu/WSL/.github/actions/wsl-install@main
         with:
+          # TODO: Migrate this to the tar-based 24.04
           distro: "Ubuntu-Preview"
+          useStore: true
       - name: Set up Go
         # actions/setup-go is broken
         shell: powershell

--- a/wsl-pro-service/internal/daemon/daemon_test.go
+++ b/wsl-pro-service/internal/daemon/daemon_test.go
@@ -69,6 +69,7 @@ func TestServe(t *testing.T) {
 		dontServe               bool
 		missingCertsDir         bool
 		missingCaCert           bool
+		breakLandscapeConf      bool
 
 		// Break the port file in various ways
 		breakPortFile         bool
@@ -87,6 +88,7 @@ func TestServe(t *testing.T) {
 	}{
 		"Success": {wantConnected: true},
 		"Success with systemd notifier returning true": {notifierReturn: true, wantConnected: true},
+		"Success with a broken Landscape config":       {breakLandscapeConf: true, wantConnected: true},
 
 		// No connection:
 		// These problems do not cause the agent to return error because it
@@ -131,6 +133,11 @@ func TestServe(t *testing.T) {
 
 			if tc.breakPortFile {
 				require.NoError(t, os.RemoveAll(publicDir), "Setup: could not remove port file")
+			}
+
+			if tc.breakLandscapeConf {
+				require.NoError(t, os.RemoveAll(system.Path("/etc/landscape/client.conf")), "Setup: couldn't remove Landscape client conf to break tests")
+				require.NoError(t, os.MkdirAll(system.Path("/etc/landscape/client.conf"), 0750), "Setup: couldn't create a directory to break Landscape client conf for tests")
 			}
 
 			if tc.breakWindowsHostAddress {

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
-	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/ubuntu/decorate"
 	"gopkg.in/ini.v1"
 )
@@ -73,10 +72,6 @@ func New(args ...Option) *System {
 
 	s := &System{
 		backend: opts.backend,
-	}
-
-	if err := s.EnsureValidLandscapeConfig(context.Background()); err != nil {
-		log.Warningf(context.Background(), "Could not ensure valid Landscape configuration: %v", err)
 	}
 
 	return s

--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -4,6 +4,7 @@ ConditionVirtualization=wsl
 
 [Service]
 Type=notify
+NotifyAccess=all
 ExecStart=/usr/libexec/wsl-pro-service
 Restart=always
 RestartSec=2s


### PR DESCRIPTION
With the current behaviour wsl-pro-service and cloud-init race for the Landscape client.conf file during first boot.
It's possible that wsl-pro-service passes by the routine supposed to fix that configuration file before it exists, thus the instance wouldn't be registered with Landscape before a reboot.

We cannot simply order them via the systemd units because the Landscape configuration happens in cloud-init's final stage. The sync point for that stage is cloud-init.target. But that systemd target `Wants=multi-user.target` so it won't be reached before the login finishes. `wsl-pro.service`on the other hand declares itself as  `WantedBy=multi-user.target` so it has a systemd target against which it's installed (otherwise it wouldn't be enabled), which makes it a dependency for the boot, thus making it impossible to make it `After=cloud-init.target` or `Wants=cloud-init.target`. That would result in a cycle.
There is no other meaningful systemd target we could make `wsl-pro.service` a dependency of to solve this cycle.

So let's sync in code. 

I'm doing the now popular snippet to check if the cloud-init.service is enabled before running `cloud-init --wait` to prevent hangs in case the unit goes disabled. I'm not checking if systemd is running because we are a child of systemd. Since I'm doing the check right before attempting to touch the client.conf file, and waiting on cloud-init could make systemd time us out, I'm moving that check to a place after we notify systemd that we are ready, thus unblocking the boot. I'm also adding a test case to make sure a broken client.conf won't interfere with wsl-pro-service's communication with the windows agent.

As a final quality-of-life measure I'm adding this line to the systemd unit:

```diff
[Service]
Type=notify
+ NotifyAccess=all
ExecStart=/usr/libexec/wsl-pro-service
Restart=always
RestartSec=2s
```
because I saw systemd logging many times complaints about wsl-pro-service notifying readiness from another PID than the one systemd originally started. This should allow any subprocess or thread of wsl-pro-service to notify it without that annoying log line.


---
UDENG-5890
