### PR TITLE
docs: fix sitemap regression introduced in 1.3.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,12 +185,8 @@ html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 
+sitemap_url_scheme = '{link}'
 
-if "READTHEDOCS_VERSION" in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = "{version}{link}"
-else:
-    sitemap_url_scheme = "stable/{link}"
 # Include `lastmod` dates in the sitemap:
 
 sitemap_show_lastmod = True


### PR DESCRIPTION
The 1.3.0 starter pack introduced a regression that duplicated versions in sitemaps, leading to malformed URLs. 1.3.0 introduced fetching the canonical URL from a RTD environment variable. In versioned docs, this URL includes the version, which means that the previous logic to set the sitemap_url_scheme is no longer necessary and duplicates the version.

This change should hopefully fix the sitemaps, but we'll only be able to check after merging.