### PR TITLE
fix(wsl-pro-service): Less logging

### DIFF
--- a/wsl-pro-service/internal/daemon/daemon.go
+++ b/wsl-pro-service/internal/daemon/daemon.go
@@ -122,15 +122,6 @@ func (d *Daemon) Serve(service streams.CommandService) error {
 	default:
 	}
 
-	// Exponential back-off
-	const (
-		minWait      = time.Second
-		maxWait      = time.Minute
-		growthFactor = 2
-	)
-	retries := 0
-	wait := 0 * time.Second
-
 	// Signal systemd before dialing for the first time
 	// We don't want to delay startup due to a timeout
 	err := d.systemdNotifyReady(d.ctx)
@@ -140,90 +131,78 @@ func (d *Daemon) Serve(service streams.CommandService) error {
 
 	// Since this function syncs with cloud-init and may take too long to run, let's do it after notifying
 	// systemd about our readiness to prevent delaying boot.
-	if err := d.system.EnsureValidLandscapeConfig(context.Background()); err != nil {
+	if err = d.system.EnsureValidLandscapeConfig(context.Background()); err != nil {
 		log.Warningf(context.Background(), "Could not ensure valid Landscape configuration: %v", err)
 	}
+	// From 0 to 1min wait times in the exponential backoff requires 8 attempts (~2min).
+	// We try another 8 times (8 more minutes) until give up on connecting to the agent.
+	rc := retryConfig{minWait: time.Second, maxWait: time.Minute, maxRetries: 16}
+	// Runs d.serveOnce() multiple times, per the configuration above.
+	err = rc.Run(d.gracefulCtx,
+		func() (bool, error) { return d.serveOnce(service) },
+		func(wait time.Duration) {
+			log.Infof(d.ctx, "Reconnecting to Windows host in %d seconds", int(wait/time.Second))
+			d.systemdNotifyStatus(d.ctx, serviceStatusWaiting)
+		},
+		func() {
+			log.Warningf(d.ctx, "Exiting after %v: check if the Windows agent is installed and running.", err)
+		})
 
-	for {
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Daemon) serveOnce(service streams.CommandService) (success bool, err error) {
+	// ctx handles force-quit
+	ctx, cancel := context.WithCancel(d.ctx)
+	defer cancel()
+
+	log.Infof(ctx, "Daemon: connecting to Windows Agent from PID %d", os.Getpid())
+	d.systemdNotifyStatus(ctx, serviceStatusConnecting)
+
+	server, err := d.connect(ctx)
+	if errors.Is(err, streams.SystemError{}) {
+		return false, err
+	} else if err != nil {
+		log.Warningf(ctx, "Daemon: %v", err)
+		return false, nil
+	}
+
+	go func() {
+		// Handle graceful quit.
 		select {
 		case <-d.gracefulCtx.Done():
-			return nil
-		case <-time.After(wait):
+		case <-ctx.Done():
 		}
+		server.GracefulStop()
+	}()
 
-		success, err := func() (success bool, err error) {
-			// ctx handles force-quit
-			ctx, cancel := context.WithCancel(d.ctx)
-			defer cancel()
+	log.Info(ctx, "Daemon: completed connection to Windows Agent")
+	d.systemdNotifyStatus(ctx, serviceStatusConnected)
 
-			log.Infof(ctx, "Daemon: connecting to Windows Agent from PID %d", os.Getpid())
-			d.systemdNotifyStatus(ctx, serviceStatusConnecting)
+	t := time.NewTimer(time.Minute)
+	defer t.Stop()
 
-			server, err := d.connect(ctx)
-			if errors.Is(err, streams.SystemError{}) {
-				return false, err
-			} else if err != nil {
-				log.Warningf(ctx, "Daemon: %v", err)
-				return false, nil
-			}
+	err = server.Serve(service)
 
-			go func() {
-				// Handle graceful quit.
-				select {
-				case <-d.gracefulCtx.Done():
-				case <-ctx.Done():
-				}
-				server.GracefulStop()
-			}()
+	if errors.Is(err, streams.SystemError{}) {
+		return false, err
+	} else if err != nil {
+		log.Warningf(ctx, "Daemon: disconnected from Windows host: %v", err)
+	} else {
+		log.Warning(ctx, "Daemon: disconnected from Windows host")
+	}
 
-			log.Info(ctx, "Daemon: completed connection to Windows Agent")
-			d.systemdNotifyStatus(ctx, serviceStatusConnected)
-
-			t := time.NewTimer(time.Minute)
-			defer t.Stop()
-
-			err = server.Serve(service)
-
-			if errors.Is(err, streams.SystemError{}) {
-				return false, err
-			} else if err != nil {
-				log.Warningf(ctx, "Daemon: disconnected from Windows host: %v", err)
-			} else {
-				log.Warning(ctx, "Daemon: disconnected from Windows host")
-			}
-
-			select {
-			case <-t.C:
-				// Long-lived connection is not a failure
-				return true, nil
-			default:
-				// Connection was short-lived: consider it a failure
-				return false, nil
-			}
-		}()
-
-		if err != nil {
-			return err
-		}
-
-		// From 0 to 1min wait times in the exponential backoff requires 8 attempts (~2min).
-		// We try another 8 times (8 more minutes) until give up on connecting to the agent.
-		// From systemd's point of view that's not a failure.
-		if retries >= 16 {
-			log.Warning(d.ctx, "Exiting after too many connection attempts to the Windows host. Check if Ubuntu Pro for WSL app is installed.")
-			return nil
-		}
-
-		if success {
-			wait *= 0
-			retries = 0
-			continue
-		}
-
-		wait = clamp(minWait, wait*growthFactor, maxWait)
-		retries = retries + 1
-		log.Infof(d.ctx, "Reconnecting to Windows host in %d seconds", int(wait/time.Second))
-		d.systemdNotifyStatus(d.ctx, serviceStatusWaiting)
+	select {
+	case <-t.C:
+		// Long-lived connection is not a failure
+		return true, nil
+	default:
+		// Connection was short-lived: consider it a failure
+		return false, nil
 	}
 }
 
@@ -282,10 +261,6 @@ func (d *Daemon) systemdNotifyStatus(ctx context.Context, status string) {
 	if sent {
 		log.Debugf(ctx, "Updated systemd status to %q", status)
 	}
-}
-
-func clamp(minimum, value, maximum time.Duration) time.Duration {
-	return max(minimum, min(value, maximum))
 }
 
 // connect connects to the Windows Agent and returns a reverse server.
@@ -410,7 +385,7 @@ type retryConfig struct {
 // "onWait" is unconditionally invoked before every new retry. This function only returns an error if the
 // invoked actions does so. None of the callbacks can be nil.
 func (r retryConfig) Run(ctx context.Context, action actionFn, onWait waitFn, onTooManyAttempts tooManyAttemptsFn) error {
-	var retryCount uint8 = 0
+	var retryCount uint8
 	wait := 0 * time.Second
 	for {
 		select {
@@ -435,7 +410,7 @@ func (r retryConfig) Run(ctx context.Context, action actionFn, onWait waitFn, on
 			continue
 		}
 
-		retryCount += 1
+		retryCount++
 		wait = clamp(r.minWait, 2*wait, r.maxWait)
 		onWait(wait)
 	}

--- a/wsl-pro-service/internal/daemon/export_test.go
+++ b/wsl-pro-service/internal/daemon/export_test.go
@@ -1,9 +1,21 @@
 package daemon
 
+import "time"
+
 type SystemdSdNotifier = systemdSdNotifier
 
 func WithSystemdNotifier(notifier SystemdSdNotifier) Option {
 	return func(o *options) {
 		o.systemdSdNotifier = notifier
+	}
+}
+
+type RetryConfig = retryConfig
+
+func NewRetryConfig(minWait, maxWait time.Duration, maxRetries uint8) RetryConfig {
+	return RetryConfig{
+		minWait:    minWait,
+		maxWait:    maxWait,
+		maxRetries: maxRetries,
 	}
 }

--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -7,7 +7,7 @@ Type=notify
 NotifyAccess=all
 ExecStart=/usr/libexec/wsl-pro-service
 Restart=always
-RestartSec=2s
+RestartSec=20min
 
 # Some daemon restrictions
 LockPersonality=yes


### PR DESCRIPTION
The current implementation of wsl-pro-service's `daemon.Serve()` keeps trying to connect to the Windows agent indefinitely, with exponential back-off starting at 1 second and saturating at 60 min with a power of 2 growth factor. That means it will roughly take 2 minutes to saturate the back-off wait time and then keep retrying at every minute. Since most WSL users don't have the Windows agent running, that means one log line being added to the journal by default every minute. That's not a good default.

With this PR I aim to make wsl-pro-service quit gracefully after a predefined number of consecutive retry attempts to connect to the Windows agent. Since systemd is set to restart it always, I'm changing the restart interval from 2 seconds to 20 minutes. So we'd be trying to connect to the Windows agent for roughly 10 min, bailing out and staying quiet and silent for 20 minutes before trying again.

We could consider alternatively asking systemd to only restart us on failure, and staying quiet for the entire duration of a boot instead. Or even establishing specific error codes for when systemd should and should not restart us.

Those alternatives as well as the magic numbers sprinkled here and there are pretty much open for debate.

One final note: I did a major refactoring of `daemon.Serve()` because otherwise adding a test case to verify that method would return no error when the maximum number of retrial attempts is reached would require having such test case running for 10min or more, just waiting. Decoupling the retrial logic allows us to infer that indirectly by covering all possible retry scenarios in half a second, and trusting that `daemon.Serve()` won't error out if `retryConfig.Run()` doesn't. I could have stopped the changes in Go code at the first commit but that would be suboptimal IMHO.

---

UDENG-6571