### PR TITLE
fix tar create command, add one-file-system parameter to ignore chroot

### DIFF
--- a/docs/howto/custom-ubuntu-distro.md
+++ b/docs/howto/custom-ubuntu-distro.md
@@ -260,7 +260,7 @@ Then compress the rootfs, outputting the tarball to the parent directory:
 
 ```{code-block} text
 :caption: /home/\<username>/myNewUbuntu
-$ sudo tar -czvf --numeric-owner --absolute-names ../myNewUbuntu.tar .
+$ sudo tar --numeric-owner --absolute-names --one-file-system -czvf ../myNewUbuntu.tar .
 ```
 
 Then `cd` into the home directory and change the file extension of the distro


### PR DESCRIPTION
The documented tar command doesn't work as followed for two reasons:

1. The tar parameters are out of order, resulting in a failure.
2. The tar command does not ignore the chrooted directories, resulting in tar getting stuck.

Unsure if this is the best way to solve it as I looked around at the WSL image, ubuntu minimal, and even ubuntu base. Some stack overflow posts recommend re-mounting the rootfs to another path to also grab the statically-created files under /dev. However, in my testing it didn't appear this mattered as the WSL image loaded successfully and WSL re-created /dev.