### PR TITLE
docs: build sitemap for WSL docs

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -1,3 +1,4 @@
 canonical-sphinx[full]
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
+sphinx-sitemap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,6 +169,24 @@ html_theme_options = {
 
 slug = "wsl"
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = "https://documentation.ubuntu.com/wsl/"
+
+# URL scheme. Add language and version scheme elements manually e.g. '{0}/{1}/{{link}}'.format(os.environ['READTHEDOCS_LANGUAGE'], os.environ['READTHEDOCS_VERSION'])
+
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "stable/{link}"
+
 
 # Template and asset locations
 
@@ -287,6 +305,7 @@ extensions = [
     "sphinxcontrib.cairosvgconverter",
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
+    "sphinx_sitemap",
 ]
 
 # Excludes files or directories from processing


### PR DESCRIPTION
A sitemap improves search engine performance but is currently not available for the Ubuntu on WSL docs.

The changes in this PR generate a `sitemap.xml` when the docs site is built, e.g.,

![Screenshot from 2025-06-16 16-02-49](https://github.com/user-attachments/assets/a7cca014-9054-4f81-8b2e-fa4f6c5bfcd9)

It can be accessed at `https://documentation.ubuntu.com/wsl/{version}/sitemap.xml` after the PR is merged (note: won't be available in stable until next release).

Similar changes are being rolle out across all Canonical product documentation sites.

UDENG-7165