### PR TITLE
fix(agent): Reserved distros match should be exact

### DIFF
--- a/windows-agent/internal/proservices/landscape/executor.go
+++ b/windows-agent/internal/proservices/landscape/executor.go
@@ -221,9 +221,9 @@ func (e executor) install(ctx context.Context, cmd *landscapeapi.Command_Install
 		}
 
 		id := distro.Name()
-		reserved := regexp.MustCompile(`(?i)Ubuntu-[0-9]{2}\.[0-9]{2}`)
+		reserved := regexp.MustCompile(`^(?i)Ubuntu-[0-9]{2}\.[0-9]{2}$`)
 		if strings.EqualFold(id, "Ubuntu") || strings.EqualFold(id, "Ubuntu-Preview") || reserved.Match([]byte(id)) {
-			return fmt.Errorf("target distro ID %s is reserved for installation from MS Store", id)
+			return fmt.Errorf("target distro ID %s is reserved and should not be used for custom instances", id)
 		}
 
 		e.sendProgressStatusMsg(ctx, landscapeapi.CommandState_InProgress)

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -202,6 +202,7 @@ func TestInstall(t *testing.T) {
 		"Error when the distro ID is reserved (Preview)":                  {sendRootfsURL: "goodfile", distroName: "Ubuntu-Preview", wantInstalled: false},
 		"Error when the distro ID is reserved (case sensitiveness)":       {sendRootfsURL: "goodfile", distroName: "ubuntu-preview", wantInstalled: false},
 		"Error when the distro ID is reserved (release numbers)":          {sendRootfsURL: "goodfile", distroName: "Ubuntu-19.13", wantInstalled: false},
+		"Success when the distro ID contains reserved (plus more)":        {sendRootfsURL: "goodfile", distroName: "My-Ubuntu-19.13", wantInstalled: true},
 		"Error when the distro ID is reserved (release numbers and case)": {sendRootfsURL: "goodfile", distroName: "uBuntu-19.13", wantInstalled: false},
 		"Error when the rootfs isn't a valid tarball":                     {sendRootfsURL: "badfile", wantInstalled: false},
 		"Error when the checksum doesn't match":                           {sendRootfsURL: "badchecksum", wantInstalled: false},


### PR DESCRIPTION
Without the fix the test cased added would fail like:

``` 
...
time="2025-10-30T18:09:27-03:00" level=info msg="Landscape: finished listening for commands."
time="2025-10-30T18:09:27-03:00" level=error msg="Landscape: could not execute command Install (id: \"My-Ubuntu-19.13\"), request : target distro ID My-Ubuntu-19.13 is reserved for installation from MS Store"
...

time="2025-10-30T18:09:37-03:00" level=info msg="Landscape: finished listening for commands."
--- FAIL: TestInstall (0.00s)
    --- FAIL: TestInstall/Success_when_the_distro_ID_contains_reserved_(plus_more) (10.18s)
        executor_test.go:269: Serving on http://127.0.0.1:34799
        executor_test.go:354: 
                Error Trace:    /home/carlos.santanadeoliveira@canonical.com/Dev/1_Work/up4w/main/windows-agent/internal/proservices/landscape/executor_test.go:354
                                                        /home/carlos.santanadeoliveira@canonical.com/Dev/1_Work/up4w/main/windows-agent/internal/proservices/landscape/executor_test.go:88
8
                                                        /home/carlos.santanadeoliveira@canonical.com/Dev/1_Work/up4w/main/windows-agent/internal/proservices/landscape/executor_test.go:27
1
                Error:          Condition never satisfied
                Test:           TestInstall/Success_when_the_distro_ID_contains_reserved_(plus_more)
                Messages:       Distro should have been registered
        executor_test.go:560: mockRootfsFileServer: serve error: accept tcp 127.0.0.1:34799: use of closed network connection
FAIL
FAIL    github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/landscape    10.210s
FAIL
```

That error would be unexpected for a distro instance named `My-Ubuntu-19.03` just because it contains the shape of an Ubuntu release. The match should be exact, fail and allow the distro instance to be created with that name, as it doesn't conflict with the real Ubuntu releases (ignore the numbering).