### PR TITLE
fix(windows-agent): Disable ALPN enforcement via the agent launcher

### DIFF
--- a/msix/ubuntu-pro-agent-launcher/console.cpp
+++ b/msix/ubuntu-pro-agent-launcher/console.cpp
@@ -1,7 +1,6 @@
 #include "console.hpp"
 
 #include <memory>
-#include <numeric>
 #include <type_traits>
 
 #include "error.hpp"
@@ -101,80 +100,7 @@ unique_attr_list PseudoConsoleProcessAttrList(HPCON con) {
   return result;
 }
 
-///  Models a Win32 Environment Strings block with merging capabilities and auto
-///  releasing semantics. Environment blocks are contiguous sequences of
-///  null-terminated strings obtained by calling GetEnvironmentStrings(), ended
-///  by an additional null character. They must be treated as read-only (even
-///  though the API returns RW pointers) and released by calling
-///  FreeEnvironmentStrings.
-class EnvironmentBlock {
-  // unique_ptr guarantees calling the deleter when this object goes out of
-  // scope no matter how.
-  using RawBlockT =
-      std::unique_ptr<wchar_t[], decltype(&::FreeEnvironmentStringsW)>;
-  static BOOL noopDeleter(wchar_t*) { return TRUE; }
-  RawBlockT block_ = {nullptr, noopDeleter};
-  size_t countChars_ = 0;
-  // A theoretical limit for environment blocks to make sure we won't loop
-  // forever when counting the OS-provided block size.
-  static constexpr unsigned int kMmaxEnvBlockSize = 65536;
-
-  // A read-only pointer to the beginning of the block, as per STL conventions.
-  const wchar_t* cbegin() const { return block_.get(); }
-  // A read-only pointer to 1 past the end of the block, as per STL conventions.
-  const wchar_t* cend() const { return block_.get() + countChars_; }
-
- public:
-  explicit EnvironmentBlock(wchar_t* envStrings) {
-    if (envStrings == nullptr) {
-      return;
-    }
-    // Calculate the size of the environment strings block
-    const wchar_t* cursor = envStrings;
-    unsigned int count = 0;
-    while (count < kMmaxEnvBlockSize) {
-      if (*cursor == L'\0' && *(cursor + 1) == L'\0') {
-        count += 2;
-        break;
-      }
-      count++;
-      cursor++;
-    }
-    if (count >= kMmaxEnvBlockSize) {
-      throw hresult_exception{ERROR_BAD_ENVIRONMENT};
-    }
-    countChars_ = count;
-    block_ = {envStrings, &::FreeEnvironmentStringsW};
-  }
-
-  /// Returns a new environment block merging this with the specified additional
-  /// environment variables in [env], described as "KEY=VALUE" null-terminated
-  /// strings.
-  std::vector<wchar_t> mergeWith(
-      std::initializer_list<std::wstring> env) const {
-    std::vector<wchar_t> merged;
-    auto envTotalSize = std::accumulate(
-        env.begin(), env.end(), size_t{0},
-        [](size_t acc, const std::wstring& s) { return acc + s.size() + 1; });
-    merged.reserve(countChars_ + envTotalSize);
-    for (auto& var : env) {
-      std::copy(var.begin(), var.end(), std::back_inserter(merged));
-      merged.push_back(L'\0');
-    }
-
-    if (block_ == nullptr) {
-      merged.push_back(L'\0');
-      return merged;
-    }
-
-    std::copy(cbegin(), cend(), std::back_inserter(merged));
-    return merged;
-  }
-};
-
-Process PseudoConsole::StartProcess(
-    std::wstring commandLine,
-    std::initializer_list<std::wstring> envVars) const {
+Process PseudoConsole::StartProcess(std::wstring commandLine) {
   unique_attr_list attributes = PseudoConsoleProcessAttrList(hDevice);
   // Prepare Startup Information structure
   STARTUPINFOEX si{};
@@ -185,13 +111,10 @@ Process PseudoConsole::StartProcess(
   si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
   si.lpAttributeList = attributes.get();
 
-  EnvironmentBlock envBlock{GetEnvironmentStringsW()};
-  auto env = envBlock.mergeWith(envVars);
-
   Process p{};
   if (!CreateProcessW(NULL, commandLine.data(), NULL, NULL, FALSE,
-                      EXTENDED_STARTUPINFO_PRESENT, env.data(), NULL,
-                      &si.StartupInfo, &p)) {
+                      EXTENDED_STARTUPINFO_PRESENT, NULL, NULL, &si.StartupInfo,
+                      &p)) {
     throw hresult_exception{HRESULT_FROM_WIN32(GetLastError())};
   }
 

--- a/msix/ubuntu-pro-agent-launcher/console.hpp
+++ b/msix/ubuntu-pro-agent-launcher/console.hpp
@@ -57,11 +57,8 @@ class PseudoConsole {
   HANDLE GetReadHandle() const { return hOutRead; }
 
   /// Starts a child process under this pseudo-console by running the fully
-  /// specified [commandLine]. If provided, the [envVars] will be merged with
-  /// the parent process' environment for the child process. Each string in
-  /// [envVars] must be in the form "KEY=VALUE" as expected by the Win32 APIs.
-  Process StartProcess(std::wstring commandLine,
-                       std::initializer_list<std::wstring> envVars = {}) const;
+  /// specified [commandLine]. The child process inherits the parent environment.
+  Process StartProcess(std::wstring commandLine);
 
   ~PseudoConsole();
 };


### PR DESCRIPTION
By default attempting to connect to the staging Landscape SaaS errors out: `cannot check peer: missing selected ALPN property.`.

```text
could not connect to Landscape server: could not connect to Landscape server: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property. If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement. For more details, see: https://github.com/grpc/grpc-go/issues/434"
```

The go-grpc documentation advises that they will support disabling this enforcement for a while, users opt in by setting the environment variable `GRPC_ENFORCE_ALPN_ENABLED` to "false".

While we could technically do so in the agent code itself, there is a potential for subtle bugs if go-grpc started to check this environment variable in a package `init()` function. So the more reliable way is to have it defined before starting the agent.

MSIX packaging doesn't support defining environment variables by default. Workarounds exist, such as using the Packaging Support Framework, but that adds more complexity to the packaging for little benefit, given we have a parent process we control: the `ubuntu-pro-agent-launcher`. We can reliably use that program to set environment variables that agent will see during its lifetime, so it's a good place to do it.

The "challenge" is doing so using just the Win32 APIs (we don't leverage other libraries in that project to keep it simple). The "proper" way to privately set environment variables for a child process is by passing a pointer to a contiguous block of environment variable strings of shape `VAR1=VALUE1\0VAR2=VALUE2\0...`, for which case merging with the parent environment must be done manually. Argh. I made https://github.com/canonical/ubuntu-pro-for-wsl/pull/1440/commits/19b19481768b37e67c2f10143ccdf13570e5db9a just to show off and justify why I prefer the "ugly" approach of just set the environment variable in the parent process's block. It's so much easier and long term maintainable **provided we don't spawn many processes with their own requirements about environment variables**, which is the current case: we just spawn the agent, we just need one additional environment variable and hopefully not for very long, as eventually Landscape should support ALPN (otherwise gRPC will break us removing the opt-out feature in a near future release). So yeah, ugly is fine.

Testing this build from CI successfully connected to Landscape staging: https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/19471279553/artifacts/4603217638 (0.9999b7-3-g584bb5bd).

---

UDENG-8506