### PR TITLE
fix(CI): Chocolatey can't find the nupkg by globbing

### DIFF
--- a/.github/workflows/chocolatey.yaml
+++ b/.github/workflows/chocolatey.yaml
@@ -8,6 +8,12 @@ on:
   release:
     types: [published] # Only triggers for stable releases.
   workflow_dispatch:
+    inputs:
+      publish-package:
+        description: Publish the package built in this workflow run
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   update-choco-assets:
@@ -116,7 +122,7 @@ jobs:
           choco uninstall ubuntu-pro-for-wsl --verbose
 
       - name: Push to chocolatey.org
-        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-package == 'true' ) }}
         run: |
           $tag=$(Get-Content .\tools\asset.json | ConvertFrom-JSON).tag
           choco apikey --key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/

--- a/.github/workflows/chocolatey.yaml
+++ b/.github/workflows/chocolatey.yaml
@@ -116,7 +116,7 @@ jobs:
           choco uninstall ubuntu-pro-for-wsl --verbose
 
       - name: Push to chocolatey.org
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         run: |
           $tag=$(Get-Content .\tools\asset.json | ConvertFrom-JSON).tag
           choco apikey --key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/

--- a/.github/workflows/chocolatey.yaml
+++ b/.github/workflows/chocolatey.yaml
@@ -118,6 +118,7 @@ jobs:
       - name: Push to chocolatey.org
         if: ${{ github.event_name == 'release' }}
         run: |
+          $tag=$(Get-Content .\tools\asset.json | ConvertFrom-JSON).tag
           choco apikey --key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/
-          choco push ubuntu-pro-for-wsl.*.nupkg --source https://push.chocolatey.org/
+          choco push ".\ubuntu-pro-for-wsl.$tag.nupkg" --source https://push.chocolatey.org/
 


### PR DESCRIPTION
https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/21370969012/job/61515105826 failed because attempting to push the nupkg while referring to it by a file glob instead of its precise name failed. Here's a demo of the problem:

```powershell
PS D:\up4w\msix\chocolatey> choco push ubuntu-pro-for-wsl.*.nupkg --source https://push.chocolatey.org/ --api-key asjdaishgahsfa
Chocolatey v2.6.0
The file is not a valid nupkg. File path: ubuntu-pro-for-wsl.*.nupkg
PS D:\up4w\msix\chocolatey> ls


    Diretório: D:\up4w\msix\chocolatey


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----        15/01/2026     16:30                tools
-a----        15/01/2026     16:09           2563 README.md
-a----        15/01/2026     16:30           7459 ubuntu-pro-for-wsl.1.0.1.nupkg
-a----        16/01/2026     09:01           3657 ubuntu-pro-for-wsl.nuspec.template
-a----        15/01/2026     16:30           6209 ubuntu-pro-for-wsl.nuspec.xml


PS D:\up4w\msix\chocolatey> choco push ubuntu-pro-for-wsl.1.0.1.nupkg --source https://push.chocolatey.org/ --api-key asjdaishgahsfa
Chocolatey v2.6.0
Attempting to push ubuntu-pro-for-wsl.1.0.1.nupkg to https://push.chocolatey.org/
```

`choco push` defaults to pushing a single `.nupkg` found in the current working directory if no path is provided. If there's more than one, then it fails, and we'd have to tell it which package to upload.

For better or worse let's be precise and make sure we're attempting to upload just the asset relevant for this release. This PR proposes doing exactly that by recovering the release tag (what matches the nupkg version) from the `tools\asset.json` file written a few steps before the publishing, and interpolating that value to match precisely the nupkg built in this workflow. We could have just read the current working directory after choco pack as well and making the output of `$(get-item -path ubuntu-pro-for-wsl.*.nupkg).Name` be a output used in the publishing step. If there was more than one nupkg though, that strategy would fail. Ofc that's a theoretical scenario, as we start with none and build only one nupkg.

I'm also allowing CI to publish on `workflow_dispatch` because we'll no longer trigger the on-release event today. I'm likely to revert that commit, though.