### PR TITLE
docs: clarifications relating to WSL versions

### DIFF
--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -54,6 +54,13 @@ While Ubuntu works on WSL 1, the experience may be degraded relative to WSL 2. T
 
 [Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) relies on systemd for much of its functionality, including automatic Pro attachment, so it does not support WSL 1. For the same reason, the [Landscape](ref::landscape-client) tool for remote management of Ubuntu instances is also not supported on WSL 1. You can still manually attach your WSL 1 instance to [Ubuntu Pro](https://documentation.ubuntu.com/pro/) using the [Ubuntu Pro Client](ref::ubuntu-pro-client), although some of Ubuntu Pro's features may not work on WSL 1.
 
+### Switching WSL versions
+
+Microsoft's official WSL documentation includes guidance on:
+
+* [Setting the WSL version for a specific distro](https://learn.microsoft.com/en-us/windows/wsl/basic-commands#set-wsl-version-to-1-or-2)
+* [Setting the default WSL version for new distro installations](https://learn.microsoft.com/en-us/windows/wsl/basic-commands#set-default-wsl-version)
+
 ## Further reading
 
 - Visit the [Microsoft WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/compare-versions) for additional information on the differences between WSL 1 and WSL 2.

--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -4,6 +4,7 @@ myst:
     "description lang=en": "Read about the differences between major versions of WSL, such as WSL 1 and WSL 2, and how it affects Ubuntu on WSL."
 ---
 
+(explanation::wsl-version)=
 # Comparing WSL versions for Ubuntu on WSL
 
 This page explains the main differences between different major versions of WSL and how they affect Ubuntu on WSL.

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -210,24 +210,24 @@ Any exchanges of data are encrypted using TLS.
 > [Read our reference on firewall configuration for Ubuntu Pro on WSL](ref::firewall)
 
 (exp::wsl1-incompatibility)=
-### WSL1 incompatibility
+### Incompatibility with WSL 1
 
-WSL2 is the default WSL version on Windows 11.
-The legacy version — WSL1 — can also still be used.
+WSL 2 is the default WSL version on Windows 11.
+The legacy version — WSL 1 — can also still be used.
 
 > [Read more about WSL versions](https://learn.microsoft.com/en-us/windows/wsl/compare-versions)
 
-Ubuntu Pro for WSL only supports WSL2.
+Ubuntu Pro for WSL only supports WSL 2.
 When relying on Ubuntu Pro for WSL to manage the security of WSL instances,
-you should therefore consider enforcing WSL2 on host Windows machines.
+you should therefore consider enforcing WSL 2 on host Windows machines.
 
-To set the default version to WSL2:
+To set the default version to WSL 2:
 
 ```text
 wsl --set-default-version 2
 ```
 
-To convert a specific distribution from WSL1 to WSL2:
+To convert a specific distribution from WSL 1 to WSL 2:
 
 ```text
 wsl --set-version <distro> 2
@@ -248,7 +248,7 @@ To set it:
 Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss" -Name DefaultVersion -Value 2
 ```
 
-Intune also supports policies for WSL, which include toggling the availability of WSL1 on client machines:
+Intune also supports policies for WSL, which include toggling the availability of WSL 1 on client machines:
 
 > [Intune configuration options for WSL](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations)
 
@@ -258,14 +258,14 @@ Intune also supports policies for WSL, which include toggling the availability o
 
 WSL features can be controlled if they present a security concern.
 
-For example, root login can be disabled, WSL1 availability toggled and network
+For example, root login can be disabled, WSL 1 availability toggled and network
 access configured.
 
 There are various options to configure WSL instances, including:
 
 * The `.wslconfig` file can be edited to configure [global settings](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig) for instances
 * [WSL policies for Intune](https://learn.microsoft.com/en-us/windows/wsl/intune?source=recommendations) enable remote management of WSL features
-* Registry entries for features like [WSL1 availability](exp::wsl1-incompatibility) can be changed in the registry editor or with PowerShell scripts 
+* Registry entries for features like [WSL 1 availability](exp::wsl1-incompatibility) can be changed in the registry editor or with PowerShell scripts 
 
 (exp::automate-hardening)=
 ### Automate hardening

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -215,7 +215,7 @@ Any exchanges of data are encrypted using TLS.
 WSL 2 is the default WSL version on Windows 11.
 The legacy version — WSL 1 — can also still be used.
 
-> [Read more about WSL versions](https://learn.microsoft.com/en-us/windows/wsl/compare-versions)
+> [Read more about WSL versions](explanation::wsl-version)
 
 Ubuntu Pro for WSL only supports WSL 2.
 When relying on Ubuntu Pro for WSL to manage the security of WSL instances,

--- a/docs/howto/cloud-init.md
+++ b/docs/howto/cloud-init.md
@@ -21,7 +21,7 @@ It is an industry standard and can now also be used to automatically setup insta
 
 ## What you will need
 
-- Windows 11 with WSL2 already enabled
+- Windows 11 with WSL 2 already enabled
 
 The guide assumes that you are using Ubuntu 24.04,
 but Ubuntu 22.04 can also be used.
@@ -227,7 +227,7 @@ See LICENSE.txt for license information.
 
 ## Enjoy!
 
-That’s all folks! In this guide, we’ve shown you how to use cloud-init to automatically set up Ubuntu on WSL2 with minimal touch.
+That’s all folks! In this guide, we’ve shown you how to use cloud-init to automatically set up Ubuntu on WSL with minimal touch.
 
 This workflow will guarantee a solid foundation for your next Ubuntu WSL project.
 

--- a/docs/howto/custom-ubuntu-distro.md
+++ b/docs/howto/custom-ubuntu-distro.md
@@ -27,7 +27,7 @@ and testing the distro.
 
 To follow the guide, make sure you have:
 
-* Windows 11 with WSL2 installed and enabled
+* Windows 11 with WSL 2 installed and enabled
 * An existing Ubuntu distro installed on WSL
 
 WSL will be used to extract the rootfs, edit the configuration files and manage packages.

--- a/docs/howto/gpu-cuda.md
+++ b/docs/howto/gpu-cuda.md
@@ -11,9 +11,9 @@ While WSL's default setup allows you to develop cross-platform applications with
 
 ## What you will learn
 
-* How to install a Windows graphical device driver compatible with WSL2
-* How to install the NVIDIA CUDA toolkit for WSL2 on Ubuntu
-* How to compile and run a sample CUDA application on Ubuntu on WSL2
+* How to install a Windows graphical device driver compatible with WSL 2
+* How to install the NVIDIA CUDA toolkit for WSL 2 on Ubuntu
+* How to compile and run a sample CUDA application on Ubuntu on WSL 2
 
 ## What you will need
 
@@ -167,4 +167,4 @@ We hope you enjoy using Ubuntu inside WSL for your Data Science projects. Don’
 * [Install Ubuntu on WSL 2](../howto/install-ubuntu-wsl2.md)
 * [Microsoft WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/)
 * [CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html)
-* [Ask Ubuntu](https://askubuntu.com/)
+* [Ask Ubuntu](https://askubuntu.com/)* [Ask Ubuntu](https://askubuntu.com/)

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -45,6 +45,14 @@ Ubuntu, unless there is a pre-existing instance named Ubuntu on the machine.
 
 ## Install specific versions of Ubuntu on WSL
 
+```{note} WSL versions
+WSL 2 is the default [WSL architecture](explanation::wsl-version) in recent
+versions of Windows. Our documentation assumes that you are installing Ubuntu
+on WSL 2.
+
+Read more about the [differences between WSL versions](explanation::wsl-version).
+```
+
 There are multiple ways of installing Ubuntu distros on WSL.
 The best method depends on your specific requirements.
 

--- a/docs/howto/install-ubuntu-wsl2.md
+++ b/docs/howto/install-ubuntu-wsl2.md
@@ -6,7 +6,7 @@ myst:
 ---
 
 (howto::install-ubuntu-wsl)=
-# Install Ubuntu on WSL2
+# Install Ubuntu on WSL 2
 
 ## What you will learn
 

--- a/docs/reference/release_notes.md
+++ b/docs/reference/release_notes.md
@@ -122,7 +122,7 @@ This application is pending an official release of its 1.0 version.
 
 ###### 22.04.2
 
-* Cherry-pick upstream patch to use more portable alignment to resolve failure to execute on WSL1.
+* Cherry-pick upstream patch to use more portable alignment to resolve failure to execute on WSL 1.
 
 ###### 22.04.1
 

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -270,7 +270,7 @@ In this tutorial, we’ve shown you how to set up a development environment with
 
 ### Further Reading
 
-* [Install Ubuntu on WSL2](../howto/install-ubuntu-wsl2.md)
+* [Install Ubuntu on WSL 2](../howto/install-ubuntu-wsl2.md)
 * [Microsoft WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/)
 * [Setting up WSL for Data Science](https://ubuntu.com/blog/wsl-for-data-scientist)
 * [Ask Ubuntu](https://askubuntu.com/)

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -134,6 +134,14 @@ The `~` is passed to the `wsl command` to start the instance in the Ubuntu home
 directory (commonly symbolised by ~) and the `-d` flag is added to specify the
 distro.
 
+We only need an Ubuntu-24.04 instance for this tutorial.
+
+To remove the Ubuntu-22.04 instance, run the following command in PowerShell:
+
+```{code-block} text
+> wsl --unregister Ubuntu-22.04
+```
+
 ```{admonition} Windows terminal integration
 :class: tip
 Each time you install a version of Ubuntu, it appears in the dropdown list of
@@ -141,14 +149,6 @@ terminal profiles in Windows terminal.
 
 If you have one version of Ubuntu running in a tab, you can open another in a
 separate tab by selecting it from the menu.
-```
-
-We only need an Ubuntu-24.04 instance for this tutorial.
-
-To remove the Ubuntu-22.04 instance, run the following command in PowerShell:
-
-```{code-block} text
-> wsl --unregister Ubuntu-22.04
 ```
 
 ## Install Visual Studio Code on Windows

--- a/docs/tutorials/develop-with-ubuntu-wsl.md
+++ b/docs/tutorials/develop-with-ubuntu-wsl.md
@@ -111,12 +111,17 @@ Use `wsl -l -v` to list all of your installed distros.
 * Ubuntu-24.04    Stopped         2
 ```
 
-```{admonition} What is version 2?
-:class: note
-WSL implements two different architectures for running 
-Linux distributions: WSL1 and WSL2.
-This means that you are using WSL2, rather than WSL1.
-WSL2 is the default WSL on recent versions of Windows.
+This shows that both distros are stopped, each uses WSL 2, and Ubuntu-24.04 is
+the default distro.
+
+```{admonition} What is WSL 2?
+:class: warning
+WSL implements two different architectures for running Linux distributions: WSL
+1 and WSL 2.
+WSL 2 is the default WSL architecture on recent versions of Windows and it is
+recommended for this tutorial.
+
+Read more about the [differences between WSL versions](explanation::wsl-version).
 ```
 
 You can open a specific instance from PowerShell using its NAME:

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -96,7 +96,7 @@ with the following command in PowerShell:
 > wsl --install Ubuntu-24.04
 ```
 
-For other installation options refer to our [install Ubuntu on WSL2 guide](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/).
+For other installation options refer to our [install Ubuntu on WSL guide](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/).
 
 To manually associate this Ubuntu instance with a Pro subscription, you could
 launch the instance and run the `pro attach` command.

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -98,6 +98,19 @@ with the following command in PowerShell:
 
 For other installation options refer to our [install Ubuntu on WSL guide](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/).
 
+To confirm the installation, and that the installed distro is using WSL 2, run:
+
+```{code-block} text
+> wsl -l -v
+```
+
+```{admonition} You must use WSL 2
+:class: warning
+WSL 2 is the default architecture on recent versions of Windows and
+is required for Ubuntu Pro for WSL to function.
+Read more about the [differences between WSL versions](explanation::wsl-version).
+```
+
 To manually associate this Ubuntu instance with a Pro subscription, you could
 launch the instance and run the `pro attach` command.
 


### PR DESCRIPTION
* Uses the convention of having a space between WSL and `<version number>`, e.g., "WSL 2", which is more common than "WSL2"
* Adds notes to tutorials and guides emphasising that WSL 2 is required
* Links added to new WSL versions explanation where appropriate

UDENG-7253