### PR TITLE
ci: Avoid installing locales and man pages

### DIFF
--- a/.github/actions/update-workspace-dependencies/action.yaml
+++ b/.github/actions/update-workspace-dependencies/action.yaml
@@ -9,6 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -16,6 +16,7 @@ jobs:
     env:
       subprojects: windows-agent wsl-pro-service
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update
@@ -70,6 +71,7 @@ jobs:
     env:
       subprojects: windows-agent wsl-pro-service
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -105,6 +105,8 @@ jobs:
         uses: canonical/ubuntu-pro-for-wsl/.github/actions/setup-git@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
+        if: ${{ matrix.os == 'ubuntu' }}
       - name: Ensure dependencies on Ubuntu
         if: ${{ matrix.os == 'ubuntu' }}
         run: |
@@ -153,6 +155,8 @@ jobs:
         uses: canonical/ubuntu-pro-for-wsl/.github/actions/setup-git@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
+        if: ${{ matrix.os == 'ubuntu' }}
       - name: Ensure dependencies on Ubuntu
         if: ${{ matrix.os == 'ubuntu' }}
         run: |
@@ -218,6 +222,8 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v2
         if: matrix.subproject == 'storeapi/go-wrapper/microsoftstore'
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
+        if: ${{ matrix.os == 'ubuntu' }}
       - name: Install gettext on Linux
         shell: bash
         if: matrix.os == 'ubuntu'


### PR DESCRIPTION
Speed up CI jobs by avoiding installation of locales and man pages.

The major performance gain that can be expected is that it makes the "Processing triggers for man-db" step a no-op. That step can otherwise take more than a minute, for example in [this recent run](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/17560477497/job/49875337391#step:3:943) it took 1m 39s:

<img width="769" height="40" alt="image" src="https://github.com/user-attachments/assets/9a2a38be-edff-4450-95c6-dc3865f746cf" />

UDENG-7865