### PR TITLE
fix(CI): Fix publish URLs and package name

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -58,6 +58,7 @@ runs:
         # Set up the full version (displayed in logs)
         $versionInfo=ConvertFrom-Json $(go run .\tools\build\compute_version.go --json)
         $env:UP4W_FULL_VERSION=$($versionInfo.full_version)
+        $tag=$($versionInfo.tag)
 
         # Set up the numeric version (used in the AppxManifest)
         $UP4W_VERSION=$($versionInfo.numeric_version)
@@ -81,7 +82,7 @@ runs:
         $mainBundle = $doc.Root.Element($ns + "MainBundle")
         if ($mainBundle) {
           $mainBundle.SetAttributeValue("Version", "${UP4W_VERSION}.0")
-          $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${UP4W_VERSION}/UbuntuProForWSL_${UP4W_VERSION}.msixbundle")
+          $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${tag}/UbuntuProForWSL_${tag}.msixbundle")
         }
         if ($releaseType -eq "pre-release") {
           # Point the App Installer file to the repo wiki instead of the latest stable release.

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
@@ -7,7 +7,7 @@ See https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/.github/actions/bu
 	Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.appinstaller"
 	Version="1.0.0.0">
 	<MainBundle
-		Name="UbuntuProForWSL"
+		Name="CanonicalGroupLimited.UbuntuPro"
 		Version="0.0.0.0"
 		Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0"
 		Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/0.0.0/UbuntuProForWSL_0.0.0.msixbundle" />

--- a/tools/build/compute_version.go
+++ b/tools/build/compute_version.go
@@ -15,6 +15,7 @@ type versionInfo struct {
 	Numeric     string `json:"numeric_version"`
 	Full        string `json:"full_version"`
 	ReleaseType string `json:"release_type"`
+	Tag         string `json:"tag"`
 }
 
 func main() {
@@ -41,6 +42,7 @@ func main() {
 			Numeric:     numeric,
 			Full:        fullVersion,
 			ReleaseType: releaseType,
+			Tag:         cut,
 		}
 		j, err := json.Marshal(v)
 		if err != nil {


### PR DESCRIPTION
The releases download asset URLs are created after the git tag, not the release name. Thus I`m changing compute_version.go to also output the closest git tag and we use that value in the build-msix action to compute the correct URL where the MSIX bundle will be at. Also, following our release documentation, the msixbundle is also named after the git tag.

Finally there was a mistake in the AppInstaller template file: the `MainBundle.Name` field must match the Package.appxmanifest's `Identity.Name`.