### PR TITLE
docs: Fixed open Powershell as admin instructions in WSL installation guide

### DIFF
--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -30,14 +30,17 @@ Open PowerShell and run:
 > wsl --install
 ```
 
-You may see the following text: The requested operation requires elevation.
-If so, you will be presented with a prompt.  If you are using an Administrator
-account, you can just click "Ok" to proceed.  Otherwise, you need to provide an
-Administrator password to proceed.
+You may see the following output and be presented with a prompt. Follow the
+instructions to proceed.
 
-By default, this command will install and enable WSL, and install the default
-Ubuntu version. Refer to the next section if you want to install a differnt
-version of Ubuntu.
+```{code-block} text
+:class: no-copy
+The requested operation requires elevation.
+```
+
+When complete, WSL will be installed and enabled, and the latest version of
+Ubuntu will be installed. Refer to the next section if you want to install a
+different version of Ubuntu.
 
 ```{admonition} What if WSL is already installed and enabled?
 :class: tip

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -30,13 +30,7 @@ Open PowerShell and run:
 > wsl --install
 ```
 
-You may see the following output and be presented with a prompt. Follow the
-instructions to proceed.
-
-```{code-block} text
-:class: no-copy
-The requested operation requires elevation.
-```
+You may be prompted to grant permission to continue the installation.
 
 You then need to reboot your machine before installing and running any Ubuntu distro.
 

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -30,8 +30,14 @@ Open PowerShell and run:
 > wsl --install
 ```
 
-You may be asked to provide an Administrator password in this process.
-You then need to reboot your machine before installing and running any Ubuntu distro.
+You may see the following text: The requested operation requires elevation.
+If so, you will be presented with a prompt.  If you are using an Administrator
+account, you can just click "Ok" to proceed.  Otherwise, you need to provide an
+Administrator password to proceed.
+
+By default, this command will install and enable WSL, and install the default
+Ubuntu version. Refer to the next section if you want to install a differnt
+version of Ubuntu.
 
 ```{admonition} What if WSL is already installed and enabled?
 :class: tip

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -38,9 +38,7 @@ instructions to proceed.
 The requested operation requires elevation.
 ```
 
-When complete, WSL will be installed and enabled, and the latest version of
-Ubuntu will be installed. Refer to the next section if you want to install a
-different version of Ubuntu.
+You then need to reboot your machine before installing and running any Ubuntu distro.
 
 ```{admonition} What if WSL is already installed and enabled?
 :class: tip

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -24,12 +24,13 @@ myst:
 To install Ubuntu using any method, you first need to install and enable WSL on
 your Windows machine.
 
-Open PowerShell as an Administrator and run:
+Open PowerShell and run:
 
 ```{code-block} text
 > wsl --install
 ```
 
+You may be asked to provide an Administrator password in this process.
 You then need to reboot your machine before installing and running any Ubuntu distro.
 
 ```{admonition} What if WSL is already installed and enabled?

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -42,8 +42,9 @@ need to provide an administrator password to proceed.
 The requested operation requires elevation.
 ```
 
-When the command has completed, WSL will be installed and enabled, and the latest
-version of Ubuntu will also be installed.
+This command will install and enable the features necessary to run WSL.
+
+**After running this command, you need to reboot your machine.**
 
 ```{admonition} What if WSL is already installed and enabled?
 :class: important

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -33,14 +33,7 @@ Open a PowerShell prompt and run:
 > wsl --install
 ```
 
-You may see the following output and be presented with a prompt. If you are using
-an administrator account, you can just click "Ok" to proceed.  Otherwise, you
-need to provide an administrator password to proceed.
-
-```{code-block} text
-:class: no-copy
-The requested operation requires elevation.
-```
+You may be prompted to grant permission to continue the installation.
 
 This command will install and enable the features necessary to run WSL.
 

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -27,15 +27,23 @@ offers excellent integration with developer tools like Visual Studio Code.
 
 You need to install and enable WSL before you can start using Ubuntu on WSL.
 
-Open a PowerShell prompt as an Administrator and run:
+Open a PowerShell prompt and run:
 
 ```{code-block} text
 > wsl --install
 ```
 
-This command will install and enable the features necessary to run WSL.
+You may see the following output and be presented with a prompt. If you are using
+an administrator account, you can just click "Ok" to proceed.  Otherwise, you
+need to provide an administrator password to proceed.
 
-**After running this command, you need to reboot your machine.**
+```{code-block} text
+:class: no-copy
+The requested operation requires elevation.
+```
+
+When the command has completed, WSL will be installed and enabled, and the latest
+version of Ubuntu will also be installed.
 
 ```{admonition} What if WSL is already installed and enabled?
 :class: important


### PR DESCRIPTION
Removed mentions of "Open Powershell as an Administrator" in Ubuntu WSL installation guides, and replaced surrounding text with more accurate and descriptive instructions.

Addresses the following issue: https://github.com/canonical/open-documentation-academy/issues/282