### PR TITLE
ci: Passes along the GH token to prevent API rate limiting ...

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   quality-go:
     name: "Go Quality checks"
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +71,7 @@ jobs:
       - name: Quality check
         uses: canonical/desktop-engineering/gh-actions/go/code-sanity@main
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ matrix.subproject }}
           go-tags: gowslmock
           tools-directory: ${{ github.workspace }}/tools


### PR DESCRIPTION
when setting up protoc. Importantly the token we pass has an empty permissions set. I tested this in a personal repository and it proved to be still possible to execute many actions we run in our CI while making sure in case downstream actions get compromised the permissions attached to our GH token are the minimum possible. [This run also confirms it](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/16355485002/job/46212676558?pr=1256).

For now the quality-go job points to a branch in the desktop-engineering project in which we pass the input token along. Once https://github.com/canonical/desktop-engineering/pull/69 is merged , I'll change this one again to point to main.

This is a quality of life improvement specially when dealing with dependabot PRs, which spawns lots of CI workflows often hitting the API rate limits.