### PR TITLE
fix(windows-agent): Cleanup cloud init files for invalid distros

### DIFF
--- a/windows-agent/internal/distros/database/database_test.go
+++ b/windows-agent/internal/distros/database/database_test.go
@@ -501,7 +501,7 @@ func TestDatabaseCleanup(t *testing.T) {
 			databaseFromTemplate(t, dbDir, distros...)
 
 			cleanupCalled := false
-			var cleanupFunc func(string) = nil
+			var cleanupFunc func(string)
 			if tc.cleanupFunc {
 				cleanupFunc = func(d string) {
 					require.True(t, strings.EqualFold(tc.markDistroUnreachable, d), "Unexpected cleaned up distro name")

--- a/windows-agent/internal/distros/database/database_test.go
+++ b/windows-agent/internal/distros/database/database_test.go
@@ -505,8 +505,7 @@ func TestDatabaseCleanup(t *testing.T) {
 			var cleanupFunc func(string)
 			if tc.cleanupFunc {
 				cleanupFunc = func(d string) {
-					require.True(t, strings.EqualFold(tc.markDistroUnreachable, d), "Unexpected cleaned up distro name")
-					cleanupCalled.Store(true)
+					cleanupCalled.Store(strings.EqualFold(tc.markDistroUnreachable, d))
 				}
 			}
 

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -203,14 +203,9 @@ func (e executor) install(ctx context.Context, cmd *landscapeapi.Command_Install
 			return
 		}
 		// Avoid error states by cleaning up on error
-		err := distro.Uninstall(ctx)
+		err := errors.Join(distro.Uninstall(ctx), e.cloudInit().RemoveDistroData(distro.Name()))
 		if err != nil {
 			log.Warningf(ctx, "Landscape Install: failed to clean up %q after failed Install: %v", distro.Name(), err)
-		}
-
-		err = e.cloudInit().RemoveDistroData(distro.Name())
-		if err != nil {
-			log.Warningf(ctx, "Landscape install: failed to clean up %q cloud-init data after failed install: %v", distro.Name(), err)
 		}
 	}()
 

--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -207,6 +207,11 @@ func (e executor) install(ctx context.Context, cmd *landscapeapi.Command_Install
 		if err != nil {
 			log.Warningf(ctx, "Landscape Install: failed to clean up %q after failed Install: %v", distro.Name(), err)
 		}
+
+		err = e.cloudInit().RemoveDistroData(distro.Name())
+		if err != nil {
+			log.Warningf(ctx, "Landscape install: failed to clean up %q cloud-init data after failed install: %v", distro.Name(), err)
+		}
 	}()
 
 	if rootfs := cmd.GetRootfsURL(); rootfs != "" {

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -175,8 +175,9 @@ func TestInstall(t *testing.T) {
 		sendRootfsURL    string
 		missingChecksums bool
 
-		wantCloudInitWriteCalled bool
-		wantInstalled            bool
+		wantCloudInitWriteCalled  bool
+		wantCloudInitRemoveCalled bool
+		wantInstalled             bool
 	}{
 		"From the store":                    {wantInstalled: true, wantCloudInitWriteCalled: true},
 		"From a tar-based distro":           {isTarBased: true, wantInstalled: true, wantCloudInitWriteCalled: true},
@@ -188,7 +189,7 @@ func TestInstall(t *testing.T) {
 		"Error when the distroname is empty":          {distroName: "-"},
 		"Error when the Appx does not exist":          {appxDoesNotExist: true},
 		"Error when the distro is already installed":  {distroAlreadyInstalled: true, wantInstalled: true},
-		"Error when the distro fails to install":      {wslInstallErr: true},
+		"Error when the distro fails to install":      {wslInstallErr: true, wantCloudInitRemoveCalled: true},
 		"Error when cannot write cloud-init file":     {cloudInitWriteErr: true, wantCloudInitWriteCalled: true},
 		"Error when registration fails":               {isTarBased: true, wslRegisterErr: true, wantInstalled: false},
 		"Error when the distro db is corrupted":       {isTarBased: true, corruptDb: true, wantInstalled: false},
@@ -363,6 +364,10 @@ func TestInstall(t *testing.T) {
 
 					if tc.wantCloudInitWriteCalled {
 						require.True(t, testBed.cloudInit.writeCalled.Load(), "Cloud-init should have been called to write the user data file")
+					}
+
+					if tc.wantCloudInitRemoveCalled {
+						require.True(t, testBed.cloudInit.removeCalled.Load(), "Cloud-init should have been called to remove the user data file")
 					}
 				})
 		})

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 		return s, err
 	}
 
-	db, err := database.New(ctx, privateDir, func(d string) { cloudInit.RemoveDistroData(d) })
+	db, err := database.New(ctx, privateDir, func(d string) { _ = cloudInit.RemoveDistroData(d) })
 	if err != nil {
 		return s, err
 	}

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 		return s, err
 	}
 
-	db, err := database.New(ctx, privateDir)
+	db, err := database.New(ctx, privateDir, func(d string) { cloudInit.RemoveDistroData(d) })
 	if err != nil {
 		return s, err
 	}

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -85,7 +85,15 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 		return s, err
 	}
 
-	db, err := database.New(ctx, privateDir, func(d string) { _ = cloudInit.RemoveDistroData(d) })
+	db, err := database.New(
+		ctx, privateDir,
+		func(d string) {
+			err = cloudInit.RemoveDistroData(d)
+			if err != nil {
+				log.Warningf(ctx, "Could not remove leftover distro data: %v", err)
+			}
+		},
+	)
 	if err != nil {
 		return s, err
 	}


### PR DESCRIPTION
If a distro is invalidated (the user deletes it, for example), its cloud-init files may stick around without being cleaned up. This could lead to unwanted behavior if a new distro with the same name is created.

Also, if a Landscape install falls, the corresponding cloud-init file is not cleaned up. This fixes that as well.

---

UDENG-6343