### PR TITLE
feat(msix): Integrates the App installer file

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: true
     description: "certificate_password to pass to sign the msix"
 
+outputs:
+  msix-version:
+    description: "The version of the built MSIX bundle"
+    value: ${{ steps.build.outputs.UP4W_VERSION }}
+
 runs:
   using: "composite"
   steps:
@@ -58,8 +63,24 @@ runs:
         $path = "$PWD/Msix/UbuntuProForWSL/Package.appxmanifest"
         $doc = [System.Xml.Linq.XDocument]::Load($path)
         $xName = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Identity")
-        $doc.Root.Element($xName).Attribute("Version").Value = "$UP4W_VERSION.0";
+        $doc.Root.Element($xName).Attribute("Version").Value = "${UP4W_VERSION}.0";
         $doc.Save($path)
+
+        # Do the same with the app installer file
+        # with both the app installer file and main bundle versions the same as $UP4W_VERSION.
+        $path = "$PWD/Msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller"
+        $doc = [System.Xml.Linq.XDocument]::Load($path)
+        $ns = $doc.Root.Name.Namespace
+        $doc.Root.SetAttributeValue("Version", "${UP4W_VERSION}.0")
+        $mainBundle = $doc.Root.Element($ns + "MainBundle")
+        if ($mainBundle) {
+          $mainBundle.SetAttributeValue("Version", "${UP4W_VERSION}.0")
+          $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${UP4W_VERSION}/UbuntuProForWSL_${UP4W_VERSION}.msixbundle")
+        }
+        $doc.Save($path)
+
+        # Outputs the version for the next steps
+        "UP4W_VERSION=${UP4W_VERSION}.0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
         # Set up the mock
         $env:UP4W_TEST_WITH_MS_STORE_MOCK=${{ inputs.mode == 'end_to_end_tests' && '1' || '$null'}}

--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   publish-msix:
+    permissions:
+      contents: write
     name: Publish MSIX app to the Microsoft Store
     runs-on: windows-latest
     steps:
@@ -16,8 +18,9 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
-      - name: Build MSIX app
+      - name: Build MSIX Bundle
         uses: ./.github/actions/build-msix
+        id: build-msix
         with:
           certificate: ${{ secrets.CERTIFICATE }}
           certificate_password: ${{ secrets.CERTIFICATE_PASSWORD }}
@@ -43,3 +46,16 @@ jobs:
           # Prepare and submit to the Store
           New-SubmissionPackage -ConfigPath .\msix\SBConfig.json
           Update-ApplicationSubmission -AppId $appid -SubmissionDataPath "out\appstore-submission.json" -PackagePath "out\appstore-submission.zip" -Force -Autocommit -ReplacePackages
+
+      - name: Create the GH Release
+        shell: powershell
+        needs: build-msix
+        id: create-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.build-msix.outputs.msix-version }}
+        run: |
+           # Intentionally not copying the msixbundle, as it is already uploaded to the store
+           # We wanted the msix bundle signed by the store instead, reason why we don't mark this as 'latest'
+           # and draft, so it doesn't appear as a published release.
+           gh release create "${env:tag}" --draft --latest=false --title="${env:tag}" --fail-on-no-commits --generate-notes "msix\UbuntuProForWSL.appinstaller"

--- a/msix/UbuntuProForWSL/Package.appxmanifest
+++ b/msix/UbuntuProForWSL/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="desktop desktop2 desktop6 virtualization uap uap3 uap5 rescap">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap13="http://schemas.microsoft.com/appx/manifest/uap/windows10/13" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="desktop desktop2 desktop6 virtualization uap uap3 uap5 uap13 rescap">
   <Identity Name="CanonicalGroupLimited.UbuntuPro" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" Version="0.0.0.0" />
   <Properties>
     <DisplayName>Ubuntu Pro for WSL</DisplayName>
@@ -14,10 +14,13 @@
         <virtualization:ExcludedKey>HKEY_CURRENT_USER\Software\</virtualization:ExcludedKey>
       </virtualization:ExcludedKeys>
     </virtualization:RegistryWriteVirtualization>
+    <uap13:AutoUpdate>
+      <uap13:AppInstaller File="UbuntuProForWSL.appinstaller" />
+    </uap13:AutoUpdate>
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
     <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Resources>

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AppInstaller
+	xmlns="http://schemas.microsoft.com/appx/appinstaller/2017/2"
+	Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.appinstaller"
+	Version="1.0.0.0">
+	<MainBundle
+		Name="UbuntuProForWSL"
+		Version="0.0.0.0"
+		Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0"
+		Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/0.0.0/UbuntuProForWSL_0.0.0.msixbundle" />
+	<Dependencies>
+		<Package
+		  Name="Microsoft.VCLibs.140.00.UWPDesktop"
+		  Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+		  Version="14.0.24217.0"
+	  ProcessorArchitecture="x64"
+		  Uri="https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx" />
+		<Package
+		  Name="Microsoft.VCLibs.140.00.UWPDesktop"
+		  Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+		  Version="14.0.24217.0"
+	  ProcessorArchitecture="arm"
+		  Uri="https://aka.ms/Microsoft.VCLibs.arm64.14.00.Desktop.appx" />
+	</Dependencies>
+	<UpdateSettings>
+		<OnLaunch HoursBetweenUpdateChecks="0" />
+		<AutomaticBackgroundTask />
+	</UpdateSettings>
+</AppInstaller>

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This URI must remain stable and always point to the most up-to-date version of the AppInstaller file. -->
+<!-- AppInstaller and MSIX Bundle versions herein referred are just placeholders modified by CI.
+See https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/.github/actions/build-msix/action.yml -->
 <AppInstaller
 	xmlns="http://schemas.microsoft.com/appx/appinstaller/2017/2"
 	Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.appinstaller"
@@ -22,6 +25,10 @@
 	  ProcessorArchitecture="arm"
 		  Uri="https://aka.ms/Microsoft.VCLibs.arm64.14.00.Desktop.appx" />
 	</Dependencies>
+	<!-- We don't expect users to interact with the GUI often, thus checking for updates on launch should be fine,
+	as the default behaviour is not to block the app launch. -->
+	<!-- Due the AutomaticBackgroundTask option the OS will check in the background for updates every 8h (in practice that means once a day for most people),
+	independent of whether the user has ineracted with the app on that particular day (but it must have done so at least once in life). -->
 	<UpdateSettings>
 		<OnLaunch HoursBetweenUpdateChecks="0" />
 		<AutomaticBackgroundTask />

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.wapproj
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.wapproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <ProjectGuid>a2df9d69-019e-4ca2-a856-785448ed3908</ProjectGuid>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <NoWarn>$(NoWarn);NU1702</NoWarn>
@@ -105,5 +105,10 @@
   <ItemGroup>
     <ProjectReference Include="..\agent\agent.vcxproj" />
     <ProjectReference Include="..\gui\gui.vcxproj" />
+  </ItemGroup>
+    <ItemGroup>
+    <Content Include="UbuntuProForWSL.appinstaller">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Spec WS044 and its backing proof of concept details the work being done here. Essentially we aim to provide an alternative to MS Store when distributing this application with some integration with the OS at least for automatic updates. Windows provides this feature via the App Installer file. This PR defines the app installer file for UP4W that assumes the MSIX packages will remain stored as GH release assets. Different from the PoC here we care about the packaging having a trusted signature, thus we cannot immediately publish it, instead the GH release automatically created by CI remains in draft until we acquire and upload the signed version and edit the release draft manually.

The targeted Windows versions are also changed, keeping consistency between the multiple places where we refer to them. 

Inspecting the "production" version of the msixbundle from [this run](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/16407431475) we can confirm that the app installer file was added to the package and its contents refer to the current repository tag:

<img width="1778" height="610" alt="image" src="https://github.com/user-attachments/assets/056ed99a-021b-4003-b7d5-4dc68a89ea3e" />


UDENG-7331