### PR TITLE
ci: Fix end-to-end tests on azure that use Ubuntu-Preview

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -91,6 +91,7 @@ jobs:
         uses: Ubuntu/WSL/.github/actions/wsl-install@main
         with:
           distro: "Ubuntu-Preview"
+          useStore: true
       - name: Set up Go
         # actions/setup-go is broken
         shell: powershell


### PR DESCRIPTION
Forces a use of the legacy install method required for `Ubuntu-Preview`-based actions.

---

UDENG-6075