### PR TITLE
fix: Ensure Built-Using is populated

### DIFF
--- a/wsl-pro-service/debian/rules
+++ b/wsl-pro-service/debian/rules
@@ -19,7 +19,7 @@ ifeq ($(strip $(GOFLAGS)),)
 	exit 1
 endif
 	@echo "Building with flags $(GOFLAGS)"
-	dh $@ --builddirectory=_build --with=apport
+	dh $@ --builddirectory=_build --with=apport,golang
 
 override_dh_auto_install:
 	dh_auto_install -- --no-source


### PR DESCRIPTION
Using golang build package system is not enough, we need to ensure that golang debhelper is hooked in too to populate that field.