### PR TITLE
docs: replace msstore download links for app

### DIFF
--- a/docs/howto/set-up-up4w.md
+++ b/docs/howto/set-up-up4w.md
@@ -22,9 +22,7 @@ You should also verify that the [firewall rules are correctly set up](../referen
 (howto::install-up4w)=
 ## Install Ubuntu Pro for WSL
 
-You can install Pro for WSL [on this page of the Microsoft Store](https://apps.microsoft.com/detail/9PD1WZNBDXKZ):
-
-![Install Ubuntu Pro for WSL from the Store](./assets/store.png)
+Pro for WSL can be installed from [ubuntu.com/desktop/wsl](https://ubuntu.com/desktop/wsl).
 
 (howto::config-up4w)=
 ## Choose a configuration method

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -27,7 +27,7 @@ You should then be ready for more advanced usage scenarios.
 
 ## What you will do
 
-- Install Pro for WSL from the Microsoft Store
+- Install Pro for WSL
 - Configure Pro for WSL with a Pro token
 - Test automatic Pro-attachment of WSL instances
 
@@ -135,9 +135,9 @@ Once you have a token you are ready to install Pro for WSL.
 (tut::get-up4w)=
 ### Install and configure Ubuntu Pro for WSL
 
-Pro for WSL can be installed from [this link to the Microsoft Store](https://apps.microsoft.com/detail/9PD1WZNBDXKZ).
+Pro for WSL can be installed from [ubuntu.com/desktop/wsl](https://ubuntu.com/desktop/wsl).
 
-Open the application and paste the token you copied from the Ubuntu Pro dashboard:
+Once installed, open the application and paste the token you copied from the Ubuntu Pro dashboard:
 
 ![Main screen of the Pro for WSL GUI](../assets/token-input-placeholder.png)
 


### PR DESCRIPTION
The MS Store link is not live yet.

We can point users to the WSL page on the Ubuntu website, which includes an install link.