### PR TITLE
docs: add a security overview

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -8,10 +8,12 @@ remediations
 unregistering
 
 # Tools and brands
+AppArmor
 apport
 appx
 AppxPackage
 Center
+checksums
 CIS
 Codecov
 cuda
@@ -22,6 +24,7 @@ gRPC
 IDEs
 js
 Intune
+livepatch
 macOS
 makefile
 MSIX
@@ -30,6 +33,7 @@ OpenGL
 OpenVINO
 powershell
 PowerShell
+SHA
 structurizr
 Structurizr
 systemd
@@ -80,6 +84,7 @@ SRU
 SSL
 ssl
 tcp
+TLS
 toolchain
 url
 vGPU
@@ -90,6 +95,7 @@ zshrc
 ESM
 Ok
 scalability
+Snapcraft
 UTF
 
 # Registry keys and types

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,13 +1,15 @@
-(explanation)=
+(exp)=
 
 # Explanation
 
 This section contains explanations that will help you develop a deeper
-understanding of how Ubuntu Pro for WSL is designed.
+understanding of how the Ubuntu distro on WSL and the Ubuntu Pro for WSL
+application are designed and secured.
 
 ```{toctree}
 :titlesonly:
 
 ref-arch-explanation
 binfmt
+security-overview
 ```

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -68,7 +68,7 @@ necessary.
 Once logged into a Windows host machine, the user can create WSL
 instances without elevated privileges.
 
-When first opening an Ubuntu on WSL terminal with `wsl.exe -d ubuntu`, the user is
+When first opening an Ubuntu on WSL terminal with `wsl.exe -d <ubuntu distro>`, the user is
 prompted for a username and password to create the default user account on Ubuntu.
 
 Even if a password is set, it can be changed by the root user; however, the

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -50,22 +50,23 @@ wsl --install --from-file ubuntu-<version number>-wsl.amd64.wsl
 
 ## Login
 
-### Host
+### Windows host
 
 Any WSL instance is only as secure as its Windows host.
 
 The Windows user should be protected by a strong password, which will — by
 extension — help secure instances of Ubuntu on WSL on the host machine.
 
-Store your passwords securely and only share them with administrators.
+Store your passwords securely and only share them with administrators when/if
+necessary.
 
-### Instance
+### WSL instance
 
 Once logged into a Windows host machine, the user can create WSL
 instances without elevated privileges.
 
 When first opening an Ubuntu on WSL terminal with `wsl.exe -d ubuntu`, the user is
-prompted for a username and password.
+prompted for a username and password to create the default user account on Ubuntu.
 
 Even if a password is set, it can be changed by the root user; however, the
 permissions of the Windows user supersede that of the Ubuntu user.
@@ -75,12 +76,12 @@ permissions of the Windows user supersede that of the Ubuntu user.
 Access to a WSL instance as the root user is possible:
 
 ```text
-wsl -d Ubuntu -u root
+wsl -d <ubuntu distro> -u root
 ```
 
 After accessing an instance as a regular (non-root) user, a password is still expected for
-commands requiring `sudo` within the instance.
-The standard Linux user account controls still apply here.
+commands requiring `sudo` within the instance:
+the standard Linux user account controls apply.
 
 Interacting with an instance using root access has no effect on the permissions
 of the Windows' user, which continues to take precedence.
@@ -137,7 +138,7 @@ apply when operating from within a WSL instance.
 The instance is therefore as secure as any arbitrary program running on the user
 account of the Windows' host.
 
-If you are concerned about the security implications of interoperability, it [can
+If you remain concerned about the security implications of interoperability, it [can
 be disabled](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#interop-settings) in `/etc/wsl.conf`:
 
 ```ini
@@ -149,7 +150,7 @@ enabled=false
 Interoperability is necessary for certain processes, including provisioning
 with cloud-init.
 
-[One approach](exp::automate-hardening) is to first provision an instance and
+[One approach](exp::disable-interoperability) is to first provision an instance and
 then subsequently disable the feature.
 ```
 
@@ -160,7 +161,8 @@ distributions. For Ubuntu on WSL, the Pro client is pre-installed.
 
 ### Manual Pro-attachment
 
-To manually attach a Pro subscription to a new instance, log in and run:
+To manually attach a Pro subscription to a new instance, run this
+command from inside the instance:
 
 ```text
 sudo pro attach
@@ -249,7 +251,7 @@ To set it:
 Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss" -Name DefaultVersion -Value 2
 ```
 
-Intune also supports policies for WSL, which include toggling the availability of WSL1:
+Intune also supports policies for WSL, which include toggling the availability of WSL1 on client machines:
 
 > [Intune configuration options for WSL](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations)
 
@@ -257,15 +259,15 @@ Intune also supports policies for WSL, which include toggling the availability o
 
 ### Configuring WSL features
 
-WSL features can be toggled if they present a security concern.
+WSL features can be controlled if they present a security concern.
 
 For example, root login can be disabled, WSL1 availability toggled and network
 access configured.
 
 There are various options to configure WSL instances, including:
 
-* The `.wslconfig` file for [global settings](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig)
-* [WSL policies with Intune](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations)
+* The `.wslconfig` file can be edited to configure [global settings](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig) for instances
+* [WSL policies for Intune](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations) enable remote management of WSL features
 * Registry entries for features like [WSL1 availability](exp::wsl1-incompatibility) can be changed in the registry editor or with PowerShell scripts 
 
 (exp::automate-hardening)=

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -105,7 +105,7 @@ Ubuntu on WSL also supports the installation of `snaps`, which are a more secure
 
 > [Read more about third-party packages in the Ubuntu Server documentation](https://documentation.ubuntu.com/server/explanation/software/third-party-repository-usage/)
 
-If an instance is running, security updates are installated automatically.
+If an instance is running, security updates are installed automatically.
 This is because `unattended-upgrades` are enabled by default.
 
 ### AppArmor

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -19,6 +19,9 @@ This page assumes a WSL version of 2.4.10 or later.
 Always use a [supported LTS version](reference::distros) of Ubuntu on WSL to
 ensure that you receive regular updates and bug fixes.
 
+> For our latest installation instructions, read the [install Ubuntu on
+WSL](howto::install-ubuntu-wsl) guide.
+
 ### Verifying the download (automatic)
 
 When installing an Ubuntu image directly from the terminal using `wsl --install

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -1,0 +1,330 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "TODO — update me"
+---
+
+# Security overview for Ubuntu on WSL
+
+```{note}
+For simplicity, we refer on this page to the default "Ubuntu" distro and not
+any numbered versions when discussing the installation and creation of
+instances.
+```
+
+## Download and installation
+
+When an Ubuntu image is installed using `wsl --install ubuntu`, the SHA-256
+checksum is automatically verified to ensure that it is secure.
+
+After downloading an image as a tarball with `.wsl` extension from an online
+archive, it can then be installed by double-clicking or running:
+
+```text
+wsl --install --from-file ubuntu.tar.wsl
+```
+
+If installing a custom tarball, it is recommended that you manually verify the
+checksums file, which is included with images on the
+[releases.ubuntu.com](https://releases.ubuntu.com) page.
+
+> [Read more about verifying an Ubuntu download](https://ubuntu.com/tutorials/how-to-verify-ubuntu#1-overview)
+
+
+## Login
+
+### Host
+
+Any WSL instance is only as secure as its Windows host.
+
+The Windows user should be protected by a strong password, which will — by
+extension — help secure instances of Ubuntu on WSL on the host machine.
+
+Store your passwords securely and only share them with administrators.
+
+### Instance
+
+Once logged into a Windows host machine, the user can create WSL
+instances without elevated privileges.
+
+When first opening an Ubuntu on WSL terminal with `ubuntu.exe`, the user is
+prompted for a username and password.
+
+Even if a password is set, it can be changed by the root user; however, the
+permissions of the Windows user supersede that of the Ubuntu user.
+
+### Root access
+
+Access to a WSL instance as the root user is possible:
+
+```text
+wsl -d Ubuntu -u root
+```
+
+After accessing an instance as a root user, a password is still expected for
+commands requiring `sudo` within the instance.
+
+Interacting with an instance using root access has no effect on the permissions
+of the Windows' user, which still take precedence.
+
+## Package management
+
+### Updates and upgrades
+
+As with any distribution, packages should be routinely updated and upgraded:
+
+```text
+sudo apt update && sudo apt upgrade -y
+```
+
+It is generally recommended that you install packages from official repositories using
+`apt`.
+
+Ubuntu on WSL also supports the installation of `snaps`, which are a more secure alternative to third-party `apt` repositories.
+
+> [Read more about third-party packages in the Ubuntu Server documentation](https://documentation.ubuntu.com/server/explanation/software/third-party-repository-usage/)
+
+### AppArmor
+
+AppArmor is a Linux Security Module implementation that controls the
+capabilities and permissions of applications.
+
+By default, AppArmor is installed in Ubuntu on WSL but not enabled.
+
+To enable AppArmor, add the following lines to `.wslconfig`:
+
+```ini
+[wsl2]
+kernelCommandLine=apparmor=1 security=apparmor lsm=apparmor
+```
+
+When inside an instance, check that AppArmor is loaded and active with:
+
+```text
+aa-status
+```
+
+> [To learn more about how AppArmor contributes to Snap security, read the Snapcraft documentation](https://snapcraft.io/docs/security-policies)
+
+## Interoperability
+
+It is possible to interact with the Windows' filesystem from a WSL instance,
+and a WSL filesystem from Windows.
+
+Note, however, that the permissions and restrictions on the Windows' user still
+apply when operating from within a WSL instance.
+
+The instance is therefore as secure as any arbitrary program running on the user
+account of the Windows' host.
+
+If you are concerned about the security implications of interoperability, it [can
+be disabled](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#interop-settings) in `/etc/wsl.conf`:
+
+```ini
+[interop]
+enabled=false
+```
+
+```{warning}
+Interoperability is necessary for certain processes, including provisioning
+with cloud-init.
+
+[One approach](exp::automate-hardening) is to first provision an instance and
+then subsequently disable the feature.
+```
+
+## Ubuntu Pro
+
+Ubuntu Pro offers [additional security](https://ubuntu.com/pro) to Ubuntu
+distributions. For Ubuntu on WSL, the Pro client is pre-installed.
+
+### Manual Pro-attachment
+
+To manually attach a Pro subscription to a new instance, log in and run:
+
+```text
+sudo pro attach
+```
+
+Once your instance is Pro-attached, you can run various commands to monitor and secure your instance, including `pro security-status` and `pro fix`:
+
+* [For more detail on the Pro client read its official documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/)
+* [For guidance on air-gapped environments, refer to the Ubuntu Pro documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/using_pro_offline/)
+
+### Livepatch
+
+The WSL kernel is maintained by Microsoft.
+
+There is no livepatch support for WSL kernels.
+Livepatch is therefore disabled for Ubuntu on WSL instances.
+
+In a Pro-attached WSL instance, running `pro status --all` will show that you
+are **entitled** to the service but the status is still **n/a**. This means
+that while your Pro subscription entitles you to using Livepatch on — for
+example — an Ubuntu Server, it does not apply to Ubuntu on WSL.
+
+> [GitHub repo for the WSL kernel](https://github.com/microsoft/WSL2-Linux-Kernel)
+
+## The Ubuntu Pro for WSL application
+
+```{include} ../pro_content_notice.txt
+    :start-after: <!-- Include start pro -->
+    :end-before: <!-- Include end pro -->
+```
+
+### Automatic Pro-attachment
+
+For Pro-attaching multiple instances automatically, use the Ubuntu Pro for WSL
+application.
+This is most relevant for deployment scenarios in which multiple Windows hosts
+are being managed centrally, using software like Landscape or Intune.
+
+> [Get started with Ubuntu Pro for WSL](howto::up4w)
+
+### Firewall configuration
+
+Firewall rules must be configured for Ubuntu Pro for WSL to enable interactions
+with different services, including Landscape and the Microsoft Store.
+
+Any exchanges of data are encrypted using TLS.
+
+> [Read our reference on firewall configuration for Ubuntu Pro on WSL](ref::firewall)
+
+(exp::wsl1-incompatibility)=
+### WSL1 incompatibility
+
+WSL2 is the default WSL version on Windows 11.
+The legacy version — WSL1 — can also still be used.
+
+> [Read more about WSL versions](https://learn.microsoft.com/en-us/windows/wsl/compare-versions)
+
+Ubuntu Pro for WSL only supports WSL2.
+When relying on Ubuntu Pro for WSL to manage the security of WSL instances,
+you should therefore consider enforcing WSL2 on host Windows machines.
+
+To set the default version to WSL2:
+
+```text
+wsl --set-default-version 2
+```
+
+To convert a specific distribution from WSL1 to WSL2:
+
+```text
+wsl --set-version <distro> 2
+```
+
+You can also get and set the default WSL version using the Windows registry,
+which may be necessary for certain remote management setups.
+
+To get the version:
+
+```powershell
+Get-ItemPropertyValue -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss" -Name DefaultVersion
+```
+
+To set it:
+
+```powershell
+Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss" -Name DefaultVersion -Value 2
+```
+
+Intune also supports policies for WSL, which include toggling the availability of WSL1:
+
+> [Intune configuration options for WSL](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations)
+
+## Security tips
+
+### Configuring WSL features
+
+WSL features can be toggled if they present a security concern.
+
+For example, root login can be disabled, WSL1 availability toggled and network
+access configured.
+
+There are various options to configure WSL instances, including:
+
+* The `.wslconfig` file for [global settings](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig)
+* [WSL policies with Intune](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations)
+* Registry entries for features like [WSL1 availability](exp::wsl1-incompatibility) can be changed in the registry editor or with PowerShell scripts 
+
+(exp::automate-hardening)=
+### Automate hardening
+
+Provisioning of WSL instances can be automated with cloud-init.
+
+> [Read about automatic setup of Ubuntu on WSL with cloud-init](howto::cloud-init)
+
+Cloud-init can be used to secure your instances before first login:
+
+```ini
+#cloud-config
+
+package_update: true
+
+users:
+- name: u
+  groups: users,sudo,netdev,audio
+  sudo: ALL=(ALL) NOPASSWD:ALL
+  shell: /bin/bash
+  ssh-authorized-keys:
+    - ssh-rsa ...
+  lock_passwd: true
+
+write_files:
+- path: /etc/wsl.conf
+  append: true
+  content: |
+    [user]
+    default=u
+  - path: /etc/ssh/sshd_config
+    content: |
+      HostKey /etc/ssh/ssh_host_rsa_key
+      MaxAuthTries 3
+      PermitRootLogin no
+      PermitEmptyPasswords no
+      AllowUsers u
+runcmd:
+  - echo "[interop]" | sudo tee -a /etc/wsl.conf
+  - echo "enabled = false" | sudo tee -a /etc/wsl.conf
+```
+
+This configuration achieves some of the following security hardening tasks:
+
+* Updates packages
+* Defines a default user and grants permissions
+* Adds an authorised public SSH key
+* Require key authentication for SSH login
+* Disables root login by SSH
+* Restricts SSH access to a user
+* Disables WSL interoperability
+
+```{note}
+It is expected that most users will SSH from WSL rather than SSH into WSL.
+```
+
+### Remote management tools
+
+Ubuntu Pro for WSL increases the capacity of system administrators to manage
+and secure Windows hosts containing instances of Ubuntu on WSL.
+
+Learn more about remote management of Ubuntu on WSL in this documentation:
+
+* [Tutorial on deploying instances with Landscape](tut::deploy)
+* [Guides on remote management with Landscape and Intune](howto::index-remote-deployment)
+
+### Reporting a vulnerability
+
+Details on the security updates that we provide and the responsible disclosure
+of security vulnerabilities for the Ubuntu distribution on WSL can be found
+below:
+
+> [Security policy for the Ubuntu on WSL](https://github.com/ubuntu/WSL/blob/main/SECURITY.md)
+
+## Resources
+
+* [Ubuntu Pro client documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/)
+* [Microsoft guide on configuring WSL](https://learn.microsoft.com/en-us/windows/wsl/wsl-config)
+* [Microsoft Defender for Endpoint plugin for WSL](https://learn.microsoft.com/en-us/defender-endpoint/mde-plugin-wsl)
+

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -16,22 +16,37 @@ This page assumes a WSL version of 2.4.10 or later.
 
 ## Download and installation
 
-When an Ubuntu image is installed using `wsl --install ubuntu`, the SHA-256
-checksum is automatically verified to ensure that it is secure.
+Always use a [supported LTS version](reference::distros) of Ubuntu on WSL to
+ensure that you receive regular updates and bug fixes.
 
-After downloading an image as a tarball with `.wsl` extension from an online
-archive, it can then be installed by double-clicking or running:
+### Verifying the download (automatic)
 
-```text
-wsl --install --from-file ubuntu.tar.wsl
+When installing an Ubuntu image directly from the terminal using `wsl --install
+<ubuntu distro>`, the SHA-256 checksum is automatically verified to ensure that it is
+secure.
+
+### Verifying the download (manual)
+
+If you download an Ubuntu image from an online archive before installation, we
+recommend that you manually verify the checksum.
+
+Before Ubuntu is installed on WSL, you can verify the checksum of the download
+in PowerShell, like this:
+
+```powershell
+Get-FileHash C:\Users\<username>\downloads\ubuntu-<version number>-wsl-amd64.wsl -A SHA256
 ```
 
-If installing a custom tarball, it is recommended that you manually verify the
-checksums file, which is included with images on the
-[releases.ubuntu.com](https://releases.ubuntu.com) page.
+You can then cross-reference the output against the checksum on the
+[releases.ubuntu.com](https://releases.ubuntu.com) page before installing the
+verified download:
 
-> [Read more about verifying an Ubuntu download](https://ubuntu.com/tutorials/how-to-verify-ubuntu#1-overview)
+```powershell
+wsl --install --from-file ubuntu-<version number>-wsl.amd64.wsl
+```
 
+* [Read more about verifying an Ubuntu download](https://ubuntu.com/tutorials/how-to-verify-ubuntu#1-overview)
+* [Read Microsoft's about testing custom Linux distros for WSL ](https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#test-the-distribution-locally)
 
 ## Login
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -341,7 +341,8 @@ Details on the security updates that we provide and the responsible disclosure
 of security vulnerabilities for the Ubuntu distribution on WSL can be found
 below:
 
-> [Security policy for the Ubuntu on WSL](https://github.com/ubuntu/WSL/blob/main/SECURITY.md)
+* [Security policy for the Ubuntu Pro for WSL](https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/SECURITY.md)
+* [Security policy for the Ubuntu distro on WSL](https://github.com/ubuntu/WSL/blob/main/SECURITY.md)
 
 ## Resources
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -113,20 +113,11 @@ This is because `unattended-upgrades` are enabled by default.
 AppArmor is a Linux Security Module implementation that controls the
 capabilities and permissions of applications.
 
-By default, AppArmor is installed in Ubuntu on WSL but not enabled.
+By default, AppArmor is installed in Ubuntu on WSL but not yet enabled, as it
+requires certain features and patches not currently available in the WSL
+kernel.
 
-To enable AppArmor, add the following lines to `.wslconfig`:
-
-```ini
-[wsl2]
-kernelCommandLine=apparmor=1 security=apparmor lsm=apparmor
-```
-
-When inside an instance, check that AppArmor is loaded and active with:
-
-```text
-aa-status
-```
+As such, snaps cannot be full confined on WSL.
 
 > [To learn more about how AppArmor contributes to Snap security, read the Snapcraft documentation](https://snapcraft.io/docs/security-policies)
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -8,9 +8,10 @@ myst:
 # Security overview for Ubuntu on WSL
 
 ```{note}
-For simplicity, we refer on this page to the default "Ubuntu" distro and not
-any numbered versions when discussing the installation and creation of
-instances.
+We refer to the default "Ubuntu" distro and not any numbered versions when
+discussing the installation and creation of instances on this page.
+
+We also assume version 2.4.10 of WSL or later.
 ```
 
 ## Download and installation

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -105,6 +105,9 @@ Ubuntu on WSL also supports the installation of `snaps`, which are a more secure
 
 > [Read more about third-party packages in the Ubuntu Server documentation](https://documentation.ubuntu.com/server/explanation/software/third-party-repository-usage/)
 
+If an instance is running, security updates are installated automatically.
+This is because `unattended-upgrades` are enabled by default.
+
 ### AppArmor
 
 AppArmor is a Linux Security Module implementation that controls the

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -63,11 +63,14 @@ Access to a WSL instance as the root user is possible:
 wsl -d Ubuntu -u root
 ```
 
-After accessing an instance as a root user, a password is still expected for
+After accessing an instance as a regular (non-root) user, a password is still expected for
 commands requiring `sudo` within the instance.
+The standard Linux user account controls still apply here.
 
 Interacting with an instance using root access has no effect on the permissions
-of the Windows' user, which still take precedence.
+of the Windows' user, which continues to take precedence.
+Running Windows binaries as root inside WSL won't make them elevated on the
+Windows side; they run with the Windows user permissions only.
 
 ## Package management
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -274,7 +274,8 @@ Provisioning of WSL instances can be automated with cloud-init.
 
 > [Read about automatic setup of Ubuntu on WSL with cloud-init](howto::cloud-init)
 
-Cloud-init can be used to secure your instances before first login.
+Cloud-init can be used to initialise your instances in a more secure way
+(depending on your needs) before first login.
 
 Below are some snippets that can help you automate hardening.
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -2,16 +2,16 @@
 myst:
   html_meta:
     "description lang=en":
-      "TODO — update me"
+      "Read about security considerations when using Ubuntu on WSL."
 ---
 
 # Security overview for Ubuntu on WSL
 
-```{note}
-We refer to the default "Ubuntu" distro and not any numbered versions when
-discussing the installation and creation of instances on this page.
+This page includes explanations of security considerations when using Ubuntu on WSL.
+It also includes example commands and configurations to help improve security.
 
-We also assume version 2.4.10 of WSL or later.
+```{note}
+This page assumes a WSL version of 2.4.10 or later.
 ```
 
 ## Download and installation

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -49,7 +49,7 @@ Store your passwords securely and only share them with administrators.
 Once logged into a Windows host machine, the user can create WSL
 instances without elevated privileges.
 
-When first opening an Ubuntu on WSL terminal with `ubuntu.exe`, the user is
+When first opening an Ubuntu on WSL terminal with `wsl.exe -d ubuntu`, the user is
 prompted for a username and password.
 
 Even if a password is set, it can be changed by the root user; however, the

--- a/docs/howto/cloud-init.md
+++ b/docs/howto/cloud-init.md
@@ -5,6 +5,7 @@ myst:
       "Preconfigure Ubuntu on WSL using cloud-init to automate the creation of custom instances."
 ---
 
+(howto::cloud-init)=
 # Automatic setup of Ubuntu on WSL with cloud-init
 
 Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.

--- a/docs/howto/index-remote-deployment.md
+++ b/docs/howto/index-remote-deployment.md
@@ -1,4 +1,4 @@
-(index-remote-deployment)=
+(howto::index-remote-deployment)=
 
 # Remote deployment
 

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -5,6 +5,7 @@ myst:
       "Install the latest version of Ubuntu on WSL using different methods."
 ---
 
+(howto::install-ubuntu-wsl)=
 # Install Ubuntu on WSL2
 
 ## What you will learn

--- a/docs/reference/firewall_requirements.md
+++ b/docs/reference/firewall_requirements.md
@@ -5,6 +5,7 @@ myst:
       "Reference information on firewall rules required for the operation of Ubuntu Pro for WSL."
 ---
 
+(ref::firewall)=
 # Firewall requirements for Ubuntu on WSL
 
 ```{include} ../pro_content_notice.txt

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -5,6 +5,7 @@ myst:
       "Use the Ubuntu Pro for WSL application to deploy Ubuntu on WSL to remote Windows machines from a Landscape server."
 ---
 
+(tut::deploy)=
 # Deploy WSL instances remotely with Ubuntu Pro for WSL and Landscape
 
 ```{include} ../pro_content_notice.txt

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -5,6 +5,7 @@ myst:
       "Ubuntu Pro for WSL is a Windows application that automatically attaches your Ubuntu Pro subscription to every Ubuntu instance created on WSL."
 ---
 
+(howto::up4w)=
 # Get started with Ubuntu Pro for WSL
 
 ```{include} ../pro_content_notice.txt


### PR DESCRIPTION
Adds a new security overview page to the Explanation section of the docs.

This page outlines security consideration when using Ubuntu on WSL, includes links to relevant security information found elsewhere, and briefly mentions some tips for configuring features relevant to security.

In future, this could possibly be broken down into individual pages if some of the content was to be developed further, but for now a single page is sufficient.

UDENG-6389