### PR TITLE
fix(ci): Assume the MSIX bundle name won't contain tag or version

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -86,7 +86,7 @@ runs:
         $mainBundle = $doc.Root.Element($ns + "MainBundle")
         if ($mainBundle) {
           $mainBundle.SetAttributeValue("Version", "${UP4W_VERSION}.0")
-          $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${tag}/UbuntuProForWSL_${tag}.msixbundle")
+          $mainBundle.SetAttributeValue("Uri", "https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/${tag}/UbuntuProForWSL.msixbundle")
         }
         if ($releaseType -eq "pre-release") {
           # Point the App Installer file to the repo wiki instead of the latest stable release.

--- a/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
+++ b/msix/UbuntuProForWSL/UbuntuProForWSL.appinstaller
@@ -10,7 +10,7 @@ See https://github.com/canonical/ubuntu-pro-for-wsl/blob/main/.github/actions/bu
 		Name="CanonicalGroupLimited.UbuntuPro"
 		Version="0.0.0.0"
 		Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0"
-		Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/0.0.0/UbuntuProForWSL_0.0.0.msixbundle" />
+		Uri="https://github.com/canonical/ubuntu-pro-for-wsl/releases/download/0.0.0/UbuntuProForWSL.msixbundle" />
 	<Dependencies>
 		<Package
 		  Name="Microsoft.VCLibs.140.00.UWPDesktop"


### PR DESCRIPTION
We want the URL
https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.msixbundle to always work and always point to the latest **stable** release of this app.
If that file was named including the version, that wouldn't work. Thus we assume the people uploading the bundle to the release won't add the version to its name.
To prevent accidents, we assume the MSIX bundle file won't ever contain the version in its filename

---

UDENG-8328