### PR TITLE
maint: Regenerate dart bindings

### DIFF
--- a/agentapi/dart/lib/src/agentapi.pb.dart
+++ b/agentapi/dart/lib/src/agentapi.pb.dart
@@ -1,7 +1,7 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: agentapi.proto
-//
+// Generated from agentapi.proto.
+
 // @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references

--- a/agentapi/dart/lib/src/agentapi.pbenum.dart
+++ b/agentapi/dart/lib/src/agentapi.pbenum.dart
@@ -1,11 +1,12 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: agentapi.proto
-//
+// Generated from agentapi.proto.
+
 // @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 

--- a/agentapi/dart/lib/src/agentapi.pbgrpc.dart
+++ b/agentapi/dart/lib/src/agentapi.pbgrpc.dart
@@ -1,7 +1,7 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: agentapi.proto
-//
+// Generated from agentapi.proto.
+
 // @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
@@ -30,48 +30,50 @@ class UIClient extends $grpc.Client {
     '',
   ];
 
-  static final _$applyProToken = $grpc.ClientMethod<$0.ProAttachInfo, $0.SubscriptionInfo>(
-      '/agentapi.UI/ApplyProToken',
-      ($0.ProAttachInfo value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.SubscriptionInfo.fromBuffer(value));
-  static final _$applyLandscapeConfig = $grpc.ClientMethod<$0.LandscapeConfig, $0.LandscapeSource>(
-      '/agentapi.UI/ApplyLandscapeConfig',
-      ($0.LandscapeConfig value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.LandscapeSource.fromBuffer(value));
-  static final _$ping = $grpc.ClientMethod<$0.Empty, $0.Empty>(
-      '/agentapi.UI/Ping',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$getConfigSources = $grpc.ClientMethod<$0.Empty, $0.ConfigSources>(
-      '/agentapi.UI/GetConfigSources',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.ConfigSources.fromBuffer(value));
-  static final _$notifyPurchase = $grpc.ClientMethod<$0.Empty, $0.SubscriptionInfo>(
-      '/agentapi.UI/NotifyPurchase',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.SubscriptionInfo.fromBuffer(value));
-
   UIClient(super.channel, {super.options, super.interceptors});
 
-  $grpc.ResponseFuture<$0.SubscriptionInfo> applyProToken($0.ProAttachInfo request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.SubscriptionInfo> applyProToken($0.ProAttachInfo request, {$grpc.CallOptions? options,}) {
     return $createUnaryCall(_$applyProToken, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.LandscapeSource> applyLandscapeConfig($0.LandscapeConfig request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.LandscapeSource> applyLandscapeConfig($0.LandscapeConfig request, {$grpc.CallOptions? options,}) {
     return $createUnaryCall(_$applyLandscapeConfig, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.Empty> ping($0.Empty request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.Empty> ping($0.Empty request, {$grpc.CallOptions? options,}) {
     return $createUnaryCall(_$ping, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ConfigSources> getConfigSources($0.Empty request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.ConfigSources> getConfigSources($0.Empty request, {$grpc.CallOptions? options,}) {
     return $createUnaryCall(_$getConfigSources, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.SubscriptionInfo> notifyPurchase($0.Empty request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.SubscriptionInfo> notifyPurchase($0.Empty request, {$grpc.CallOptions? options,}) {
     return $createUnaryCall(_$notifyPurchase, request, options: options);
   }
+
+    // method descriptors
+
+  static final _$applyProToken = $grpc.ClientMethod<$0.ProAttachInfo, $0.SubscriptionInfo>(
+      '/agentapi.UI/ApplyProToken',
+      ($0.ProAttachInfo value) => value.writeToBuffer(),
+      $0.SubscriptionInfo.fromBuffer);
+  static final _$applyLandscapeConfig = $grpc.ClientMethod<$0.LandscapeConfig, $0.LandscapeSource>(
+      '/agentapi.UI/ApplyLandscapeConfig',
+      ($0.LandscapeConfig value) => value.writeToBuffer(),
+      $0.LandscapeSource.fromBuffer);
+  static final _$ping = $grpc.ClientMethod<$0.Empty, $0.Empty>(
+      '/agentapi.UI/Ping',
+      ($0.Empty value) => value.writeToBuffer(),
+      $0.Empty.fromBuffer);
+  static final _$getConfigSources = $grpc.ClientMethod<$0.Empty, $0.ConfigSources>(
+      '/agentapi.UI/GetConfigSources',
+      ($0.Empty value) => value.writeToBuffer(),
+      $0.ConfigSources.fromBuffer);
+  static final _$notifyPurchase = $grpc.ClientMethod<$0.Empty, $0.SubscriptionInfo>(
+      '/agentapi.UI/NotifyPurchase',
+      ($0.Empty value) => value.writeToBuffer(),
+      $0.SubscriptionInfo.fromBuffer);
 }
 
 @$pb.GrpcServiceName('agentapi.UI')
@@ -120,27 +122,32 @@ abstract class UIServiceBase extends $grpc.Service {
     return applyProToken($call, await $request);
   }
 
+  $async.Future<$0.SubscriptionInfo> applyProToken($grpc.ServiceCall call, $0.ProAttachInfo request);
+
   $async.Future<$0.LandscapeSource> applyLandscapeConfig_Pre($grpc.ServiceCall $call, $async.Future<$0.LandscapeConfig> $request) async {
     return applyLandscapeConfig($call, await $request);
   }
+
+  $async.Future<$0.LandscapeSource> applyLandscapeConfig($grpc.ServiceCall call, $0.LandscapeConfig request);
 
   $async.Future<$0.Empty> ping_Pre($grpc.ServiceCall $call, $async.Future<$0.Empty> $request) async {
     return ping($call, await $request);
   }
 
+  $async.Future<$0.Empty> ping($grpc.ServiceCall call, $0.Empty request);
+
   $async.Future<$0.ConfigSources> getConfigSources_Pre($grpc.ServiceCall $call, $async.Future<$0.Empty> $request) async {
     return getConfigSources($call, await $request);
   }
+
+  $async.Future<$0.ConfigSources> getConfigSources($grpc.ServiceCall call, $0.Empty request);
 
   $async.Future<$0.SubscriptionInfo> notifyPurchase_Pre($grpc.ServiceCall $call, $async.Future<$0.Empty> $request) async {
     return notifyPurchase($call, await $request);
   }
 
-  $async.Future<$0.SubscriptionInfo> applyProToken($grpc.ServiceCall call, $0.ProAttachInfo request);
-  $async.Future<$0.LandscapeSource> applyLandscapeConfig($grpc.ServiceCall call, $0.LandscapeConfig request);
-  $async.Future<$0.Empty> ping($grpc.ServiceCall call, $0.Empty request);
-  $async.Future<$0.ConfigSources> getConfigSources($grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.SubscriptionInfo> notifyPurchase($grpc.ServiceCall call, $0.Empty request);
+
 }
 @$pb.GrpcServiceName('agentapi.WSLInstance')
 class WSLInstanceClient extends $grpc.Client {
@@ -152,33 +159,35 @@ class WSLInstanceClient extends $grpc.Client {
     '',
   ];
 
-  static final _$connected = $grpc.ClientMethod<$0.DistroInfo, $0.Empty>(
-      '/agentapi.WSLInstance/Connected',
-      ($0.DistroInfo value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$proAttachmentCommands = $grpc.ClientMethod<$0.MSG, $0.ProAttachCmd>(
-      '/agentapi.WSLInstance/ProAttachmentCommands',
-      ($0.MSG value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.ProAttachCmd.fromBuffer(value));
-  static final _$landscapeConfigCommands = $grpc.ClientMethod<$0.MSG, $0.LandscapeConfigCmd>(
-      '/agentapi.WSLInstance/LandscapeConfigCommands',
-      ($0.MSG value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.LandscapeConfigCmd.fromBuffer(value));
-
   WSLInstanceClient(super.channel, {super.options, super.interceptors});
 
-  $grpc.ResponseFuture<$0.Empty> connected($async.Stream<$0.DistroInfo> request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.Empty> connected($async.Stream<$0.DistroInfo> request, {$grpc.CallOptions? options,}) {
     return $createStreamingCall(_$connected, request, options: options).single;
   }
 
   /// Reverse unary calls
-  $grpc.ResponseStream<$0.ProAttachCmd> proAttachmentCommands($async.Stream<$0.MSG> request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseStream<$0.ProAttachCmd> proAttachmentCommands($async.Stream<$0.MSG> request, {$grpc.CallOptions? options,}) {
     return $createStreamingCall(_$proAttachmentCommands, request, options: options);
   }
 
-  $grpc.ResponseStream<$0.LandscapeConfigCmd> landscapeConfigCommands($async.Stream<$0.MSG> request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseStream<$0.LandscapeConfigCmd> landscapeConfigCommands($async.Stream<$0.MSG> request, {$grpc.CallOptions? options,}) {
     return $createStreamingCall(_$landscapeConfigCommands, request, options: options);
   }
+
+    // method descriptors
+
+  static final _$connected = $grpc.ClientMethod<$0.DistroInfo, $0.Empty>(
+      '/agentapi.WSLInstance/Connected',
+      ($0.DistroInfo value) => value.writeToBuffer(),
+      $0.Empty.fromBuffer);
+  static final _$proAttachmentCommands = $grpc.ClientMethod<$0.MSG, $0.ProAttachCmd>(
+      '/agentapi.WSLInstance/ProAttachmentCommands',
+      ($0.MSG value) => value.writeToBuffer(),
+      $0.ProAttachCmd.fromBuffer);
+  static final _$landscapeConfigCommands = $grpc.ClientMethod<$0.MSG, $0.LandscapeConfigCmd>(
+      '/agentapi.WSLInstance/LandscapeConfigCommands',
+      ($0.MSG value) => value.writeToBuffer(),
+      $0.LandscapeConfigCmd.fromBuffer);
 }
 
 @$pb.GrpcServiceName('agentapi.WSLInstance')
@@ -210,6 +219,9 @@ abstract class WSLInstanceServiceBase extends $grpc.Service {
   }
 
   $async.Future<$0.Empty> connected($grpc.ServiceCall call, $async.Stream<$0.DistroInfo> request);
+
   $async.Stream<$0.ProAttachCmd> proAttachmentCommands($grpc.ServiceCall call, $async.Stream<$0.MSG> request);
+
   $async.Stream<$0.LandscapeConfigCmd> landscapeConfigCommands($grpc.ServiceCall call, $async.Stream<$0.MSG> request);
+
 }

--- a/agentapi/dart/lib/src/agentapi.pbjson.dart
+++ b/agentapi/dart/lib/src/agentapi.pbjson.dart
@@ -1,14 +1,14 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: agentapi.proto
-//
+// Generated from agentapi.proto.
+
 // @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;


### PR DESCRIPTION
The recommended way to install the Dart protoc plugin is via `dart pub global activate` which doesn't record the version in the pubspec files. While that command allows hardcoding the version, if we do so in the CI workflows/actions, then  it becomes one more place to upgrade from time to time and dependabot doesn't know how to handle that. So we trust that CI fails from time to time when a new version of that plugin is available. It'd be good if we turn that failure into an automated PR. That will come eventually. In the meanwhile I'm doing the regeneration of the bindings by hand :)

That should unblock the outstanding pull requests failing.