### PR TITLE
feat(windows-agent): Ensure telemetry consent registry is set and valid

### DIFF
--- a/msix/UbuntuProForWSL/Package.appxmanifest
+++ b/msix/UbuntuProForWSL/Package.appxmanifest
@@ -12,6 +12,7 @@
     <virtualization:RegistryWriteVirtualization>
       <virtualization:ExcludedKeys>
         <virtualization:ExcludedKey>HKEY_CURRENT_USER\Software\Canonical\UbuntuPro</virtualization:ExcludedKey>
+        <virtualization:ExcludedKey>HKEY_CURRENT_USER\Software\Canonical\Ubuntu</virtualization:ExcludedKey>
       </virtualization:ExcludedKeys>
     </virtualization:RegistryWriteVirtualization>
     <uap13:AutoUpdate>

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
@@ -28,6 +28,16 @@ func (Windows) WriteValue(k Key, field, value string, multiLine bool) error {
 	panic("the Windows registry is not available on Linux")
 }
 
+// ReadIntegerValue reads the value of the specified integer (DWORD or QWORD) field in the specified key.
+func (Windows) ReadIntegerValue(k Key, field string) (uint64, error) {
+	panic("the Windows registry is not available on Linux")
+}
+
+// SetDWordValue sets the value of the specified DWORD field in the specified key.
+func (Windows) SetDWordValue(k Key, field string, value uint32) error {
+	panic("the Windows registry is not available on Linux")
+}
+
 // RegNotifyChangeKeyValue creates an event and attaches it to a registry key.
 // Modifying that key or its children will trigger the event.
 // This trigger can be detected by WaitForSingleObject.

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
@@ -28,8 +28,8 @@ func (Windows) WriteValue(k Key, field, value string, multiLine bool) error {
 	panic("the Windows registry is not available on Linux")
 }
 
-// ReadIntegerValue reads the value of the specified integer (DWORD or QWORD) field in the specified key.
-func (Windows) ReadIntegerValue(k Key, field string) (uint64, error) {
+// ReadDWordValue reads the value of the specified DWORD integer field in the specified key.
+func (Windows) ReadDWordValue(k Key, field string) (uint64, error) {
 	panic("the Windows registry is not available on Linux")
 }
 

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
@@ -347,8 +347,8 @@ func (r *Mock) WriteValue(ptr Key, field, value string, multiString bool) error 
 	return nil
 }
 
-// ReadIntegerValue reads the value of the specified integer (DWORD or QWORD) field in the specified key.
-func (r *Mock) ReadIntegerValue(ptr Key, field string) (uint64, error) {
+// ReadDWordValue reads the value of the specified DWORD integer field in the specified key.
+func (r *Mock) ReadDWordValue(ptr Key, field string) (uint64, error) {
 	if ptr == 0 {
 		return 0, errors.New("null key")
 	}

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
@@ -87,8 +87,8 @@ func (Windows) WriteValue(k Key, field, value string, multiLine bool) error {
 	return translateRegistryError(err)
 }
 
-// ReadIntegerValue reads the value of the specified integer (DWORD or QWORD) field in the specified key.
-func (Windows) ReadIntegerValue(k Key, field string) (uint64, error) {
+// ReadDWordValue reads the value of the specified DWORD integer field in the specified key.
+func (Windows) ReadDWordValue(k Key, field string) (uint64, error) {
 	value, _, err := registry.Key(k).GetIntegerValue(field)
 	if errors.Is(err, registry.ErrNotExist) {
 		return 0, ErrFieldNotExist

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
@@ -89,6 +89,30 @@ func (Windows) WriteValue(k Key, field, value string, multiLine bool) error {
 	return err
 }
 
+// ReadIntegerValue reads the value of the specified integer (DWORD or QWORD) field in the specified key.
+func (Windows) ReadIntegerValue(k Key, field string) (uint64, error) {
+	value, _, err := registry.Key(k).GetIntegerValue(field)
+	if errors.Is(err, registry.ErrNotExist) {
+		return 0, ErrFieldNotExist
+	} else if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+// SetDWordValue sets the value of the specified DWORD field in the specified key.
+func (Windows) SetDWordValue(k Key, field string, value uint32) error {
+	err := registry.Key(k).SetDWordValue(field, value)
+	if errors.Is(err, registry.ErrNotExist) {
+		return ErrKeyNotExist
+	}
+	if errors.Is(err, syscall.Errno(5)) {
+		return ErrAccessDenied
+	}
+	return err
+}
+
 // RegNotifyChangeKeyValue creates an event and attaches it to a registry key.
 // Modifying that key or its children will trigger the event.
 // This trigger can be detected by WaitForSingleObject.

--- a/windows-agent/internal/proservices/registrywatcher/watcher.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher.go
@@ -47,7 +47,7 @@ type Registry interface {
 	CloseKey(k registry.Key)
 	ReadValue(k registry.Key, field string) (value string, err error)
 	WriteValue(k registry.Key, field, value string, multiline bool) (err error)
-	ReadIntegerValue(k registry.Key, field string) (uint64, error)
+	ReadDWordValue(k registry.Key, field string) (uint64, error)
 	SetDWordValue(k registry.Key, field string, value uint32) error
 
 	// Win32 stuff: not strictly registry but not worth separating out
@@ -342,7 +342,7 @@ func setDefaultTelemetryConsent(r Registry) (err error) {
 	defer r.CloseKey(key)
 
 	// Initialize consent to "false" if not present, or is not either 0 or 1.
-	val, err := r.ReadIntegerValue(key, telemetryConsentField)
+	val, err := r.ReadDWordValue(key, telemetryConsentField)
 	if err == nil && (val == 0 || val == 1) {
 		// Consent already properly initialized
 		return nil

--- a/windows-agent/internal/proservices/registrywatcher/watcher_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher_test.go
@@ -238,7 +238,7 @@ func TestDefaultTelemetryConsent(t *testing.T) {
 			require.NoError(t, err)
 			defer reg.CloseKey(k)
 
-			val, err := reg.ReadIntegerValue(k, telemetryField)
+			val, err := reg.ReadDWordValue(k, telemetryField)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantValue, val)
 		})


### PR DESCRIPTION
The telemetry consent registry key found at Software\Canonical\UbuntuPro is used by wsl-setup to determine what it should use for Ubuntu Insights consent. If it is not set, then it will prompt the user.

Here, we default the registry value to zero whenever the Windows Agent watcher starts if it is not already set to ensure that this new behavior does not break the workflows of those utilizing Ubuntu Pro for WSL. This is only initial behavior, and we should eventually expand upon this to provide the user with greater control of consent through all of their WSL instances via UP4W in the future.

Though we now read and modify the registry path `Software/Canonical/Ubuntu`, Ubuntu Pro for WSL should not be considered the owner of this path, and it should *not* clean it up on uninstall as Ubuntu for WSL uses it independently.