### PR TITLE
fix(CI): Invokes TiCS twice

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -376,6 +376,16 @@ jobs:
       - name: Install dependencies
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: Read flutter version
+        id: flutter-version
+        uses: ./.github/actions/read-file
+        with:
+          path: tools/flutter-version
+      - name: Set up flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: ${{ steps.flutter-version.outputs.contents }}
       - name: Download coverage artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
One for Linux and other for Windows

I just learned that the acronym UP4W seen in TiCS dashboard is a repository or project group, not the project itself, which is split in two projects. The correct way to report QA is then submitting it against the proper project name as seen in the dashboard.

The proper fix is likely to split CI entirely so we process wsl-pro-service differently from the Windows parts, but since they have parts in common, my first attempt is to report everything all together twice. Let's see how it goes.

I learned along the way that TiCS expects a coverage report at `./coverage/` for the Windows part and `./wsl-pro-service/.coverage/` for the Linux part (notice the dot). I'll check with them if we can at least use the same directory name.

Here's a good run (I temporarily removed the github.event_name guard): https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/18604233461/job/53050463703?pr=1406#logs

