### PR TITLE
fix(docs): Note about PowerShell version required

### DIFF
--- a/docs/howto/custom-rootfs-multiple-targets.md
+++ b/docs/howto/custom-rootfs-multiple-targets.md
@@ -27,7 +27,7 @@ To follow the steps outlined in this guide you can use either:
 - Familiarity with Bash and/or PowerShell.
 
 ```{note}
-Throughout this guide we assume PowerShell 7.0 or later. Some commands will fail on PowerShell 5.
+You need PowerShell 7.0 or later to follow this guide. Some commands will fail on PowerShell 5.
 You can check your PowerShell version by running the command `$PSVersionTable`.
 ```
 


### PR DESCRIPTION
To follow the howto/custom-rootfs-multiple-targets.md.

The rest of the documentation work on either PowerShell 5.1 or 7.0 and later without changes AFAICT, but this one is special because it assumes the `-Authentication` parameter is available for the `Invoke-WebRequest` cmdlet, which is only the case on PowerShell 6 (no longer supported) and later.

I'd add a note somewhere saying that throughout the documentation we assume PowerShell 5.1 or later, but I don't know where to place it 😅 . If you have recommendations I'm happy to implement them.


---

UDENG-7639
