### PR TITLE
docs: add comparison of WSL versions and their impact on Ubuntu

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -69,6 +69,7 @@ gpg
 grpc
 https
 init
+IPv
 filesystem
 FIPS
 Fosstodon

--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -48,7 +48,7 @@ The differences between WSL 1 and WSL 2 and how it affects Ubuntu can be summari
 
 The differences between WSL 1 and WSL 2 have notable consequences for Ubuntu on WSL, largely due to the lack of systemd support on WSL 1. Systemd is a system and service management suite that Ubuntu and many applications for Ubuntu depend on. Most notably, [Snaps](https://snapcraft.io/) and [cloud-init](https://cloud-init.io/) do not work on WSL 1 due to the lack of support for systemd. There is also a lack of support for graphical applications on WSL 1.
 
-While Ubuntu for WSL will still work on WSL 1, the experience may be degraded. Thus, we generally recommend sticking to WSL 2 unless your use case has specific requirements that make WSL 1 a better fit.
+While Ubuntu works on WSL 1, the experience may be degraded relative to WSL 2. Thus, we generally recommend using WSL 2 unless you have specific requirements. For example, if you make extensive use of file interoperability between WSL and Windows, you may benefit from the better performance of WSL 1 in that specific area.
 
 ### How this affects Ubuntu Pro for WSL
 

--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -1,0 +1,59 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Read about the differences between major versions of WSL, such as WSL 1 and WSL 2, and how it affects Ubuntu on WSL."
+---
+
+# Comparing WSL versions for Ubuntu on WSL
+
+This page explains the main differences between different major versions of WSL and how they affect Ubuntu on WSL.
+
+## Background on WSL Versions
+
+WSL has had two major versions: WSL 1 and WSL 2. The default version on Windows is WSL 2, although it is possible to run individual Ubuntu instances using either version.
+
+There are significant architectural differences between the two versions, which can impact the behaviour of Ubuntu on WSL.
+
+## Overview of major differences between WSL 1 and WSL 2
+
+The primary difference between WSL 1 and WSL 2 is that WSL 1 functions as a compatibility layer, translating Linux system calls for the Windows kernel and providing only partial support for Linux system calls. In contrast, WSL 2 runs a full Linux kernel inside a lightweight virtual machine, offering complete system call compatibility. This fundamental architectural difference leads to significant variations in capabilities and performance between the two versions.
+
+As WSL 1 only has partial support for Linux system calls, some programs may not behave as expected when using WSL 1. Additionally, WSL 1 lacks support for graphical applications and systemd, a system and service management suite.
+
+In most cases, applications that are entirely contained in WSL will be faster on WSL 2, particularly for file IO intensive applications. However, WSL 1 has faster access to files mounted from Windows, so for certain use cases, WSL 1 may be faster.
+
+## Summary of feature support across WSL versions
+
+The differences between WSL 1 and WSL 2 and how it affects Ubuntu can be summarised with the table below:
+
+| Feature                                                               | WSL 1 | WSL 2 |
+| --------------------------------------------------------------------- | ----- | ----- |
+| Integration between Windows and Linux                                 | ✅    | ✅    |
+| Fast boot times                                                       | ✅    | ✅    |
+| Small resource footprint compared to traditional Virtual Machines     | ✅    | ✅    |
+| Managed VM                                                            | ⛔    | ✅    |
+| Full Linux Kernel                                                     | ⛔    | ✅    |
+| Full system call compatibility                                        | ⛔    | ✅    |
+| High performance across OS file systems                               | ✅    | ⛔    |
+| systemd support                                                       | ⛔    | ✅    |
+| IPv6 support                                                          | ✅    | ✅    |
+| Graphical application support                                         | ⛔    | ✅    |
+| [Snap](https://snapcraft.io/) support                                 | ⛔    | ✅    |
+| [cloud-init](https://cloud-init.io/) support                          | ⛔    | ✅    |
+| [Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) support | ⛔    | ✅    |
+| [Landscape](ref::landscape-client) support                            | ⛔    | ✅    |
+| [Ubuntu Pro Client](ref::ubuntu-pro-client) support                   | ⚠️    | ✅    |
+
+### How this affects Ubuntu for WSL
+
+The differences between WSL 1 and WSL 2 have notable consequences for Ubuntu on WSL, largely due to the lack of systemd support on WSL 1. Systemd is a system and service management suite that Ubuntu and many applications for Ubuntu depend on. Most notably, [Snaps](https://snapcraft.io/) and [cloud-init](https://cloud-init.io/) do not work on WSL 1 due to the lack of support for systemd. There is also a lack of support for graphical applications on WSL 1.
+
+While Ubuntu for WSL will still work on WSL 1, the experience may be degraded. Thus, we generally recommend sticking to WSL 2 unless your use case has specific requirements that make WSL 1 a better fit.
+
+### How this affects Ubuntu Pro for WSL
+
+[Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) relies on systemd for much of its functionality, including automatic Pro attachment, so it does not support WSL 1. For the same reason, the [Landscape](ref::landscape-client) tool for remote management of Ubuntu instances is also not supported on WSL 1. You can still manually attach your WSL 1 instance to [Ubuntu Pro](https://documentation.ubuntu.com/pro/) using the [Ubuntu Pro Client](ref::ubuntu-pro-client), although some of Ubuntu Pro's features may not work on WSL 1.
+
+## Further reading
+
+- Visit the [Microsoft WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/compare-versions) for additional information on the differences between WSL 1 and WSL 2.

--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -26,23 +26,23 @@ In most cases, applications that are entirely contained in WSL will be faster on
 
 The differences between WSL 1 and WSL 2 and how it affects Ubuntu can be summarised with the table below:
 
-| Feature                                                               | WSL 1 | WSL 2 |
-| --------------------------------------------------------------------- | ----- | ----- |
-| Integration between Windows and Linux                                 | ✅    | ✅    |
-| Fast boot times                                                       | ✅    | ✅    |
-| Small resource footprint compared to traditional Virtual Machines     | ✅    | ✅    |
-| Managed VM                                                            | ⛔    | ✅    |
-| Full Linux Kernel                                                     | ⛔    | ✅    |
-| Full system call compatibility                                        | ⛔    | ✅    |
-| High performance across OS file systems                               | ✅    | ⛔    |
-| systemd support                                                       | ⛔    | ✅    |
-| IPv6 support                                                          | ✅    | ✅    |
-| Graphical application support                                         | ⛔    | ✅    |
-| [Snap](https://snapcraft.io/) support                                 | ⛔    | ✅    |
-| [cloud-init](https://cloud-init.io/) support                          | ⛔    | ✅    |
-| [Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) support | ⛔    | ✅    |
-| [Landscape](ref::landscape-client) support                            | ⛔    | ✅    |
-| [Ubuntu Pro Client](ref::ubuntu-pro-client) support                   | ⚠️    | ✅    |
+| Feature                                                               |         WSL 1          |       WSL 2        |
+| --------------------------------------------------------------------- | :--------------------: | :----------------: |
+| Integration between Windows and Linux                                 |   {bdg-success}`Yes`   | {bdg-success}`Yes` |
+| Fast boot times                                                       |   {bdg-success}`Yes`   | {bdg-success}`Yes` |
+| Small resource footprint compared to traditional Virtual Machines     |   {bdg-success}`Yes`   | {bdg-success}`Yes` |
+| Managed VM                                                            |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| Full Linux Kernel                                                     |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| Full system call compatibility                                        |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| High performance across OS file systems                               |   {bdg-success}`Yes`   |  {bdg-danger}`No`  |
+| systemd support                                                       |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| IPv6 support                                                          |   {bdg-success}`Yes`   | {bdg-success}`Yes` |
+| Graphical application support                                         |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| [Snap](https://snapcraft.io/) support                                 |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| [cloud-init](https://cloud-init.io/) support                          |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| [Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) support |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| [Landscape](ref::landscape-client) support                            |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| [Ubuntu Pro Client](ref::ubuntu-pro-client) support                   | {bdg-warning}`Partial` | {bdg-success}`Yes` |
 
 ### How this affects Ubuntu for WSL
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -33,3 +33,12 @@ Explore how Ubuntu on WSL can be used safely and securely.
 
 security-overview
 ```
+
+## Comparing WSL versions for Ubuntu on WSL
+
+Read about the differences between major versions of WSL, such as WSL 1 and WSL 2, and how it affects Ubuntu on WSL.
+
+```{toctree}
+:titlesonly:
+compare-wsl-versions
+```


### PR DESCRIPTION
This PR adds a new page to the documentation on the differences between the major versions of WSL and how these differences affect Ubuntu for WSL and Ubuntu Pro for WSL.

A quick summary table as well as more detailed explanations are included on the page. Links to relevant pages of the documentation, both internal and external, are included.

The titles and internal page names are version agnostic just in case there is ever a WSL 3. If that ever is the case, then we can expand on this page without needing to change links or titles.

<img width="2950" height="2634" alt="image" src="https://github.com/user-attachments/assets/e4e4143f-1ac0-4931-bd7a-c7017697ea4e" />

---
[UDENG-7644](https://warthogs.atlassian.net/browse/UDENG-7644)

[UDENG-7644]: https://warthogs.atlassian.net/browse/UDENG-7644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ