### PR TITLE
fix(docs): add mount point cleanup section

### DIFF
--- a/docs/howto/custom-ubuntu-distro.md
+++ b/docs/howto/custom-ubuntu-distro.md
@@ -221,12 +221,9 @@ systems:
 ```{code-block} text
 :caption: ~
 $ sudo mount -t proc /proc myNewUbuntu/proc
-$ sudo mount --rbind /sys myNewUbuntu/sys
-$ sudo mount --make-rslave myNewUbuntu/sys
-$ sudo mount --rbind /dev myNewUbuntu/dev
-$ sudo mount --make-rslave myNewUbuntu/dev
-$ sudo mount --rbind /run myNewUbuntu/run
-$ sudo mount --make-rslave myNewUbuntu/run
+$ sudo mount --rbind --make-rslave /sys myNewUbuntu/sys
+$ sudo mount --rbind --make-rslave /dev myNewUbuntu/dev
+$ sudo mount --rbind --make-rslave /run myNewUbuntu/run
 ```
 
 Then `chroot` into the root directory of your custom distro and open a bash shell:


### PR DESCRIPTION
Did some additional research and investigation here. Part of the issue appears to be that mounts are shared by default, which causes issues with unmounting the mount points afterwards, showing the mount point is busy, etc.

So this modifies the mount points to be read only in the chroot and allows us to unmount them further down the pipe.
