### PR TITLE
feat(windows-agent): Report unmanaged instances to the Landscape server

### DIFF
--- a/common/testutils/testutils.go
+++ b/common/testutils/testutils.go
@@ -81,3 +81,22 @@ func GenerateTempCertificate(t *testing.T, path string) {
 	err = os.WriteFile(filepath.Join(path, "key.pem"), out.Bytes(), 0600)
 	require.NoError(t, err, errPrefix+"could not write private key to file")
 }
+
+// WriteOsRelease is a test helper that writes a sample os-release file for the given distro inside
+// the uncRoot directory, creating any needed directories.
+func WriteOsRelease(t *testing.T, uncRoot, distroName, template string) {
+	t.Helper()
+
+	testdata, err := filepath.Abs(filepath.Join(TestFamilyPath(t), template))
+	require.NoError(t, err, "Setup: Couldn't compute absolute path of sample os-release file")
+	data, err := os.ReadFile(testdata)
+	require.NoError(t, err, "Setup: couldn't read sample os-release file")
+
+	dir := filepath.Join(uncRoot, distroName, "usr", "lib")
+	err = os.MkdirAll(dir, 0750)
+	require.NoError(t, err, "Setup: Failed to create directories to contain the distros os-release file")
+
+	//nolint:gosec // This file is meant to be read by anyone.
+	err = os.WriteFile(filepath.Join(dir, "os-release"), data, 0644)
+	require.NoError(t, err, "Setup: Failed to write sample os-release file")
+}

--- a/end-to-end/go.mod
+++ b/end-to-end/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/ubuntu-pro-for-wsl/end-to-end
 go 1.23.0
 
 require (
-	github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f
+	github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f
 	github.com/canonical/ubuntu-pro-for-wsl/mocks v0.0.0-20240909072650-75a32126b04f
 	github.com/stretchr/testify v1.11.1

--- a/end-to-end/go.sum
+++ b/end-to-end/go.sum
@@ -1,7 +1,7 @@
 github.com/0xrawsec/golang-utils v1.3.2 h1:ww4jrtHRSnX9xrGzJYbalx5nXoZewy4zPxiY+ubJgtg=
 github.com/0xrawsec/golang-utils v1.3.2/go.mod h1:m7AzHXgdSAkFCD9tWWsApxNVxMlyy7anpPVOyT/yM7E=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f h1:98VdOj+VrXa3esA66XX0rM0IiJSe0M+6lCGztGdttP4=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f/go.mod h1:3N+AXDrTJvuwy+F9uIDzi2g9xqpeZpxfwobtn84JHEQ=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1 h1:fi5eVdZCelJd6lUufEXgtBbNf/Jll2n2Cgvd9UGqIys=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1/go.mod h1:SEDBCzpOq4KPCsPQiPaUl+lOtkvbBWDRjwavnkY4qss=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f h1:dRvnh9c8Su1KB9CoOTwj6hYi8AgwF6i6EvifCvBsaQU=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f/go.mod h1:zRV9zbYgMl8VnSZCIaA+q++vWsQgwQ0oJzVGOZJrej0=
 github.com/canonical/ubuntu-pro-for-wsl/contractsapi v0.0.0-20240909070948-cee447de36ba h1:wHIORK4F7/YUyjQXI/hgq7yHXHXE3HNI7FxYAgkNhxo=

--- a/mocks/go.mod
+++ b/mocks/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/ubuntu-pro-for-wsl/mocks
 go 1.23.0
 
 require (
-	github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f
+	github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909070948-cee447de36ba
 	github.com/canonical/ubuntu-pro-for-wsl/contractsapi v0.0.0-20240909070948-cee447de36ba
 	github.com/spf13/cobra v1.9.1

--- a/mocks/go.sum
+++ b/mocks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f h1:98VdOj+VrXa3esA66XX0rM0IiJSe0M+6lCGztGdttP4=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f/go.mod h1:3N+AXDrTJvuwy+F9uIDzi2g9xqpeZpxfwobtn84JHEQ=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1 h1:fi5eVdZCelJd6lUufEXgtBbNf/Jll2n2Cgvd9UGqIys=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1/go.mod h1:SEDBCzpOq4KPCsPQiPaUl+lOtkvbBWDRjwavnkY4qss=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909070948-cee447de36ba h1:BdZzJ9clVUCPgUkM4YnJGwmgned0A7HUWD4vT5QjklU=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909070948-cee447de36ba/go.mod h1:zRV9zbYgMl8VnSZCIaA+q++vWsQgwQ0oJzVGOZJrej0=
 github.com/canonical/ubuntu-pro-for-wsl/contractsapi v0.0.0-20240909070948-cee447de36ba h1:wHIORK4F7/YUyjQXI/hgq7yHXHXE3HNI7FxYAgkNhxo=

--- a/mocks/landscape/landscapemockservice/landscape_mock_service.go
+++ b/mocks/landscape/landscapemockservice/landscape_mock_service.go
@@ -32,8 +32,9 @@ type HostInfo struct {
 	AccountName     string
 	RegistrationKey string
 
-	Instances         []InstanceInfo
-	DefaultInstanceID string
+	Instances          []InstanceInfo
+	UnmanagedInstances []InstanceInfo
+	DefaultInstanceID  string
 }
 
 // CmdStatusMsg is the same as landscapeapi.CommandStatus, but without the mutexes and
@@ -67,6 +68,15 @@ func receiveHostInfo(stream landscapeapi.LandscapeHostAgent_ConnectServer) (Host
 
 	for _, inst := range msg.GetInstances() {
 		h.Instances = append(h.Instances, InstanceInfo{
+			ID:            inst.GetId(),
+			Name:          inst.GetName(),
+			VersionID:     inst.GetVersionId(),
+			InstanceState: inst.GetInstanceState(),
+		})
+	}
+
+	for _, inst := range msg.GetUnmanagedInstances() {
+		h.UnmanagedInstances = append(h.UnmanagedInstances, InstanceInfo{
 			ID:            inst.GetId(),
 			Name:          inst.GetName(),
 			VersionID:     inst.GetVersionId(),

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/breml/errchkjson v0.4.0 // indirect
 	github.com/butuzov/ireturn v0.3.1 // indirect
 	github.com/butuzov/mirror v1.3.0 // indirect
-	github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f // indirect
+	github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1 // indirect
 	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909070948-cee447de36ba // indirect
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909070948-cee447de36ba // indirect
 	github.com/canonical/ubuntu-pro-for-wsl/contractsapi v0.0.0-20240705150615-15d23a639880 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -104,8 +104,8 @@ github.com/butuzov/ireturn v0.3.1 h1:mFgbEI6m+9W8oP/oDdfA34dLisRFCj2G6o/yiI1yZrY
 github.com/butuzov/ireturn v0.3.1/go.mod h1:ZfRp+E7eJLC0NQmk1Nrm1LOrn/gQlOykv+cVPdiXH5M=
 github.com/butuzov/mirror v1.3.0 h1:HdWCXzmwlQHdVhwvsfBb2Au0r3HyINry3bDWLYXiKoc=
 github.com/butuzov/mirror v1.3.0/go.mod h1:AEij0Z8YMALaq4yQj9CPPVYOyJQyiexpQEQgihajRfI=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f h1:98VdOj+VrXa3esA66XX0rM0IiJSe0M+6lCGztGdttP4=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f/go.mod h1:3N+AXDrTJvuwy+F9uIDzi2g9xqpeZpxfwobtn84JHEQ=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1 h1:fi5eVdZCelJd6lUufEXgtBbNf/Jll2n2Cgvd9UGqIys=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1/go.mod h1:SEDBCzpOq4KPCsPQiPaUl+lOtkvbBWDRjwavnkY4qss=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909070948-cee447de36ba h1:UGqA3M/shRzMs4vo8b326i6ev6l2MFFgDPfbPdSD6pE=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909070948-cee447de36ba/go.mod h1:xssoyTYh2NqXuj0sG6m7HsLTwI4HXPESweUjbh2WUQs=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909070948-cee447de36ba h1:BdZzJ9clVUCPgUkM4YnJGwmgned0A7HUWD4vT5QjklU=

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
-	github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b
+	github.com/ubuntu/gowsl v0.0.0-20251003130259-5c49d26cf9f5
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/sys v0.35.0
 	google.golang.org/grpc v1.75.1

--- a/windows-agent/go.mod
+++ b/windows-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/ubuntu-pro-for-wsl/windows-agent
 go 1.23.0
 
 require (
-	github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f
+	github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1
 	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909072650-75a32126b04f
 	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f
 	github.com/canonical/ubuntu-pro-for-wsl/contractsapi v0.0.0-20240909072650-75a32126b04f

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -74,8 +74,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b h1:LnvVFBFZ8F9NCqr+oS+LMHBIWZyOcLoL4JidRnGuh8A=
-github.com/ubuntu/gowsl v0.0.0-20250220202122-f4267f82434b/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
+github.com/ubuntu/gowsl v0.0.0-20251003130259-5c49d26cf9f5 h1:473ltrZvZFcqZVPNeBT6vODRXwTj9iYC4ovHUvjPwJs=
+github.com/ubuntu/gowsl v0.0.0-20251003130259-5c49d26cf9f5/go.mod h1:e1N5AoWkQv9ralO2G80XkLGPlAlCtT8ibOh2ZBEZYIg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=

--- a/windows-agent/go.sum
+++ b/windows-agent/go.sum
@@ -1,7 +1,7 @@
 github.com/0xrawsec/golang-utils v1.3.2 h1:ww4jrtHRSnX9xrGzJYbalx5nXoZewy4zPxiY+ubJgtg=
 github.com/0xrawsec/golang-utils v1.3.2/go.mod h1:m7AzHXgdSAkFCD9tWWsApxNVxMlyy7anpPVOyT/yM7E=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f h1:98VdOj+VrXa3esA66XX0rM0IiJSe0M+6lCGztGdttP4=
-github.com/canonical/landscape-hostagent-api v0.0.0-20241007124637-88f060ef7c8f/go.mod h1:3N+AXDrTJvuwy+F9uIDzi2g9xqpeZpxfwobtn84JHEQ=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1 h1:fi5eVdZCelJd6lUufEXgtBbNf/Jll2n2Cgvd9UGqIys=
+github.com/canonical/landscape-hostagent-api v0.0.0-20250919154603-590e7d7ae4e1/go.mod h1:SEDBCzpOq4KPCsPQiPaUl+lOtkvbBWDRjwavnkY4qss=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909072650-75a32126b04f h1:NiCanRAKQannR6M4uB1YB/s3ZB+aIEIESclRlcrIKic=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20240909072650-75a32126b04f/go.mod h1:xssoyTYh2NqXuj0sG6m7HsLTwI4HXPESweUjbh2WUQs=
 github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20240909072650-75a32126b04f h1:dRvnh9c8Su1KB9CoOTwj6hYi8AgwF6i6EvifCvBsaQU=

--- a/windows-agent/internal/distros/database/database_test.go
+++ b/windows-agent/internal/distros/database/database_test.go
@@ -139,6 +139,88 @@ func TestDatabaseGetAll(t *testing.T) {
 	}
 }
 
+func TestDatabaseGetUnmanaged(t *testing.T) {
+	ctx := context.Background()
+	uncRoot := t.TempDir()
+
+	if wsl.MockAvailable() {
+		t.Parallel()
+		ctx = context.WithValue(wsl.WithMock(ctx, wslmock.New()), database.UNCRootKey, uncRoot)
+	}
+
+	// Registers some Ubuntu instances
+	var distros []string
+	for range 3 {
+		distros = append(distros, func() string {
+			d, _ := wsltestutils.RegisterDistro(t, ctx, false)
+			d = strings.ToLower(d)
+			writeOsRelease(t, uncRoot, d, "ubuntu-os-release")
+			return d
+		}())
+	}
+
+	// Register one non-Ubuntu instance.
+	nonUbuntu, _ := wsltestutils.RegisterDistro(t, ctx, false)
+	nonUbuntu = strings.ToLower(nonUbuntu)
+	writeOsRelease(t, uncRoot, nonUbuntu, "other-os-release")
+
+	testCases := map[string]struct {
+		dbDistros []string
+
+		want []string
+	}{
+		"empty database":            {want: distros},
+		"database with one entry":   {dbDistros: []string{distros[0]}, want: distros[1:]},
+		"database with two entries": {dbDistros: distros[0:2], want: []string{distros[2]}},
+		"no unmanaged distros":      {dbDistros: distros, want: []string{}},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if wsl.MockAvailable() {
+				t.Parallel()
+			}
+
+			db, err := database.New(ctx, t.TempDir())
+			require.NoError(t, err, "Setup: database creation should not fail")
+			defer db.Close(ctx)
+
+			for i := range tc.dbDistros {
+				_, err := db.GetDistroAndUpdateProperties(ctx, tc.dbDistros[i], distro.Properties{})
+				require.NoError(t, err, "Setup: could not add %q to database", tc.dbDistros[i])
+			}
+
+			var gotUnmanaged []string
+			for _, d := range db.GetUnmanagedDistros() {
+				gotUnmanaged = append(gotUnmanaged, d.Name)
+			}
+
+			require.ElementsMatch(t, tc.want, gotUnmanaged, "GetUnmanagedDistros returned unexpected set of distros")
+			require.NotElementsMatch(t, tc.dbDistros, gotUnmanaged, "GetUnmanagedDistros should not return a distro in the database")
+			require.NotContains(t, gotUnmanaged, nonUbuntu, "GetUnmanagedDistros should not return a non-Ubuntu distro")
+		})
+	}
+}
+
+// writeOsRelease is a test helper that writes a sample os-release file for the given distro inside
+// the uncRoot directory, creating any needed directories.
+func writeOsRelease(t *testing.T, uncRoot, distroName, template string) {
+	t.Helper()
+
+	testdata, err := filepath.Abs(filepath.Join(testutils.TestFamilyPath(t), template))
+	require.NoError(t, err, "Setup: Couldn't compute absolute path of sample os-release file")
+	data, err := os.ReadFile(testdata)
+	require.NoError(t, err, "Setup: couldn't read sample os-release file")
+
+	dir := filepath.Join(uncRoot, distroName, "usr", "lib")
+	err = os.MkdirAll(dir, 0750)
+	require.NoError(t, err, "Setup: Failed to create directories to contain the distros os-release file")
+
+	//nolint:gosec // This file is meant to be read by anyone.
+	err = os.WriteFile(filepath.Join(dir, "os-release"), data, 0644)
+	require.NoError(t, err, "Setup: Failed to write sample os-release file")
+}
+
 //nolint:tparallel // Subtests are parallel but the test itself is not due to the calls to RegisterDistro.
 func TestDatabaseGet(t *testing.T) {
 	ctx := context.Background()

--- a/windows-agent/internal/distros/database/export_test.go
+++ b/windows-agent/internal/distros/database/export_test.go
@@ -29,5 +29,3 @@ func (db *DistroDB) DistroNames() (out []string) {
 	}
 	return out
 }
-
-var UNCRootKey = uncRootKey

--- a/windows-agent/internal/distros/database/export_test.go
+++ b/windows-agent/internal/distros/database/export_test.go
@@ -29,3 +29,5 @@ func (db *DistroDB) DistroNames() (out []string) {
 	}
 	return out
 }
+
+var UNCRootKey = uncRootKey

--- a/windows-agent/internal/distros/database/testdata/TestDatabaseGetUnmanaged/other-os-release
+++ b/windows-agent/internal/distros/database/testdata/TestDatabaseGetUnmanaged/other-os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support/"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/windows-agent/internal/distros/database/testdata/TestDatabaseGetUnmanaged/ubuntu-os-release
+++ b/windows-agent/internal/distros/database/testdata/TestDatabaseGetUnmanaged/ubuntu-os-release
@@ -1,0 +1,13 @@
+PRETTY_NAME="Ubuntu Questing Quokka (development branch)"
+NAME="Ubuntu"
+VERSION_ID="25.10"
+VERSION="25.10 (Questing Quokka)"
+VERSION_CODENAME=questing
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=questing
+LOGO=ubuntu-logo

--- a/windows-agent/internal/distros/database/unmanaged.go
+++ b/windows-agent/internal/distros/database/unmanaged.go
@@ -102,6 +102,12 @@ type uncRootKeyT struct{}
 
 var uncRootKey = uncRootKeyT{}
 
+// WithUNCRootPath returns a child context that will use the supplied Windows Universal Naming Convention
+// root path to access WSL files. This is only meant for testing.
+func WithUNCRootPath(ctx context.Context, uncRoot string) context.Context {
+	return context.WithValue(ctx, uncRootKey, uncRoot)
+}
+
 // selectUNCRoot returns the Windows Universal Naming Convention root path to use to access WSL
 // files based on the supplied context (to allow injection for testing).
 func selectUNCRoot(ctx context.Context) string {

--- a/windows-agent/internal/distros/database/unmanaged.go
+++ b/windows-agent/internal/distros/database/unmanaged.go
@@ -1,0 +1,140 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
+	"github.com/google/uuid"
+	"github.com/ubuntu/gowsl"
+	"gopkg.in/ini.v1"
+)
+
+// BasicDistroInfo contains the minimal information about a distro instance for display purposes.
+type BasicDistroInfo struct {
+	Name      string      // The distro instance name
+	GUID      string      // The WSL internal GUID
+	DistroID  string      // Same as /etc/os-relase ID
+	VersionID string      // Same as /etc/os-relase VERSION_ID
+	Hostname  string      // Instance hostname
+	State     gowsl.State // Stopped, Running, Uninstalling etc
+}
+
+// GetUnmanagedDistros returns a list of Ubuntu instances that are currently registered in WSL but not managed by this agent.
+// That's an expensive operation that involves a light wake up of all instances not previously discovered.
+// This information is a snapshot at the time of the call, we don't store it.
+func (db *DistroDB) GetUnmanagedDistros() (distros []BasicDistroInfo) {
+	managed := db.GetAll()
+
+	registered, err := gowsl.RegisteredDistros(db.ctx)
+	if err != nil {
+		log.Errorf(db.ctx, "failed to get registered distros: %v", err)
+		return distros
+	}
+
+	uncRoot := selectUNCRoot(db.ctx)
+	for _, d := range registered {
+		// Acquiring the distro GUID from GoWSL is quite expensive the way it's implemented now, so we do it once and then pass it along.
+		guid, err := d.GUID()
+		if err != nil {
+			log.Warningf(db.ctx, "failed to get GUID for distro %q: %v", d.Name(), err)
+			continue
+		}
+		if slices.ContainsFunc(managed, func(m *distro.Distro) bool {
+			// m.GUID() is cheap because it reads from a value already cached.
+			return guid.String() == m.GUID()
+		}) {
+			// This is a managed distro, skip it.
+			continue
+		}
+
+		info, err := basicDistroInfo(db.ctx, d, guid, uncRoot)
+		if err != nil {
+			log.Warningf(db.ctx, "failed to get basic info for distro %q: %v", d.Name(), err)
+			continue
+		}
+		distros = append(distros, info)
+	}
+
+	return distros
+}
+
+// basicDistroInfo collects the minimal information about a distro instance for display purposes.
+func basicDistroInfo(ctx context.Context, d gowsl.Distro, guid uuid.UUID, uncRoot string) (info BasicDistroInfo, err error) {
+	// State has to be read earlier, because reading files and running commands alters it (into 'Running' ofc).
+	state, err := d.State()
+	if err != nil {
+		return BasicDistroInfo{}, fmt.Errorf("failed to get state of distro %q: %v", d.Name(), err)
+	}
+
+	osInfo, err := readOsRelease(filepath.Join(uncRoot, d.Name()))
+	if err != nil {
+		return BasicDistroInfo{}, fmt.Errorf("failed to get distro basic info for %q: %v", d.Name(), err)
+	}
+
+	if osInfo.Id != "ubuntu" {
+		// Our business only concerns with Ubuntu instances.
+		return BasicDistroInfo{}, fmt.Errorf("skipping non-Ubuntu distro instance %q", d.Name())
+	}
+
+	hostname, err := d.Command(ctx, "hostname").CombinedOutput()
+	if err != nil {
+		return BasicDistroInfo{}, fmt.Errorf("failed to get hostname for %s: %v", d.Name(), err)
+	}
+
+	return BasicDistroInfo{
+		Name:      d.Name(),
+		GUID:      guid.String(),
+		DistroID:  osInfo.Id,
+		VersionID: osInfo.VersionId,
+		Hostname:  strings.TrimSpace(string(hostname)),
+		State:     state,
+	}, nil
+}
+
+type uncRootKeyT struct{}
+
+var uncRootKey = uncRootKeyT{}
+
+// selectUNCRoot returns the Windows Universal Naming Convention root path to use to access WSL
+// files based on the supplied context (to allow injection for testing).
+func selectUNCRoot(ctx context.Context) string {
+	if u, ok := ctx.Value(uncRootKey).(string); ok {
+		return u
+	}
+	return `\\wsl.localhost\`
+}
+
+type osReleaseInfo struct {
+	//nolint:revive //ini mapper is strict with naming, so we cannot rename Id -> ID as the linter suggests
+	Id, VersionId, PrettyName string
+}
+
+// readOsRelease marshalls the os-release file found at either /usr/lib/os-release or /etc/os-release relative to the supplied root directory.
+func readOsRelease(root string) (osReleaseInfo, error) {
+	var marshaller osReleaseInfo
+	// systemd docs advise reading first /etc/os-release, then /usr/lib/os-release as a fallback, although vendors are
+	// supposed to ship /usr/lib/os-release and /etc/os-release is likely a symlink to it.
+	// See https://www.freedesktop.org/software/systemd/man/249/os-release.html
+	// Reading /etc/os-release via the Windows UNC path when it's a symlink to /usr/lib/os-release fails.
+	// Since we only care about Ubuntu, which does like systemd suggests above, we read /usr/lib/os-release first.
+	out, err := os.ReadFile(filepath.Join(root, "usr", "lib", "os-release"))
+	if err != nil {
+		errUsrLib := err
+		if out, err = os.ReadFile(filepath.Join(root, "etc", "os-release")); err != nil {
+			return osReleaseInfo{}, fmt.Errorf("could not read the os-release file from %s: %v", root, errors.Join(errUsrLib, err))
+		}
+	}
+
+	if err := ini.MapToWithMapper(&marshaller, ini.SnackCase, out); err != nil {
+		return osReleaseInfo{}, fmt.Errorf("could not parse %s: %v", root, err)
+	}
+
+	return marshaller, nil
+}

--- a/windows-agent/internal/distros/database/unmanaged.go
+++ b/windows-agent/internal/distros/database/unmanaged.go
@@ -27,7 +27,7 @@ type BasicDistroInfo struct {
 }
 
 // GetUnmanagedDistros returns a list of Ubuntu instances that are currently registered in WSL but not managed by this agent.
-// That's an expensive operation that involves a light wake up of all instances not previously discovered.
+// This is an expensive operation that involves a light wake up of all instances not previously discovered.
 // This information is a snapshot at the time of the call, we don't store it.
 func (db *DistroDB) GetUnmanagedDistros() (distros []BasicDistroInfo) {
 	managed := db.GetAll()
@@ -78,12 +78,12 @@ func basicDistroInfo(ctx context.Context, d gowsl.Distro, guid uuid.UUID, uncRoo
 		return BasicDistroInfo{}, fmt.Errorf("failed to get distro basic info for %q: %v", d.Name(), err)
 	}
 
-	if osInfo.Id != "ubuntu" {
+	if !strings.EqualFold(osInfo.Id, "ubuntu") {
 		// Our business only concerns with Ubuntu instances.
 		return BasicDistroInfo{}, fmt.Errorf("skipping non-Ubuntu distro instance %q", d.Name())
 	}
 
-	hostname, err := d.Command(ctx, "hostname").CombinedOutput()
+	hostname, err := d.Command(ctx, "hostname").Output()
 	if err != nil {
 		return BasicDistroInfo{}, fmt.Errorf("failed to get hostname for %s: %v", d.Name(), err)
 	}

--- a/windows-agent/internal/proservices/landscape/testdata/TestSendUpdatedInfo/ubuntu-os-release
+++ b/windows-agent/internal/proservices/landscape/testdata/TestSendUpdatedInfo/ubuntu-os-release
@@ -1,0 +1,13 @@
+PRETTY_NAME="Ubuntu Questing Quokka (development branch)"
+NAME="Ubuntu"
+VERSION_ID="25.10"
+VERSION="25.10 (Questing Quokka)"
+VERSION_CODENAME=questing
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=questing
+LOGO=ubuntu-logo


### PR DESCRIPTION
The spec WS043 deals with augmenting the Windows agent to report to the Landscape server about WSL instances not managed by this system. In that spec we restricted the information to only touch Ubuntu instances. Landscape's ultimate objective is to eventually send commands to remove such instances if the system administrator desires.

This PR implements a method in the agent's database to report the instances considered unmanaged (Ubuntu instances that didn't present themselves to the agent - what is done by the wsl-pro-service), which is later added to the hostagent info message the agent eventually sends to the server. The Landscape hostagent API dependency is updated to include that field. The list of unmanaged instances is a best effort snapshot, we don't cache that data for later comparison. To acquire information about the unmanaged instances we go rather invasively:
- We run the `hostname` command and
- We read the instance's `os-release` file from the Windows side, via its complete UNC path, such as `\\wsl.localhost\<DISTRO>\etc\os-release`.

The GoWSL dependency was also upgraded to cope with the need to launch the hostname command, which wasn't previously supported in the mocked backend.

---

UDENG-7822

---

Side note: the code coverage could get better if the GoWSL mock backend offered a way to predefine state for distros when queried, but implementing that is rather outside of the scope of this task.