### PR TITLE
docs: disable faulty edit button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,9 +164,9 @@ if os.getenv("OPENAPI", ""):
 # - https://launchpad.net/example
 # - https://git.launchpad.net/example
 #
-html_theme_options = {
-    "source_edit_link": "https://github.com/canonical/ubuntu-pro-for-wsl",
-}
+# html_theme_options = {
+#     "source_edit_link": "https://github.com/canonical/ubuntu-pro-for-wsl",
+# }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #


### PR DESCRIPTION
The edit button functionality of the starter pack is incompatible with tagged versions.

Currently, the edit button functions for `latest`, which builds from a branch, but not `stable`, which builds from a tag. Users who click edit when on `stable` get a 404, which is not good when the button is supposed to be a convenience feature.

The maintainers of the starter pack have not settled on a solution to this problem, and it is not possible to only enable the button on a per-branch basis, so it should be disabled until the problem is fixed.

UDENG-8691