### PR TITLE
docs: add release notes page

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -36,6 +36,8 @@ OpenVINO
 passwordless
 powershell
 PowerShell
+Quokka
+reproducibly
 rootfs
 rootFS
 SHA
@@ -60,10 +62,12 @@ autopkgtest
 autopkgtests
 backporting
 binfmt
+cdimage
 changelog
 compinit
 config
 dev
+exe
 gapped
 gpg
 grpc
@@ -79,6 +83,7 @@ Hostagent
 JWT
 localhost
 LTS
+MotD
 Numbat
 os
 pem
@@ -92,6 +97,7 @@ ssl
 tcp
 TLS
 toolchain
+upgrader
 url
 vGPU
 webserver
@@ -100,6 +106,7 @@ whitespace
 zshrc
 ESM
 Ok
+ppid
 scalability
 Snapcraft
 UTF

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ production in an enterprise environment.
 **Find technical information**, including:
 
 * [Ubuntu distributions available for WSL](/reference/distributions.md)
+* [Release notes for Ubuntu on WSL](/reference/release_notes.md)
 ```
 
 ```{grid-item-card} [Explanation](explanation/index)
@@ -63,6 +64,7 @@ production in an enterprise environment.
 **Build an understanding** of:
 
 * [The architecture of Ubuntu Pro for WSL](/explanation/ref-arch-explanation.md)
+* [Security overview for Ubuntu on WSL](/explanation/security-overview.md)
 ```
 
 ````

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -22,7 +22,7 @@ Interim releases of Ubuntu are currently not supported on WSL.
 These are the releases of Ubuntu that we support for WSL and that are available on the Microsoft Store:
 
 - [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS (Long Term Support) release of Ubuntu. When new LTS versions are released, this release of Ubuntu can be upgraded once the first point release is available.
-- Numbered releases --- for example, [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) --- refer to specific Long Term Stability (LTS) releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
+- Numbered releases --- for example, [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) --- refer to specific LTS releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
 - [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu, which previews new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
 
 ```{tip}

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -49,3 +49,13 @@ Information helpful for developers working on Ubuntu Pro for WSL.
 
 index_up4w_development
 ```
+
+## Release notes
+
+Highlights from the latest releases of Ubuntu on WSL and Ubuntu Pro for WSL:
+
+```{toctree}
+:titlesonly:
+
+Release notes <release_notes>
+```

--- a/docs/reference/release_notes.md
+++ b/docs/reference/release_notes.md
@@ -1,0 +1,149 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Release notes for Ubuntu on WSL and Ubuntu Pro for WSL."
+---
+
+(ref::release-notes)=
+# Release notes for Ubuntu on WSL
+
+This page includes:
+
+* [Release notes for LTS versions of Ubuntu on WSL](ref::ubuntu-wsl-lts-releases)
+* [Release notes for interim releases of Ubuntu on WSL](ref::ubuntu-wsl-interim-releases)
+* [Release notes for the Ubuntu Pro for WSL application](ref::up4w-releases)
+
+(ref::upgrade-instructions)=
+## Upgrade instructions for Ubuntu on WSL
+
+The default Ubuntu distro for WSL (`wsl --install Ubuntu`) always ships the
+latest stable LTS release, which can be upgraded once the first point release
+of a new LTS is available:
+
+```{code-block} text
+$ sudo apt update && sudo apt full-upgrade 
+$ do-release-upgrade
+```
+
+By default, Ubuntu distros downloaded as explicitly numbered releases (`wsl
+--install Ubuntu-24.04`) will not be upgraded in this manner, unless the
+following configuration change is made:
+
+```{code-block} diff
+:caption: /etc/update-manager/release-upgrades
+:class: no-copy
+- Prompt=never
++ Prompt=normal
+```
+
+(ref::latest-supported-releases)=
+## Latest supported releases
+
+```{admonition} LTS is recommended for Ubuntu on WSL
+:class: important
+We recommend LTS versions of Ubuntu on WSL, which receive standard support for
+five years.
+
+You can try interim releases of Ubuntu but they are not recommended for
+production.
+```
+
+(ref::ubuntu-wsl-lts-releases)=
+### Ubuntu on WSL distro (LTS)
+
+#### Ubuntu 24.04 LTS (Noble Numbat)
+
+##### Cloud-init support
+
+`cloud-init` is the *industry standard* multi-distribution method for cross-platform cloud instance initialisation. It is supported across all major public cloud providers, provisioning systems for private cloud infrastructure, and bare-metal installations.
+
+With `cloud-init` on WSL you can now automatically and reproducibly configure your WSL instances on first boot. Make the first steps with [this guide](https://documentation.ubuntu.com/wsl/stable/howto/cloud-init/).
+
+##### New documentation
+
+The documentation specific to [Ubuntu on WSL is available on Read the Docs](https://documentation.ubuntu.com/wsl). This evolving project is regularly updated with new content about Ubuntu’s specifics on WSL.
+
+##### Reduced footprint
+
+Experience faster download and installation times with 24.04, with a 200MB reduction in image size.
+
+##### Systemd by default
+
+systemd is now enabled by default even when the instance is launched directly from a terminal with the wsl.exe command or from an imported root files system.
+
+##### Point release changes
+
+###### 24.04.3
+
+* WSL setup: remove the `systemd-binfmt.service` override after WSL implemented a more robust binfmt protection mechanism.
+([wsl-setup/#11](https://github.com/ubuntu/wsl-setup/issues/11))
+
+* WSL setup: Fix an issue when the Windows user name contains non-ASCII characters
+([wsl-setup/#23](https://github.com/ubuntu/wsl-setup/issues/23))
+
+###### 24.04.2
+
+* WSL setup: Adapt to new Microsoft package format
+([2091293](https://bugs.launchpad.net/bugs/2091293))
+
+* Cloud init: Deliver warnings via MotD if cloud-init doesn’t succeed
+([2080223](https://bugs.launchpad.net/bugs/2080223)).
+
+###### 24.04.1
+
+* WSL setup: Override cloud-init default_user configuration for Ubuntu distros to
+prevent creation of a default user which confused WSLg
+([2065349](https://bugs.launchpad.net/bugs/2065349))
+
+(ref::up4w-releases)=
+### Ubuntu Pro for WSL
+
+This application is pending an official release of its 1.0 version.
+
+
+### Previous LTS distro releases
+
+```{dropdown} Ubuntu 22.04 LTS (Jammy Jellyfish)
+
+#### 22.04
+
+* Various bug fixes relating to the installer, UI and profile page
+
+##### Point release changes
+
+###### 22.04.4, 22.04.5
+
+* None
+
+###### 22.04.3
+
+* Fix for get_ppid() not working on WSL
+
+###### 22.04.2
+
+* Cherry-pick upstream patch to use more portable alignment to resolve failure to execute on WSL1.
+
+###### 22.04.1
+
+* Fixes and improvements to the store listing, slide show and release upgrader policy.
+
+```
+
+(ref::ubuntu-wsl-interim-releases)=
+### Interim distro releases
+
+
+```{dropdown} Click to expand for 25.04 (Plucky Puffin), and more...
+#### Ubuntu 25.04 (Plucky Puffin)
+
+* Published WSL images have moved to
+[cdimage.ubuntu.com](https://cdimage.ubuntu.com/ubuntu-wsl/) (previously on
+[cloud-images.ubuntu.com](http://cloud-images.ubuntu.com/)).
+
+#### Ubuntu 24.10 (Oracular Oriole)
+
+* None
+
+```
+


### PR DESCRIPTION
Adds a release notes page to the Reference section of the docs.

Goals:

* Have a single place to find Ubuntu-on-WSL-specific release notes
* Emphasise the latest supported versions of the distro and the Windows app
* Focus on highlights (this is not a changelog)
* Include notes for older LTS releases and interim releases in optional, dropdown sections

UDENG-7637