### PR TITLE
fix(docs): More emphasis about Landscape FQDN

### DIFF
--- a/docs/howto/set-up-landscape-client.md
+++ b/docs/howto/set-up-landscape-client.md
@@ -62,12 +62,27 @@ In the UP4W app navigate to the Landscape configuration screen:
 
 Choose your preferred configuration option and enter the required details.
 
-The "Advanced Configuration" option requires you to specify a `landscape.conf`.
+The "Manual configuration" is easier if the server was configured with the
+default options, only the "Landscape FQDN" field is trully required.
+Importantly, that field cannot have a complete URL, but rather the server's
+fully qualified domain name only. For user's commodity the field accepts
+a URL like `https://landscape-server.domain.com` but the `https://` part is
+removed from the address, resulting in the FQDN only. That's for allowing
+users to copy and paste the server address from a web browser address bar, for
+example.
+More complex URLs will be rejected and an error message will be shown.
+
+The "Advanced configuration" option requires you to specify a `landscape.conf`.
 Refer to the section on [Landscape client configuration](howto::config-landscape-client) for an example.
 
 When you continue a status screen will appear confirming that configuration is complete:
 
 ![Configuration is complete](../assets/status-complete.png)
+
+The application waits a fraction of second to confirm that the configuration
+data supplied resulted in a successful connection to the Landscape server. In
+case of errors a dialog presents the error details and lets you decide to edit
+the configuration and try again or simply proceed.
 
 ```
 
@@ -109,6 +124,12 @@ ssl_public_key = C:\Users\user\Downloads\landscape_server.pem
 ```
 
 ```{warning}
+The `url` field in the `[host]` section cannot be a true URL, but rather a fully
+qualified domain name (or IP address if your server was configured in that way)
+suffixed by a port (6554 by default) separated by a colon (`:`),
+as shown in the example above `landscape-server.domain.com:6554`. No scheme or
+other URL components are applicable.
+
 The `ping_url` must be a `http` address. A `https` address will not work.
 ```
 

--- a/docs/howto/set-up-landscape-client.md
+++ b/docs/howto/set-up-landscape-client.md
@@ -63,15 +63,16 @@ In the UP4W app navigate to the Landscape configuration screen:
 Choose your preferred configuration option and enter the required details.
 
 The "Manual configuration" is easier if the server was configured with the
-default options (you should double check with system administrator on that), for
+default options (if in doubt, check this with your system administrator), in
 which case only the "Landscape FQDN" field is truly required. This field does
 not accept a complete URL for the server (with paths and queries, for example),
 and a FQDN should always be used. The field accepts URLs like
-`https://landscape-server.domain.com` (with just scheme and host name) but the
-`https://` part (the scheme) is removed from the address, resulting in the FQDN
-only. This is for user convenience, as it allows you to copy and paste server
-addresses from a web browser address bar, for example. Richer URLs with queries,
-paths and fragments will rejected and an error message will be shown.
+`https://landscape-server.domain.com` (with a just scheme and a host name) but
+the `https://` part (the scheme) is removed from the address, resulting in the
+FQDN only. This is for user convenience, as it allows you to copy an address for
+a server from a web browser address bar, for example, and paste it into the
+field. Richer URLs with queries, paths and fragments will be rejected and an
+error message will be shown.
 
 The "Advanced configuration" option requires you to specify a `landscape.conf`.
 Refer to the section on [Landscape client configuration](howto::config-landscape-client) for an example.

--- a/docs/howto/set-up-landscape-client.md
+++ b/docs/howto/set-up-landscape-client.md
@@ -63,26 +63,28 @@ In the UP4W app navigate to the Landscape configuration screen:
 Choose your preferred configuration option and enter the required details.
 
 The "Manual configuration" is easier if the server was configured with the
-default options, only the "Landscape FQDN" field is trully required.
-Importantly, that field cannot have a complete URL, but rather the server's
-fully qualified domain name only. For user's commodity the field accepts
-a URL like `https://landscape-server.domain.com` but the `https://` part is
-removed from the address, resulting in the FQDN only. That's for allowing
-users to copy and paste the server address from a web browser address bar, for
-example.
-More complex URLs will be rejected and an error message will be shown.
+default options (you should double check with system administrator on that), for
+which case only the "Landscape FQDN" field is truly required. This field does
+not accept a complete URL for the server (with paths and queries, for example),
+and a FQDN should always be used. The field accepts URLs like
+`https://landscape-server.domain.com` (with just scheme and host name) but the
+`https://` part (the scheme) is removed from the address, resulting in the FQDN
+only. This is for user convenience, as it allows you to copy and paste server
+addresses from a web browser address bar, for example. Richer URLs with queries,
+paths and fragments will rejected and an error message will be shown.
 
 The "Advanced configuration" option requires you to specify a `landscape.conf`.
 Refer to the section on [Landscape client configuration](howto::config-landscape-client) for an example.
 
-When you continue a status screen will appear confirming that configuration is complete:
+When you continue, a status screen will appear confirming that configuration is complete:
 
 ![Configuration is complete](../assets/status-complete.png)
 
-The application waits a fraction of second to confirm that the configuration
+The application waits a short period of time to confirm that the configuration
 data supplied resulted in a successful connection to the Landscape server. In
-case of errors a dialog presents the error details and lets you decide to edit
-the configuration and try again or simply proceed.
+case of errors, a dialog presents the error details and lets you decide whether
+to edit the configuration and try again, or proceed with the configuration
+already provided.
 
 ```
 
@@ -124,11 +126,8 @@ ssl_public_key = C:\Users\user\Downloads\landscape_server.pem
 ```
 
 ```{warning}
-The `url` field in the `[host]` section cannot be a true URL, but rather a fully
-qualified domain name (or IP address if your server was configured in that way)
-suffixed by a port (6554 by default) separated by a colon (`:`),
-as shown in the example above `landscape-server.domain.com:6554`. No scheme or
-other URL components are applicable.
+The `url` field in the `[host]` section must be `FQDN:PORT`. An actual URL with
+scheme, path, queries and/or fragments would cause the connection to fail.
 
 The `ping_url` must be a `http` address. A `https` address will not work.
 ```


### PR DESCRIPTION
It has to be a Fully Qualified Domain Name. Submitting complete URLs break communication attempts in many ways. Those errors were mostly silent, specially when the user submitted the config via the Advanced configuration option (where they crafted the config by hand).

An effort is being made in #1285 to present those errors to the UI, but that's still not enough.

UDENG-7545