### PR TITLE
fix(ci): No partial codecov uploads

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -252,7 +252,7 @@ jobs:
           mkdir -p ${cov_dir}/codecov ${cov_dir}/raw
           go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=count ./... -tags=gowslmock
           grep -hv -e "testutils" -e "pb.go:" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov
-          gocov convert ${cov_dir}/codecov/coverage.out.codecov | gocov-xml > ${cov_dir}/coverage.xml
+          gocov convert ${cov_dir}/codecov/coverage.out.codecov | gocov-xml > ${cov_dir}/codecov/coverage.xml
 
           SAFE_ID=$(echo "${{ matrix.subproject }}-${{ matrix.os }}" | tr '/' '_')
           echo "SAFE_ID=$SAFE_ID" >> $GITHUB_ENV
@@ -260,7 +260,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ env.SAFE_ID }}
-          path: ${{ matrix.subproject }}/coverage/coverage.xml
+          path: ${{ matrix.subproject }}/coverage/codecov/
       - name: Run tests (with race detector)
         shell: bash
         # -race not supported on Windows
@@ -298,7 +298,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/Cobertura.xml
+          files: ./coverage/Cobertura.xml,./artifacts/*/coverage.out.codecov
           disable_search: true
 
       - name: Determine TiCS run conditions


### PR DESCRIPTION
I remember relying solely on the Cobertura format for codecov was yielding subpar results because it didn't handle partial coverage in branches. Yet, that's not enough of a reason to preserve this step issuing partial uploads to codecov when we could just include the gocov binary format as part of the collected files from the test matrix.

So with this changeset I aim to include the filtered gocov binary format in the list of artifacts uploaded by the testing steps of the matrix and when recollecting all those artifacts we push both the Cobertura and the binary format at the same time.

That should stop those false alarms issued by codecov while CI is not yet finished.