### PR TITLE
ci: QoL: Attempt to prevent reaching setup-protoc rate limit

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -18,6 +18,8 @@ jobs:
   quality-go:
     name: "Go Quality checks"
     strategy:
+      # Attempt to prevent reaching arduino/setup-protoc API rate limit.
+      max-parallel: 7
       fail-fast: false
       matrix:
         os: [ubuntu, windows]

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,5 +1,4 @@
 name: QA
-
 on:
   pull_request:
     paths-ignore:
@@ -17,9 +16,8 @@ concurrency:
 jobs:
   quality-go:
     name: "Go Quality checks"
+    permissions: {}
     strategy:
-      # Attempt to prevent reaching arduino/setup-protoc API rate limit.
-      max-parallel: 7
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
@@ -70,8 +68,9 @@ jobs:
         run: |
           dart pub global activate protoc_plugin
       - name: Quality check
-        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@main
+        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@setup-protoc-token
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ matrix.subproject }}
           go-tags: gowslmock
           tools-directory: ${{ github.workspace }}/tools


### PR DESCRIPTION
By passing a GH token with an empty permissions set. I tested this in a personal repository and it proved to be still possible to execute many actions we run in our CI while making sure in case downstream actions get compromised the permissions attached to our GH token are the minimum possible. [This run also confirms it](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/16355064325/job/46211266463?pr=1248).

For now the quality-go job points to a branch in the desktop-engineering project in which we pass the input token along. Once https://github.com/canonical/desktop-engineering/pull/69 is merged , I'll change this one again to point to main.

This is a quality of life improvement specially when dealing with dependabot PRs, which spawns lots of CI workflows often hitting the API rate limits.