### PR TITLE
maint(CI): Revert "maint(CI): Always push to the package Flight"

### DIFF
--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -50,11 +50,15 @@ jobs:
           New-SubmissionPackage -ConfigPath .\msix\SBConfig.json -Verbose
           $subFileStem="out\appstore-submission"
           Get-Content "$subFileStem.json"
+          if ($env:pre_release -eq "pre-release") {
             # The existing package flight for beta testers.
             $flightId="876dc297-0b4d-4a74-94ef-720279050fc4"
             Write-Output "Starting a new submission under package flight $flightId from:"
             Get-ChildItem ./msix/UbuntuProForWSL/AppPackages/
             $sub, $url = Update-ApplicationFlightSubmission -AppId $appid -FlightId $flightId -SubmissionDataPath "$subFileStem.json" -PackagePath "$subFileStem.zip" -Force -AutoCommit -ReplacePackages -Verbose
+          } else {
+            $sub, $url = Update-ApplicationSubmission -AppId $appid -SubmissionDataPath "$subFileStem.json" -PackagePath "$subFileStem.zip" -Force -ReplacePackages -AutoCommit -Verbose
+          }
           Write-Output "If needed the package built by this run can be downloaded from:"
           Write-Output $url
           Write-Output "Access the submission via the link below:"


### PR DESCRIPTION
Reverts canonical/ubuntu-pro-for-wsl#1470

As said before, that was a temporary measure. We should no longer need to always push to package flights.
While we'd still need the two release channels is a separate topic we might want to discuss further at another point, but for now let's undo this and push stable releases directly to the main channel in MS Store.