### PR TITLE
docs: fix incorrect Pro command

### DIFF
--- a/docs/howto/verify-subscribe-attach.md
+++ b/docs/howto/verify-subscribe-attach.md
@@ -75,7 +75,7 @@ Each new Ubuntu WSL instance that is created should automatically now be Pro-att
 To find other useful Ubuntu pro commands run:
 
 ```{code-block} text
-u@mib:~$ pro status
+u@mib:~$ pro --help
 ```
 
 (howto::verify-landscape)=


### PR DESCRIPTION
The incorrect command (`pro status`) was used for printing Pro's CLI options.

This replaces it with the correct command (`pro --help`).

UDENG-7627