### PR TITLE
maint(wsl-pro-service): Update changelog for version 0.1.19

### DIFF
--- a/wsl-pro-service/debian/changelog
+++ b/wsl-pro-service/debian/changelog
@@ -1,11 +1,11 @@
-wsl-pro-service (0.1.19) UNRELEASED; urgency=medium
+wsl-pro-service (0.1.19) resolute; urgency=medium
 
   * Packaging fixes to prevent lintian errors.
   * Better sync with cloud-init.
   * Improved Go version detection for packaging.
   * Upgrade Go to 1.24 and multiple dependencies.
 
- -- Carlos Nihelton <cnihelton@ubuntu.com>  Wed, 17 Dec 2025 11:27:24 -0300
+ -- Carlos Nihelton <cnihelton@ubuntu.com>  Wed, 17 Dec 2025 18:15:30 -0300
 
 wsl-pro-service (0.1.18) plucky; urgency=medium
 


### PR DESCRIPTION
I wanted to include a last minute change but time won't allow it.
I'll trigger a new release tomorrow morning, which will encompass small fixes to the Windows app, documentation and wsl-pro-service (for resolute only ofc).