### PR TITLE
fix(gui): Flips GUI default settings

### DIFF
--- a/gui/packages/ubuntupro/lib/core/settings.dart
+++ b/gui/packages/ubuntupro/lib/core/settings.dart
@@ -13,15 +13,15 @@ class Settings {
     try {
       repository.load();
 
-      // Enable store purchase if the registry value is 1.
-      final purchase = repository.readInt(kAllowStorePurchase) == 1
-          ? Options.withStorePurchase
-          : Options.none;
-
-      // Hide Landscape UI if the registry value is 0.
-      final landscape = repository.readInt(kLandscapeConfigVisibility) == 0
+      // Disables store purchase if the registry value is 0.
+      final purchase = repository.readInt(kAllowStorePurchase) == 0
           ? Options.none
-          : Options.withLandscapeConfiguration;
+          : Options.withStorePurchase;
+
+      // Show Landscape UI if the registry value is 1.
+      final landscape = repository.readInt(kLandscapeConfigVisibility) == 1
+          ? Options.withLandscapeConfiguration
+          : Options.none;
 
       repository.close();
 
@@ -40,8 +40,8 @@ class Settings {
   /// Useful for integration testing.
   Settings.withOptions(this._options);
 
-  /// By default Landscape is enabled and Store purchase is disabled.
-  Options _options = Options.withLandscapeConfiguration;
+  /// By default Landscape is hidden and Store purchase is enabled.
+  Options _options = Options.withStorePurchase;
 
   bool get isLandscapeConfigurationEnabled =>
       _options & Options.withLandscapeConfiguration;

--- a/gui/packages/ubuntupro/test/core/settings_test.dart
+++ b/gui/packages/ubuntupro/test/core/settings_test.dart
@@ -61,7 +61,7 @@ void main() {
       when(repository.load()).thenAnswer((_) {});
       when(
         repository.readInt(Settings.kLandscapeConfigVisibility),
-      ).thenReturn(null);
+      ).thenReturn(1);
       when(repository.readInt(Settings.kAllowStorePurchase)).thenReturn(1);
 
       final settings = Settings(repository);
@@ -74,7 +74,7 @@ void main() {
       when(repository.load()).thenAnswer((_) {});
       when(
         repository.readInt(Settings.kLandscapeConfigVisibility),
-      ).thenReturn(null);
+      ).thenReturn(1);
       when(repository.readInt(Settings.kAllowStorePurchase)).thenReturn(0);
 
       final settings = Settings(repository);
@@ -101,7 +101,7 @@ void main() {
       when(
         repository.readInt(Settings.kLandscapeConfigVisibility),
       ).thenReturn(0);
-      when(repository.readInt(Settings.kAllowStorePurchase)).thenReturn(null);
+      when(repository.readInt(Settings.kAllowStorePurchase)).thenReturn(0);
 
       final settings = Settings(repository);
 
@@ -115,8 +115,8 @@ void main() {
 
       final settings = Settings(repository);
 
-      expect(settings.isLandscapeConfigurationEnabled, isTrue);
-      expect(settings.isStorePurchaseAllowed, isFalse);
+      expect(settings.isLandscapeConfigurationEnabled, isFalse);
+      expect(settings.isStorePurchaseAllowed, isTrue);
     });
     test('defaults with log', () {
       final repository = MockSettingsRepository();
@@ -126,8 +126,8 @@ void main() {
 
       final settings = Settings(repository);
 
-      expect(settings.isLandscapeConfigurationEnabled, isTrue);
-      expect(settings.isStorePurchaseAllowed, isFalse);
+      expect(settings.isLandscapeConfigurationEnabled, isFalse);
+      expect(settings.isStorePurchaseAllowed, isTrue);
     });
   });
 

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -119,6 +119,7 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 	})
 
 	conf.SetLandscapeNotifier(func(ctx context.Context, conf, uid string) {
+		log.Warning(ctx, "Landscape features are experimental and not enabled by default in this version.")
 		landscape.NotifyConfigUpdate(ctx, conf, uid)
 		cloudInit.Update(ctx)
 	})


### PR DESCRIPTION
The desired behaviour for the GA is the following defaults:

- Purchase via MS Store enabled
- Landscape disabled.

That means that either in the absence of the registry key or any missing or erroneous value those must be the settings, only forced otherwise if:

- Purchase disabled forcefully by the value 0 in the registry value;
- Landscape forcefully enabled by the value 1 in the registry value.

Additionally we warn in the agent logs if the Landscape config is changed, as we don't completely disabled it, at least we inform the user they are touching unstable territory. 