### PR TITLE
ci: Use go/code-sanity@v1

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           dart pub global activate protoc_plugin
       - name: Quality check
-        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@main
+        uses: canonical/desktop-engineering/gh-actions/go/code-sanity@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ matrix.subproject }}


### PR DESCRIPTION
We're about to merge a breaking change in the go/code-sanity GitHub Action ([use of golangci-lint v2 instead of v1](https://github.com/canonical/desktop-engineering/pull/75)), so to avoid breaking the CI, we need to switch to go/code-sanity@v1 instead of go/code-sanity@main.

Once the change has been merged, I will prepare a follow-up PR to migrate to golangci-lint v2.

UDENG-7801