### PR TITLE
fix(tools): compute_version now outputs json

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -63,7 +63,7 @@ runs:
         $UP4W_VERSION=$($versionInfo.numeric_version)
 
         # Whether this is a 'stable' or 'pre-release'
-        $relKind=$($versionInfo.release_kind)
+        $relKind=$($versionInfo.release_type)
 
         [Reflection.Assembly]::LoadWithPartialName("System.Xml.Linq")
         $path = "$PWD/Msix/UbuntuProForWSL/Package.appxmanifest"

--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -56,13 +56,14 @@ runs:
       shell: powershell
       run: |
         # Set up the full version (displayed in logs)
-        $env:UP4W_FULL_VERSION=$(go run .\tools\build\compute_version.go)
+        $versionInfo=ConvertFrom-Json $(go run .\tools\build\compute_version.go --json)
+        $env:UP4W_FULL_VERSION=$($versionInfo.full_version)
 
         # Set up the numeric version (used in the AppxManifest)
-        $UP4W_VERSION=$(go run .\tools\build\compute_version.go --numeric)
+        $UP4W_VERSION=$($versionInfo.numeric_version)
 
         # Whether this is a 'stable' or 'pre-release'
-        $stable=$(go run .\tools\build\compute_version.go --is-stable)
+        $relKind=$($versionInfo.release_kind)
 
         [Reflection.Assembly]::LoadWithPartialName("System.Xml.Linq")
         $path = "$PWD/Msix/UbuntuProForWSL/Package.appxmanifest"
@@ -82,7 +83,7 @@ runs:
           $mainBundle.SetAttributeValue("Version", "${UP4W_VERSION}.0")
           $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${UP4W_VERSION}/UbuntuProForWSL_${UP4W_VERSION}.msixbundle")
         }
-        if ($stable -eq "pre-release") {
+        if ($relKind -eq "pre-release") {
           # Point the App Installer file to the repo wiki instead of the latest stable release.
           $doc.Root.SetAttributeValue("Uri", "https://raw.githubusercontent.com/wiki/canonical/ubuntu-pro-for-wsl/pre-release/UbuntuProForWSL.appinstaller")
         }

--- a/tools/build/build-appx.ps1
+++ b/tools/build/build-appx.ps1
@@ -72,9 +72,9 @@ function Update-Certificate {
 }
 
 function Set-Version {
-    $env:UP4W_FULL_VERSION=$(go run .\tools\build\compute_version.go)
-
-    $UP4W_VERSION=$(go run .\tools\build\compute_version.go --numeric)
+    $versionInfo=ConvertFrom-Json $(go run .\tools\build\compute_version.go --json)
+    $env:UP4W_FULL_VERSION=$($versionInfo.full_version)
+    $UP4W_VERSION=$($versionInfo.numeric_version)
     # Update the AppxManifest version
     [Reflection.Assembly]::LoadWithPartialName("System.Xml.Linq")
     $path = "$PWD/Msix/UbuntuProForWSL/Package.appxmanifest"

--- a/tools/build/compute_version.go
+++ b/tools/build/compute_version.go
@@ -14,7 +14,7 @@ import (
 type versionInfo struct {
 	Numeric     string `json:"numeric_version"`
 	Full        string `json:"full_version"`
-	ReleaseKind string `json:"release_kind"`
+	ReleaseType string `json:"release_type"`
 }
 
 func main() {
@@ -32,16 +32,15 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Warning: Working tree at %s contains commits after the latest tag %s\n", tag, cut)
 		}
 
-		st := "pre-release"
+		releaseType := "pre-release"
 		if stableOr {
-			st = "stable"
-
+			releaseType = "stable"
 		}
 
 		v := versionInfo{
 			Numeric:     numeric,
 			Full:        fullVersion,
-			ReleaseKind: st,
+			ReleaseType: releaseType,
 		}
 		j, err := json.Marshal(v)
 		if err != nil {


### PR DESCRIPTION
This way we avoid subprocessing it three times in build-msix action. The usage in debian/prepare-source.sh didn't change.

We didn't have to do this now, but I need something else on top of main to issue a new tag to test the autoupdates end-to-end.

---

UDENG-7812