### PR TITLE
maint: Cope with Windows SDK and Dart protoc plugin upgrades

### DIFF
--- a/agentapi/dart/lib/src/agentapi.pb.dart
+++ b/agentapi/dart/lib/src/agentapi.pb.dart
@@ -35,7 +35,7 @@ class Empty extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  Empty clone() => Empty()..mergeFromMessage(this);
+  Empty clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Empty copyWith(void Function(Empty) updates) =>
       super.copyWith((message) => updates(message as Empty)) as Empty;
@@ -80,7 +80,7 @@ class ProAttachInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  ProAttachInfo clone() => ProAttachInfo()..mergeFromMessage(this);
+  ProAttachInfo clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ProAttachInfo copyWith(void Function(ProAttachInfo) updates) =>
       super.copyWith((message) => updates(message as ProAttachInfo))
@@ -136,7 +136,7 @@ class LandscapeConfig extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  LandscapeConfig clone() => LandscapeConfig()..mergeFromMessage(this);
+  LandscapeConfig clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LandscapeConfig copyWith(void Function(LandscapeConfig) updates) =>
       super.copyWith((message) => updates(message as LandscapeConfig))
@@ -223,7 +223,7 @@ class SubscriptionInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  SubscriptionInfo clone() => SubscriptionInfo()..mergeFromMessage(this);
+  SubscriptionInfo clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SubscriptionInfo copyWith(void Function(SubscriptionInfo) updates) =>
       super.copyWith((message) => updates(message as SubscriptionInfo))
@@ -243,8 +243,16 @@ class SubscriptionInfo extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SubscriptionInfo>(create);
   static SubscriptionInfo? _defaultInstance;
 
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
+  @$pb.TagNumber(4)
+  @$pb.TagNumber(5)
   SubscriptionInfo_SubscriptionType whichSubscriptionType() =>
       _SubscriptionInfo_SubscriptionTypeByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
+  @$pb.TagNumber(4)
+  @$pb.TagNumber(5)
   void clearSubscriptionType() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
@@ -344,7 +352,7 @@ class LandscapeSource extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  LandscapeSource clone() => LandscapeSource()..mergeFromMessage(this);
+  LandscapeSource clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LandscapeSource copyWith(void Function(LandscapeSource) updates) =>
       super.copyWith((message) => updates(message as LandscapeSource))
@@ -364,8 +372,14 @@ class LandscapeSource extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LandscapeSource>(create);
   static LandscapeSource? _defaultInstance;
 
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
   LandscapeSource_LandscapeSourceType whichLandscapeSourceType() =>
       _LandscapeSource_LandscapeSourceTypeByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
   void clearLandscapeSourceType() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
@@ -433,7 +447,7 @@ class ConfigSources extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  ConfigSources clone() => ConfigSources()..mergeFromMessage(this);
+  ConfigSources clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ConfigSources copyWith(void Function(ConfigSources) updates) =>
       super.copyWith((message) => updates(message as ConfigSources))
@@ -517,7 +531,7 @@ class DistroInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  DistroInfo clone() => DistroInfo()..mergeFromMessage(this);
+  DistroInfo clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DistroInfo copyWith(void Function(DistroInfo) updates) =>
       super.copyWith((message) => updates(message as DistroInfo)) as DistroInfo;
@@ -616,7 +630,7 @@ class ProAttachCmd extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  ProAttachCmd clone() => ProAttachCmd()..mergeFromMessage(this);
+  ProAttachCmd clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ProAttachCmd copyWith(void Function(ProAttachCmd) updates) =>
       super.copyWith((message) => updates(message as ProAttachCmd))
@@ -672,7 +686,7 @@ class LandscapeConfigCmd extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  LandscapeConfigCmd clone() => LandscapeConfigCmd()..mergeFromMessage(this);
+  LandscapeConfigCmd clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LandscapeConfigCmd copyWith(void Function(LandscapeConfigCmd) updates) =>
       super.copyWith((message) => updates(message as LandscapeConfigCmd))
@@ -739,7 +753,7 @@ class MSG extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
-  MSG clone() => MSG()..mergeFromMessage(this);
+  MSG clone() => deepCopy();
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MSG copyWith(void Function(MSG) updates) =>
       super.copyWith((message) => updates(message as MSG)) as MSG;
@@ -757,7 +771,11 @@ class MSG extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MSG>(create);
   static MSG? _defaultInstance;
 
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
   MSG_Data whichData() => _MSG_DataByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
   void clearData() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)

--- a/gui/packages/p4w_ms_store/windows/CMakeLists.txt
+++ b/gui/packages/p4w_ms_store/windows/CMakeLists.txt
@@ -32,9 +32,8 @@ if (NOT NUGET)
     set(NUGET ${nuget_SOURCE_DIR}/nuget.exe)
 endif()
 # The cppwinrt.exe version chosen is the same of the [local_auth] plugin.
-# It's higher than the one shipped with SDK version 10.0.22621.0 (the current SDK version),
-# but not the latest available in NuGet repos.
-# The only machine-level side effect of this is the download of CppWinRT's nuget file to 
+# It's lower than the one shipped with SDK version 10.0.26100.0 (the current SDK version).
+# The only machine-level side effect of this is the download of CppWinRT's nuget file to
 # Nuget's cache (~.nuget\packages), and the unzipping of it to that same folder
 set(CPPWINRT_VERSION "2.0.220418.1")
 execute_process(COMMAND

--- a/msix/UbuntuProForWSL/Package.appxmanifest
+++ b/msix/UbuntuProForWSL/Package.appxmanifest
@@ -20,7 +20,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
     <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Resources>

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.wapproj
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.wapproj
@@ -19,7 +19,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>a2df9d69-019e-4ca2-a856-785448ed3908</ProjectGuid>
-    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>

--- a/msix/agent/agent.vcxproj
+++ b/msix/agent/agent.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6427bb31-c4be-4585-a090-10efdfb06b04}</ProjectGuid>
     <RootNamespace>agent</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ProjectName>ubuntu-pro-agent</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/msix/storeapi/storeapi.vcxproj
+++ b/msix/storeapi/storeapi.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{4ee3b168-c58d-4ae5-a259-1b5a04c018de}</ProjectGuid>
     <RootNamespace>storeapi</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/msix/storeapi/storeapi.vcxproj
+++ b/msix/storeapi/storeapi.vcxproj
@@ -65,6 +65,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);runtimeobject.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -88,6 +89,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);runtimeobject.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/storeapi/base/Exception.hpp
+++ b/storeapi/base/Exception.hpp
@@ -49,7 +49,7 @@ inline std::string to_string(ErrorCode err) {
     case ErrorCode::EmptyJwt:
       return "Empty user JWT was generated.";
     case ErrorCode::Unknown:
-      return "Unkown.";
+      return "Unknown.";
     case ErrorCode::None:
       return "";
   }

--- a/storeapi/test/CMakeLists.txt
+++ b/storeapi/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 # Latest Windows SDK for Windows 10/11
-set(CMAKE_SYSTEM_VERSION 10.0.22621.0)
+set(CMAKE_SYSTEM_VERSION 10.0.26100.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -77,12 +77,12 @@ if(MSVC)
         /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
         /permissive- # standards conformance mode for MSVC compiler.
         /fsanitize=address,leak,undefined
-        /Zi 
+        /Zi
         /INCREMENTAL:NO
         /await
     )
     target_compile_options(StoreApiServicesTests INTERFACE ${MSVC_OPTIONS})
- endif()
+endif()
 
 include(GoogleTest)
 gtest_discover_tests(StoreApiServicesTests DISCOVERY_MODE PRE_TEST)


### PR DESCRIPTION
The Windows 2025 GH runner no longer ships the SDK version 22621, instead it only comes with the version 26100.
While upgrading the SDK is usually advised and MS most often handles backwards compatibility, the runner image coming only with that version requires us to adjust a few things in the project:

- First: the target version/max version tested in the MSBuild files must be updated matching that SDK version
- The `storeapi.dll` project file needs to link explicitly against `runtimeobject.lib`. I couldn't find a public explanation for that or changelog entry, but noticed that pattern in the [cppwinrt tests](https://github.com/microsoft/cppwinrt/blob/34fba98b48cc4cf98e069f7f2c1f7f51122894cf/test/test/CMakeLists.txt#L59) as well as a Flutter plugin for Windows [CMake file](https://github.com/MaikuB/flutter_local_notifications/pull/2650/files#diff-77289d0befe4073b56ca99954645a420917e68af1d297ba13be85225ec4e4734). Apparently MSVC handled that implicitly before but not with the newest SDK versions.

Without those changes we see CI failing to link that DLL like [in here](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/18224571881/job/51892388907#step:9:24).

Besides that, the latest release of the Dart protoc plugin causes CI to fail in the generation step due diffs introduced by that plugin in the agentapi Dart bindings, so I'm pushing the changes here as well.

Finally I fixed a small typo I spotted while passing by some C++ sources :)