### PR TITLE
fix(custom-ubuntu-distro): Fix spellcheck error against chroot

### DIFF
--- a/docs/howto/custom-ubuntu-distro.md
+++ b/docs/howto/custom-ubuntu-distro.md
@@ -255,7 +255,7 @@ When you're finished managing packages, exit the `chroot` environment:
 exit
 ```
 
-After exiting the chroot environment it's useful to cleanup the mount points.
+After exiting the `chroot` environment it's useful to cleanup the mount points.
 
 ```{code-block} text
 $ sudo umount -R myNewUbuntu/proc


### PR DESCRIPTION
Fixes spellcheck error against chroot as discussed in #1452 
- Ensure chroot is in an inline-code block