### PR TITLE
fix(docs): Clarify why removing .wslconfig in the UP4W tutorial

### DIFF
--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -68,11 +68,11 @@ The `wsl --install` command will download and install the latest Ubuntu distro,
 unless a distro with the name "Ubuntu" is already installed.
 ```
 
-Certain WSL global configurations may block the communication between the Ubuntu
-Pro for WSL and the WSL instances. For simplicity, if you already have WSL
-installed, with `~\.wslconfig` on your system, you are advised to backup the
-file then remove it before continuing the tutorial.
-For more information about `.wslconfig`, refer to [WSL docs](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig)
+Global configuration settings for WSL may block the communication between the Ubuntu
+Pro for WSL application and instances of Ubuntu on WSL. If you already have WSL
+installed, with `~\.wslconfig` on your system, we recommend that you back up the
+file, then remove it, before continuing the tutorial.
+For more information about `.wslconfig`, refer to the [WSL documentation from Microsoft](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig).
 
 To check if the file exists run the following in PowerShell:
 

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -68,8 +68,11 @@ The `wsl --install` command will download and install the latest Ubuntu distro,
 unless a distro with the name "Ubuntu" is already installed.
 ```
 
-If you already have WSL installed, with `~\.wslconfig` on your system, you
-are advised to backup the file then remove it before continuing the tutorial.
+Certain WSL global configurations may block the communication between the Ubuntu
+Pro for WSL and the WSL instances. For simplicity, if you already have WSL
+installed, with `~\.wslconfig` on your system, you are advised to backup the
+file then remove it before continuing the tutorial.
+For more information about `.wslconfig`, refer to [WSL docs](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig)
 
 To check if the file exists run the following in PowerShell:
 


### PR DESCRIPTION
Certain .wslconfig entries may break the communication between the Windows agent and the WSL pro service inside the instances. As we don't know the future to list them all and how they could break it, I just made a generic short line about this theme making things simple.

UDENG-7640