### PR TITLE
docs: new distro format

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -7,6 +7,7 @@ APIs
 balancer
 Charmhub
 CLI
+CTRL
 DCO
 Diátaxis
 Dqlite
@@ -26,6 +27,7 @@ Juju
 Kubeflow
 Kubernetes
 Launchpad
+LeftClick
 linter
 LTS
 LXD

--- a/docs/howto/backup-and-restore.md
+++ b/docs/howto/backup-and-restore.md
@@ -57,7 +57,7 @@ If you want to restore the Ubuntu-24.04 instance that you have previously backed
 PS C:\Users\me> wsl --import Ubuntu-24.04 .\backup\Ubuntu2404\ .\backup\Ubuntu-24.04.tar.gz
 ```
 
-This will import your previous data and if you run `ubuntu2404.exe` an Ubuntu WSL instance
+This will import your previous data and if you run `wsl -d Ubuntu-24.04`, an Ubuntu WSL instance
 should be restored with your previous configuration intact.
 
 To login as a user `k`, created with the original instance, run: 

--- a/docs/howto/cloud-init.md
+++ b/docs/howto/cloud-init.md
@@ -8,12 +8,10 @@ myst:
 (howto::cloud-init)=
 # Automatic setup of Ubuntu on WSL with cloud-init
 
-Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
-Ubuntu WSL users can now leverage it to perform an automatic setup to get a working instance with minimal touch.
+Cloud-init is a cross-platform tool for provisioning cloud instances.
+It is an industry standard and can now also be used to automatically setup instances of Ubuntu on WSL.
 
 > See more:  [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
-
-The latest release of Ubuntu 24.04 LTS (Noble Numbat) comes with cloud-init already preinstalled, so you'll need that specific application to follow this guide. Ubuntu 24.04 LTS can be installed from [this link to the Microsoft Store](https://apps.microsoft.com/detail/9nz3klhxdjp5?hl=en-us&gl=US). A previous version of this guide used Ubuntu (Preview), because that comes with the latest in-development features. You can still use it to follow the instructions below, if you prefer. This feature is now available in the default Ubuntu application as well as Ubuntu 22.04 LTS.
 
 ## What you will learn
 
@@ -23,18 +21,36 @@ The latest release of Ubuntu 24.04 LTS (Noble Numbat) comes with cloud-init alre
 
 ## What you will need
 
-- Windows 11 with WSL 2 already enabled
-- The latest Ubuntu 24.04 LTS application from the Microsoft Store
+- Windows 11 with WSL2 already enabled
+
+The guide assumes that you are using Ubuntu 24.04,
+but Ubuntu 22.04 can also be used.
+
+In the latest versions of WSL, installing a distro also launches the instance
+and prompts the user through setup. Cloud-init will not provision an instance
+that has already been set up in this way.
+
+If you want to provision with cloud-init after a distro is installed, first
+install the distro with the `--no-launch` flag. Alternatively, set up cloud-init
+before you install the distro.
 
 ## Write the cloud-config file
 
-Locate your Windows user home directory. It typically is `C:\Users\<YOUR_USER_NAME>`.
+Locate your Windows user home directory, which is typically `C:\Users\<YOUR_USER_NAME>`.
 
-> You can be sure about that path by running `echo $env:USERPROFILE` in PowerShell.
+````{tip}
+If you want to find your home directory, run the following in PowerShell:
 
-Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` à la Linux
-configuration directories), and inside the new directory, create an empty file named `Ubuntu-24.04.user-data`. That file name must
-match the name of the distro instance that will be created in the next step.
+```text
+echo $env:USERPROFILE` in PowerShell
+```
+````
+
+Inside your Windows user home directory, create a new folder named
+`.cloud-init`, ensuring there is `.` at the start of the directory name. Inside
+the new directory, create an empty file named `Ubuntu-24.04.user-data`. The
+name of this file name has to match the name of the distro instance that will
+be created in the next step.
 
 Open that file with your text editor of choice (`notepad.exe` is just fine) and paste in the following contents:
 
@@ -63,29 +79,28 @@ runcmd:
    - /opt/vcpkg/bootstrap-vcpkg.sh
 ```
 
-Save it and close it.
+Save the file and close it.
 
-> That example will create a user named `jdoe` and set it as default via `/etc/wsl.conf`, install the packages
-> `ginac-tools` and `octave` and install `vcpkg` from the git repository, since there is no deb or snap of that
-> application (hence the reason for being included in this guide - it requires an unusual setup).
-
+```{note}
+The cloud-config will create a user named `jdoe` and set it as default via
+`/etc/wsl.conf`, install the packages `ginac-tools` and `octave`. It will also
+install `vcpkg` from a git repository, since there is no deb or snap of that
+application.
+```
 
 > See more: [WSL data source reference](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 
-## Register a new Ubuntu-24.04 instance
+## Install and launch a new Ubuntu-24.04 instance
 
 In PowerShell, run:
 
 ```{code-block} text
-> ubuntu2404.exe
+> wsl --install Ubuntu-24.04
 ```
 
-This command will register a new Ubuntu-24.04 instance that will be configured automatically by cloud-init.
+This command installs and launches an Ubuntu-24.04 instance.
+This instance will then be configured automatically by cloud-init.
 The process can take several minutes, depending on your computer and network speeds.
-
-> If you want to be sure that there is now an Ubuntu-24.04 instance, run `wsl -l -v`.
-> Notice that the application is named `Ubuntu24.04LTS` but the WSL instance created is named `Ubuntu-24.04`.
-> See more about that naming convention in [our reference documentation](naming).
 
 ## Verify automatic configuration by cloud-init
 
@@ -120,13 +135,13 @@ jdoe@mib01:~$
 
 Once logged into the new distro instance's shell, verify that:
 
-1. The default user matches what was configured in the user data file (in our case `jdoe`).
+1. The default user matches what was configured:
 
 ```{code-block} text
 jdoe@mib:~$ whoami
 ```
 
-This should be verified with the output message:
+This should be verified with the output:
 
 ```{code-block} text
 :class: no-copy
@@ -174,7 +189,7 @@ LC_ALL=
 
 ```
 
-4. The packages were installed and the commands they provide are available.
+4. The packages were installed and the commands that they provide are available.
 
 ```{code-block} text
 jdoe@mib:~$ apt list --installed | egrep 'ginac|octave'
@@ -195,13 +210,13 @@ octave/noble,now 8.4.0-1 amd64 [installed]
 ```
 
 5. Lastly, verify that the commands requested were also run. In this case we set up `vcpkg` from git, as recommended by its
-   documentation (there is no deb or snap available for that program).
+   documentation (there is no deb or snap available for that program):
 
 ```{code-block} text
 jdoe@mib:~$ /opt/vcpkg/vcpkg version
 ```
 
-This should also be verified with:
+This should be verified with:
 
 ```{code-block} text
 :class: no-copy
@@ -212,7 +227,7 @@ See LICENSE.txt for license information.
 
 ## Enjoy!
 
-That’s all folks! In this guide, we’ve shown you how to use cloud-init to automatically set up Ubuntu on WSL 2 with minimal touch.
+That’s all folks! In this guide, we’ve shown you how to use cloud-init to automatically set up Ubuntu on WSL2 with minimal touch.
 
 This workflow will guarantee a solid foundation for your next Ubuntu WSL project.
 

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -10,131 +10,164 @@ myst:
 
 ## What you will learn
 
-* How to enable and install WSL on Windows 10 and Windows 11
-* How to install `Ubuntu 24.04 LTS` using the Microsoft Store or WSL commands in the terminal
+* How to enable and install WSL on Windows
+* How to install Ubuntu 24.04 LTS using the Microsoft Store or WSL commands in the terminal
+* How to start Ubuntu instances
 
 ## What you will need
 
 * Windows 10 or 11 running on either a physical device or virtual machine 
 * All of the latest Windows updates installed
 
-## Install WSL
+## Install WSL and run the default Ubuntu distro
 
-You can install WSL from the command line. Open a PowerShell prompt as an Administrator (we recommend using [Windows Terminal](https://github.com/microsoft/terminal?tab=readme-ov-file#installing-and-running-windows-terminal)) and run:
-
+To install WSL, open PowerShell as an Administrator and run:
 
 ```{code-block} text
 > wsl --install
 ```
 
-It is recommended to reboot your machine after this initial installation to complete the setup.
+This installs both WSL and the default distro for WSL, which is the latest LTS version of Ubuntu.
 
-## Install Ubuntu WSL
+## Install specific versions of Ubuntu on WSL
 
-There are multiple ways of installing distros on WSL, here we focus on two: the Microsoft Store application and WSL commands run in the terminal. The result is the same regardless of the method.
+There are multiple ways of installing Ubuntu distros on WSL.
+The best method depends on your specific requirements.
 
-### Method 1: Microsoft Store application
+### Method 1: Install Ubuntu from the terminal
 
-Find the distribution you prefer on the Microsoft Store and then click **Get**. 
-
-![Installation page for Ubuntu 24.04 LTS in the Microsoft store.](assets/install-ubuntu-wsl2/choose-distribution.png)
-
-Ubuntu will then be installed on your machine. Once installed, you can either launch the application directly from the Microsoft Store or search for Ubuntu in your Windows search bar.
-
-![Search results for Ubuntu 24.04 LTS in Windows search bar.](assets/install-ubuntu-wsl2/search-ubuntu-windows.png)
-
-### Method 2: WSL commands in the terminal
-
-In a PowerShell terminal, you can run `wsl --list --online` to see an output with all available distros and versions:
+In a PowerShell terminal, run `wsl --list --online` to see a list of all available distros and versions:
 
 ```{code-block} text
 :class: no-copy
 The following is a list of valid distributions that can be installed.
-The default distribution is denoted by '*'.
-Install using 'wsl --install -d <Distro>'.
+Install using 'wsl --install <Distro>'.
 
   NAME                                   FRIENDLY NAME
-* Ubuntu                                 Ubuntu
-  Debian                                 Debian GNU/Linux
+  AlmaLinux-8                            AlmaLinux OS 8
+  ...                                    ...
+  Ubuntu                                 Ubuntu
+  Ubuntu-24.04                           Ubuntu 24.04 LTS
+  archlinux                              Arch Linux
   kali-linux                             Kali Linux Rolling
+  ...                                    ...
   Ubuntu-18.04                           Ubuntu 18.04 LTS
   Ubuntu-20.04                           Ubuntu 20.04 LTS
   Ubuntu-22.04                           Ubuntu 22.04 LTS
-  Ubuntu-24.04                           Ubuntu 24.04 LTS
 ...
 
-``` 
-
-Your list may be different once new distributions become available.  
-
-You can install a version using a NAME from the output:
-
-```{code-block} text
-> wsl --install -d Ubuntu-24.04
 ```
 
-You'll see an indicator of the installation progress in the terminal:
+Install a specific Ubuntu distro using a NAME from the output:
+
+```{code-block} text
+> wsl --install Ubuntu-24.04
+```
+
+```{important}
+At time of writing, Ubuntu 24.04 LTS and later versions are download in [WSL's
+new tar-based format](https://ubuntu.com/blog/ubuntu-wsl-new-format-available).
+Earlier Ubuntu versions are currently downloaded in the old format. The new format
+requires WSL 2.4.10 or higher.
+```
+
+### Method 2: Download and install from the Ubuntu archive
+
+Ubuntu images for WSL can be downloaded directly from [ubuntu.com/wsl](https://ubuntu.com/desktop/wsl).
+
+The image has a `.wsl` extension and can be installed in two ways:
+
+1. Double-clicking the downloaded file
+2. Running `wsl --install --from-file <image>.wsl` in the download directory
+
+This method has advantages in some contexts:
+
+* Access to the Microsoft Store is not required
+* Images can be self-hosted on an internal network
+* Custom installations can be created by modifying the image
+
+> Read our [blog post](https://ubuntu.com/blog/ubuntu-wsl-new-format-available)
+about the new format and [Microsoft's guide on building custom WSL
+distros](https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro).
+
+
+### Method 3: Install from the Microsoft Store
+
+Find the Ubuntu distribution that you want in the Microsoft Store and click **Get**.
+
+![Installation page for Ubuntu 24.04 LTS in the Microsoft store.](assets/install-ubuntu-wsl2/choose-distribution.png)
+
+Once installed, you can either launch Ubuntu 24.04 LTS directly from the Microsoft Store or search for Ubuntu in your Windows search bar.
+
+![Search results for Ubuntu 24.04 LTS in Windows search bar.](assets/install-ubuntu-wsl2/search-ubuntu-windows.png)
+
+## Starting an Ubuntu instance
+
+During installation of an Ubuntu distro, you are asked to create a username and password specific to that instance.
+This also starts an Ubuntu session and logs you in.
+
+After installation, you can open Ubuntu instances by:
+
+* Searching for them in the Window's search bar
+* Opening the dropdown in [Windows Terminal](https://github.com/microsoft/terminal?tab=readme-ov-file#installing-and-running-windows-terminal)
+* Running the `wsl -d <Distro>` command in PowerShell
+
+At any point, you can list the Ubuntu distros that you can start with `wsl -l -v`.
+
+## Starting an instance in the right directory
+
+By default, if you open Ubuntu using the Windows search bar or the Windows Terminal dropdown,
+the instance starts in the Ubuntu home directory.
+
+When starting an instance from the terminal, the command run determines the starting directory.
+
+### Start Ubuntu in the current Windows directory from the terminal
+
+When you open PowerShell, the working Windows directory is `C:\Users\username`.
+
+Run `wsl -d <Distro>` to start an Ubuntu session in that directory. The prompt
+will indicate that the Windows `C:` drive is mounted to Ubuntu and that you are
+in the Windows home directory:
 
 ```{code-block} text
 :class: no-copy
-Installing: Ubuntu 24.04 LTS
-[==========================72,0%==========                 ]
+username@pc:/mnt/c/Users/username$
 ```
 
-Use `wsl -l -v` to see all your currently installed distros and the version of WSL that they are using:
+### Start Ubuntu in the Ubuntu home directory from the terminal
+
+When in a directory in the mounted `C:` drive, you can change to the Ubuntu
+home directory with:
 
 ```{code-block} text
-:class: no-copy
-  NAME            STATE           VERSION
-  Ubuntu-20.04    Stopped         2
-* Ubuntu-24.04    Stopped         2
+username@pc:/mnt/c/Users/username$ cd ~
 ```
 
-## Note on installing images without the Microsoft Store
-
-If you do not have access to the Microsoft Store or need to install
-a custom image it is possible to import a distribution as a tar file:
+To skip this step, and start an instance from PowerShell with Ubuntu home as
+the working directory, run:
 
 ```{code-block} text
-> wsl --import <DistroName> <InstallLocation> <InstallTarFile>
-```
-Appx and MSIX packages for a given distro can also be downloaded and installed.
-Please refer to Microsoft's documentation for more detailed information on these installation methods:
-
-- [Importing Linux distributions](https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro)
-- [Installing distributions without the Microsoft Store](https://learn.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions)
-
-```{warning}
-You should always try to use the latest LTS release of Ubuntu, as it offers the best security, reliability and support when using Ubuntu WSL.
-
-Currently we do not have a recommended location from which to download tar and Appx/MSIX files for Ubuntu distros.
+> wsl ~ -d Ubuntu
 ```
 
-## Run and configure Ubuntu
-
-To open an Ubuntu 24.04 terminal run the following command in PowerShell:
+````{tip}
+For the **default Ubuntu distro only**, this command can be shortened further to:
 
 ```{code-block} text
-> ubuntu2404.exe 
+> wsl ~
 ```
 
-Once it has finished its initial setup, you will be prompted to create a username and password. They don't need to match your Windows user credentials.
-
-Finally, it’s always good practice to install the latest updates by running the following commands within the Ubuntu terminal, entering your password when prompted:
-
-```{code-block} text
-$ sudo apt update
-$ sudo apt full-upgrade -y
-```
+````
 
 ## Enjoy Ubuntu on WSL
 
-In this guide, we’ve shown you how to install Ubuntu WSL on Windows 10 or 11.
+In this guide, we’ve shown you how to install Ubuntu WSL using different methods.
 
 We hope you enjoy working with Ubuntu in WSL. Don’t forget to check out [our blog](https://ubuntu.com/blog) for the latest news on all things Ubuntu.
 
-### Further Reading
+## Further Reading
 
+* [Read a detailed reference on WSL terminal commands](https://learn.microsoft.com/en-us/windows/wsl/basic-commands)
 * [Setting up WSL for Data Science](https://ubuntu.com/blog/upgrade-data-science-workflows-ubuntu-wsl)
 * [Whitepaper: Ubuntu WSL for Data Scientists](https://ubuntu.com/engage/ubuntu-wsl-for-data-scientists)
 * [Microsoft WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/)

--- a/docs/howto/verify-subscribe-attach.md
+++ b/docs/howto/verify-subscribe-attach.md
@@ -36,14 +36,14 @@ To verify Pro-attachment a new Ubuntu instance needs to be created.
 Running the following command in PowerShell will create a new Ubuntu-24.04 instance
 and prompt you to create a username and password for the machine:
 
-```text
-PS C:\Users\me\up4wInstall> ubuntu2404.exe
+```{code-block} text
+PS C:\Users\me\up4wInstall> wsl ~ -d Ubuntu-24.04
 ```
 
 You will now be logged in to the new instance shell and can
 check that UP4W has Pro-attached this instance with:
 
-```text
+```{code-block} text
 u@mib:~$ pro status
 ```
 
@@ -54,7 +54,8 @@ The output will confirm the following:
 - Verification of Pro-attachment
 
 
-```text
+```{code-block} text
+:class: no-copy
 SERVICE          ENTITLED  STATUS       DESCRIPTION
 esm-apps         yes       enabled      Expanded Security Maintenance for Applications
 esm-infra        yes       enabled      Expanded Security Maintenance for Infrastructure
@@ -73,7 +74,7 @@ Each new Ubuntu WSL instance that is created should automatically now be Pro-att
 
 To find other useful Ubuntu pro commands run:
 
-```text
+```{code-block} text
 u@mib:~$ pro status
 ```
 

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -8,22 +8,28 @@ myst:
 (reference::distros)=
 # Distributions of Ubuntu on WSL
 
-Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. Several releases of the Ubuntu distro are available for WSL.
 
-Each release of Ubuntu for WSL is available as an application from the Microsoft Store. Once a release is [installed](https://documentation.ubuntu.com/wsl/en/latest/howto/install-ubuntu-wsl2/#method-1-microsoft-store-application), it will be available to use in your WSL environment.
+Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. Several releases of the Ubuntu distro are available for WSL.
 
 (reference::releases)=
 ## Releases of Ubuntu on WSL
 
-These are the releases of Ubuntu that we support and that are available on the Microsoft Store:
-
-- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS (Long Term Support) release of Ubuntu. When new LTS versions are released, this release of Ubuntu can be upgraded once the first point release is available.
-- Numbered releases -- for example, [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) -- refer to specific Long Term Stability (LTS) releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
-- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu, which previews new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
-
 ```{admonition} Interim releases
 :class: seealso
 Interim releases of Ubuntu are currently not supported on WSL.
+```
+
+These are the releases of Ubuntu that we support for WSL and that are available on the Microsoft Store:
+
+- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS (Long Term Support) release of Ubuntu. When new LTS versions are released, this release of Ubuntu can be upgraded once the first point release is available.
+- Numbered releases --- for example, [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) --- refer to specific Long Term Stability (LTS) releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
+- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu, which previews new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
+
+```{tip}
+Ubuntu 24.04 LTS is available in the [new WSL distro
+format](https://ubuntu.com/blog/ubuntu-wsl-new-format-available), which can be
+installed directly from [ubuntu.com/wsl](https://ubuntu.com/desktop/wsl)
+without the Microsoft Store.
 ```
 
 (naming)=
@@ -31,10 +37,19 @@ Interim releases of Ubuntu are currently not supported on WSL.
 
 Depending on context, releases of Ubuntu are referred to by different names: 
 
-1. **App name** is the name of the application for a specific Ubuntu release that you will see in the Microsoft Store.
+1. **App name** is the name of the application for an Ubuntu release that appears in the Microsoft Store or as FRIENDLY NAME when you run the `wsl -l -v` command.
 2. **AppxPackage name** is the name that can be passed to `Get-AppxPackage -Name` in PowerShell to get information about an installed package.
-3. **Distro name** is the name logged when you invoke `wsl -l -v` to list installed releases of Ubuntu.
+3. **Distro name** is the NAME logged when you invoke `wsl -l -v` to list installed releases of Ubuntu.
 4. **Executable name** is the program you need to run to start the Ubuntu distro.
+
+```{note}
+WSL distros are transitioning from an appx-based architecture to a tar-based architecture.
+The prior architecture involved building WSL distros as an AppxPackage; after installation,
+they could be run with `<distro name>.exe`.
+
+The more recent tar-based distros are available as images with the `.wsl` extension and must be run
+with `wsl -d <distro name>`.
+```
 
 These naming conventions are summarised in the table below:
 

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -7,20 +7,21 @@ myst:
 
 # Develop with Ubuntu on WSL
 
-The easiest way to access your Ubuntu development environment in WSL is by using Visual Studio Code via the built-in `Remote` extension.
+Ubuntu on WSL can be used as a powerful development environment on Windows and
+offers excellent integration with developer tools like Visual Studio Code.
 
 ## What you will learn
 
-* How to install WSL and Ubuntu on WSL from the terminal
-* How to set up Visual Studio Code for remote development with Ubuntu on WSL
-* How to create a basic Node.js webserver on Ubuntu using Visual Studio Code
-* How to preview HTML served from an Ubuntu WSL instance in a native browser on Windows
+* Installing WSL and Ubuntu on WSL from the terminal
+* Setting up Visual Studio Code for remote development with Ubuntu on WSL
+* Creating a basic Node.js webserver on Ubuntu using Visual Studio Code
+* Previewing HTML served from an Ubuntu WSL instance in a native browser on Windows
 
 ## What you will need
 
-* A PC with Windows 10 or 11
+* A machine running Windows 10 or 11
 
-## Install Ubuntu on WSL2
+## Install Ubuntu on WSL
 
 ### Install WSL
 
@@ -30,43 +31,46 @@ Open a PowerShell prompt as an Administrator and run:
 > wsl --install
 ```
 
-This command will enable the features necessary to run WSL and also install the latest Ubuntu distribution available for WSL. It is recommended to reboot your machine after this initial installation to complete the setup.
+This command will enable the features necessary to run WSL and installs the
+latest Ubuntu distribution available for WSL.
 
-### Install Ubuntu on WSL
+As this step creates an Ubuntu instance, you will be prompted to create a username
+and password. An Ubuntu terminal will then open automatically.
 
-WSL supports a variety of Ubuntu releases. Check our [reference on the distributions](../reference/distributions.md) for more information.
+Changing from PowerShell to Ubuntu is indicated by a change in the terminal prompt.
 
-There are multiple ways of installing Ubuntu on WSL, here we focus on using the terminal.
-For other installation methods, refer to your dedicated guide:
-
-* [Install Ubuntu on WSL2](../howto/install-ubuntu-wsl2.md)
-
-In a PowerShell terminal, run `wsl --list --online` to see all available distros and versions:
+**PowerShell prompt**:
 
 ```{code-block} text
 :class: no-copy
-The following is a list of valid distributions that can be installed.
-The default distribution is denoted by '*'.
-Install using 'wsl --install -d <Distro>'.
+PS C:\Users\username>
+```
 
-  NAME                                   FRIENDLY NAME
-* Ubuntu                                 Ubuntu
-  Debian                                 Debian GNU/Linux
-  kali-linux                             Kali Linux Rolling
-  Ubuntu-18.04                           Ubuntu 18.04 LTS
-  Ubuntu-20.04                           Ubuntu 20.04 LTS
-  Ubuntu-22.04                           Ubuntu 22.04 LTS
-  Ubuntu-24.04                           Ubuntu 24.04 LTS
-...
-
-``` 
-
-Your list may be different once new distributions become available.  
-
-You can install a version using a NAME from the output, for example:
+**Ubuntu prompt**:
 
 ```{code-block} text
-> wsl --install -d Ubuntu-24.04
+:class: no-copy
+username@pc:~$
+```
+
+To exit the Ubuntu terminal, type the `exit` command and execute it by pressing
+<kbd>enter</kbd>, which will return you to the PowerShell prompt.
+
+```{tip}
+It is recommended to reboot your machine after this initial installation to
+complete the setup.
+```
+
+### Install a specific version of Ubuntu on WSL
+
+There are multiple ways of installing Ubuntu on WSL, here we focus on using the
+terminal. For more detail on installation methods for Ubuntu on WSL, refer to
+our [dedicated installation guide](../howto/install-ubuntu-wsl2.md).
+
+To install Ubuntu 24.04 LTS, run the following command in a PowerShell terminal:
+
+```{code-block} text
+> wsl --install Ubuntu-24.04
 ```
 
 You'll see an indicator of the installation progress in the terminal:
@@ -77,26 +81,45 @@ Installing: Ubuntu 24.04 LTS
 [==========================72,0%==========                 ]
 ```
 
-Use `wsl -l -v` to see all your currently installed distros and the version of WSL they are using:
+```{note}
+WSL supports a variety of Ubuntu releases. Read our [reference on distributions
+of Ubuntu on WSL](../reference/distributions.md) for more information.
+```
+
+### Run a specific Ubuntu version
+
+Use `wsl -l -v` to list all your installed distros and the version of WSL that they are using:
 
 ```{code-block} text
 :class: no-copy
   NAME            STATE           VERSION
-  Ubuntu-20.04    Stopped         2
+  Ubuntu          Stopped         2
 * Ubuntu-24.04    Stopped         2
 ```
 
+Two instances of Ubuntu are installed:
+
+1. The default Ubuntu version that was installed automatically when you installed WSL
+2. The numbered Ubuntu version that you installed manually
+
+You can open a specific instance from PowerShell using its NAME:
+
+```{code-block} text
+> wsl ~ -d Ubuntu-24.04
+```
+
+The `~` is passed to the `wsl command` to start the instance in the Ubuntu home directory,
+the `-d` flag is added before specifying a distro.
+
 ## Install Visual Studio Code on Windows
 
-One of the advantages of WSL is that it can interact with the native Windows version of Visual Studio Code using its remote development extension.
+One of the advantages of WSL is its integration with native Windows applications, such as Visual Studio Code.
 
-To install Visual Studio Code, visit the Microsoft Store and search for Visual Studio Code.
-
-Then click **Install**.
+Search for "Visual Studio Code" in the Microsoft Store and install it.
 
 ![Installation page for Visual Studio Code on the Microsoft Store.](assets/vscode/msstore.png)
 
-Alternatively, you can install Visual Studio Code from the web link [here](https://code.visualstudio.com/Download).
+Alternatively, you can install Visual Studio Code from the [web link](https://code.visualstudio.com/Download).
 
 ![Visual Studio Code download page showing download options for Windows, Linux, and Mac.](assets/vscode/download-vs-code.png)
 
@@ -114,23 +137,17 @@ This is an extension pack that allows you to open any folder in a container, rem
 
 ![Installation page for the Remote Development Visual Studio Code extension.](assets/vscode/remote-extension.png)
 
-Once installed we can test it out by creating an example local web server with Node.js
+Once installed you can test the development environment by creating an example local web server with Node.js
 
 ## Install Node.js and create a new project
 
-Open your Ubuntu WSL terminal and ensure everything is up to date by typing:
+Open an Ubuntu terminal using the `wsl ~ -d Ubuntu24.04` command.
+
+Ensure the packages in Ubuntu are up-to-date with the following command:
 
 ```{code-block} text
-$ sudo apt update
+$ sudo apt update && sudo apt upgrade -y
 ```
-
-Then:
-
-```{code-block} text
-$ sudo apt upgrade -y
-```
-
-Entering your password when prompted.
 
 Next, install Node.js and npm:
 
@@ -139,27 +156,25 @@ $ sudo apt-get install nodejs
 $ sudo apt install npm
 ```
 
-Press `Y` when prompted.
-
-Now, create a new folder for our server.
+Create a directory for your server.
 
 ```{code-block} text
 $ mkdir serverexample/
 ```
 
-Then navigate into it:
+Change into that directory:
 
 ```{code-block} text
 $ cd serverexample/
 ```
 
-Now, open up your folder in Visual Studio Code, with the following command:
+Then open the directory in Visual Studio Code:
 
 ```{code-block} text
 $ code .
 ```
 
-The first time you do this, it will trigger a download for the necessary dependencies:
+The first time you do run `code` from Ubuntu, it will trigger a download of the necessary dependencies:
 
 ![Bash snippet showing the installation of Visual Studio Code Server's required dependencies.](assets/vscode/downloading-vscode-server.png)
 
@@ -167,7 +182,7 @@ Once complete, your native version of Visual Studio Code will open the folder.
 
 ## Creating a basic web server
 
-In Visual Studio Code, create a new `package.json` file and add the following text ([original example](https://learn.microsoft.com/en-gb/archive/blogs/cdndevs/visual-studio-code-and-local-web-server#3-add-a-packagejson-file-to-the-project-folder))
+In Visual Studio Code, create a new `package.json` file and add the following text:
 
 ```{code-block} json
 {
@@ -186,7 +201,7 @@ In Visual Studio Code, create a new `package.json` file and add the following te
 }
 ```
 
-Save the file and then, in the same folder, create a new one called `index.html`
+Save the file and then --- in the same folder --- create a new one called `index.html`
 
 Add the following text, then save and close:
 
@@ -206,7 +221,7 @@ Finally, type the following to launch the web server:
 $ npm start
 ```
 
-You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+LeftClick` on the terminal links.
+You can now navigate to `localhost:10001` in your native Windows web browser by using <kbd>CTRL</kbd>+<kbd>LeftClick</kbd> on the terminal links.
 
 ![Windows desktop showing a web server being run from a terminal with "npm start", A Visual Studio Code project with a "hello world" html file, and a web browser showing the "hello world" page being served on local host.](assets/vscode/hello-world.png)
 


### PR DESCRIPTION
Updates the documentation to include WSL's new distribution format and recommend different wsl commands for common tasks.

# Main changes

* Defaulting to `wsl -d <Distro>` to run instances instead of `<Distro>.exe`
* Referencing use of `wsl ~` to start a distro in Ubuntu home dir, as opening in mounted C drive could be unexpected for users
* Changing to `wsl --install <Distro>` instead of `wsl --install -d <Distro>`
* Adding section on tar-based Ubuntu distros to install guide
* Adding explanatory notes on new distro format in relevant pages

As we are still in a transitionary phase between the old and new formats, we shouldn't remove information on the old format yet; for example, the reference page on Ubuntu distributions still talks about the AppxPackage, etc. There, I added an explanatory note about the two formats.

# Future work

* When other Ubuntu on WSL releases are migrated, we will need to revisit the documentation again to reflect the increased availability of Ubuntu in the new format.
* We could offer guidance on customising and deploying Ubuntu tar-based distros, in addition to a dedicated explanation of the new format and its advantages, but that is outside scope for this PR.

# Other minor changes

* Some additions to the tutorial to better meet the needs of beginner users (installing, running, exiting)
* Fixed some code blocks that didn't use our regex for excluding prompt icons or our no-copy-button for output logs
* General edits to improve flow and consistency

UDENG-6995