### PR TITLE
fix(wsl-pro-service): Subprocess cmd.exe in unicode mode

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.24.13
 
 use (
 	./agentapi

--- a/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
+++ b/wsl-pro-service/cmd/wsl-pro-service/service/service_test.go
@@ -306,4 +306,3 @@ func captureStdout(t *testing.T) func() string {
 func TestWithProMock(t *testing.T)     { testutils.ProMock(t) }
 func TestWithWslPathMock(t *testing.T) { testutils.WslPathMock(t) }
 func TestWithWslInfoMock(t *testing.T) { testutils.WslInfoMock(t) }
-func TestWithCmdExeMock(t *testing.T)  { testutils.CmdExeMock(t) }

--- a/wsl-pro-service/go.mod
+++ b/wsl-pro-service/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
+	golang.org/x/text v0.31.0
 	google.golang.org/grpc v1.78.0
 	gopkg.in/ini.v1 v1.67.1
 )
@@ -34,7 +35,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda // indirect
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/wsl-pro-service/internal/commandservice/commandservice_test.go
+++ b/wsl-pro-service/internal/commandservice/commandservice_test.go
@@ -152,4 +152,3 @@ func TestWithProMock(t *testing.T)             { testutils.ProMock(t) }
 func TestWithLandscapeConfigMock(t *testing.T) { testutils.LandscapeConfigMock(t) }
 func TestWithWslPathMock(t *testing.T)         { testutils.WslPathMock(t) }
 func TestWithWslInfoMock(t *testing.T)         { testutils.WslInfoMock(t) }
-func TestWithCmdExeMock(t *testing.T)          { testutils.CmdExeMock(t) }

--- a/wsl-pro-service/internal/daemon/daemon_test.go
+++ b/wsl-pro-service/internal/daemon/daemon_test.go
@@ -520,4 +520,3 @@ func (s *mockService) ApplyLandscapeConfig(ctx context.Context, msg *agentapi.La
 func TestWithProMock(t *testing.T)     { testutils.ProMock(t) }
 func TestWithWslPathMock(t *testing.T) { testutils.WslPathMock(t) }
 func TestWithWslInfoMock(t *testing.T) { testutils.WslInfoMock(t) }
-func TestWithCmdExeMock(t *testing.T)  { testutils.CmdExeMock(t) }

--- a/wsl-pro-service/internal/streams/server_test.go
+++ b/wsl-pro-service/internal/streams/server_test.go
@@ -195,4 +195,3 @@ func (s *mockService) ApplyLandscapeConfig(ctx context.Context, msg *agentapi.La
 func TestWithProMock(t *testing.T)     { testutils.ProMock(t) }
 func TestWithWslPathMock(t *testing.T) { testutils.WslPathMock(t) }
 func TestWithWslInfoMock(t *testing.T) { testutils.WslInfoMock(t) }
-func TestWithCmdExeMock(t *testing.T)  { testutils.CmdExeMock(t) }

--- a/wsl-pro-service/internal/system/export_test.go
+++ b/wsl-pro-service/internal/system/export_test.go
@@ -7,3 +7,13 @@ func (s *System) CmdExeCache() *string {
 }
 
 type RealBackend = realBackend
+type StrictUTF16Transformer = strictUTF16Transformer
+
+// ErrOddByteCount is the error returned by the strictUTF16Tranformer when the source contains an
+// odd number of bytes, exported just for testing, as it's only an implementation detail.
+var ErrOddByteCount = errOddByteCount
+
+// ErrInvalidSurrogatePair is the error returned by the strictUTF16Transformer when a supposed
+// surrogate pair doesn't meet the expected byte range, exported just for testing as it's only an
+// implementation detail.
+var ErrInvalidSurrogatePair = errInvalidSurrogatePair

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -15,11 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
-
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
 	"github.com/ubuntu/decorate"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 	"gopkg.in/ini.v1"
 )
 

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -186,7 +186,14 @@ func decodeUtf16Le(input bytes.Buffer) (string, error) {
 	if _, err := io.Copy(&sb, reader); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(sb.String()), nil
+	// The step above is unlikely to fail due ill-formed UTF-16 data, because the decoder is
+	// designed for robustness, so it just replaces invalid pieces with U+FFFD.
+	// We need to check for the replacement char manually then:
+	decoded := sb.String()
+	if strings.Contains(decoded, "�") {
+		return "", fmt.Errorf("result should not contain the U+FFFD char: %s", decoded)
+	}
+	return strings.TrimSpace(decoded), nil
 }
 
 // UserProfileDir provides the path to Windows' user profile directory from WSL,

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -179,7 +179,7 @@ func decodeUtf16Le(input bytes.Buffer) (string, error) {
 	if _, err := io.Copy(&sb, reader); err != nil {
 		return "", err
 	}
-	// The step above is unlikely to fail due ill-formed UTF-16 data, because the decoder is
+	// The step above is unlikely to fail due to ill-formed UTF-16 data, because the decoder is
 	// designed for robustness, so it just replaces invalid pieces with U+FFFD.
 	// We need to check for the replacement char manually then:
 	decoded := sb.String()

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -173,13 +173,6 @@ func (s *System) WslDistroName(ctx context.Context) (name string, err error) {
 
 // decodeUtf16Le decodes a bytes.Buffer containing (presumed small amount of) UTF-16LE encoded data into a string.
 func decodeUtf16Le(input bytes.Buffer) (string, error) {
-	// This ugly hack is to support testing with mocked cmd.exe. We mock executables by subprocessing a go test binary.
-	// As much as I try to force it to output UTF-16, it ends up eating the last NULL byte of the '\n' sequence, resulting in '\r\n' being
-	// represented as 0x0d 0x00 0x0a (missing 0x00). So we detect this very specific case and add the missing NULL byte back.
-	rawBytes := input.Bytes()
-	if len(rawBytes) >= 3 && len(rawBytes)%2 == 1 && bytes.Equal(rawBytes[len(rawBytes)-3:], []byte{0x0d, 0x00, 0x0a}) {
-		input.WriteByte(0x00)
-	}
 	utf16le := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 	reader := transform.NewReader(bytes.NewReader(input.Bytes()), utf16le.NewDecoder())
 	var sb strings.Builder

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -235,7 +235,7 @@ func TestUserProfileDir(t *testing.T) {
 				mock.SetControlArg(testutils.CmdExeErr)
 			}
 			if tc.cmdEncodingErr {
-				mock.SetControlArg(testutils.CmdEncodingErr)
+				mock.SetControlArg(testutils.CmdExeEncodingErr)
 			}
 			if tc.emptyUserprofileEnvVar {
 				mock.SetControlArg(testutils.EmptyUserprofileEnvVar)

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -820,4 +820,3 @@ func TestWithProMock(t *testing.T)             { testutils.ProMock(t) }
 func TestWithLandscapeConfigMock(t *testing.T) { testutils.LandscapeConfigMock(t) }
 func TestWithWslPathMock(t *testing.T)         { testutils.WslPathMock(t) }
 func TestWithWslInfoMock(t *testing.T)         { testutils.WslInfoMock(t) }
-func TestWithCmdExeMock(t *testing.T)          { testutils.CmdExeMock(t) }

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -202,6 +202,7 @@ func TestUserProfileDir(t *testing.T) {
 		cachedCmdExe           bool
 		cmdExeNotExist         bool
 		cmdExeErr              bool
+		cmdEncodingErr         bool
 		emptyUserprofileEnvVar bool
 		wslpathErr             bool
 		wslpathBadOutput       bool
@@ -219,6 +220,7 @@ func TestUserProfileDir(t *testing.T) {
 		"Error finding cmd.exe because there is no Windows FS in /proc/mounts": {wantErr: true, overrideProcMount: true},
 		"Error when cmd.exe does not exist":                                    {cmdExeNotExist: true, overrideProcMount: true, wantErr: true},
 		"Error on cmd.exe error":                                               {cmdExeErr: true, wantErr: true},
+		"Error on cmd.exe output encoding wrong":                               {cmdEncodingErr: true, wantErr: true},
 		"Error when UserProfile env var is empty":                              {emptyUserprofileEnvVar: true, wantErr: true},
 		"Error on wslpath error":                                               {wslpathErr: true, wantErr: true},
 		"Error when wslpath returns a bad path":                                {wslpathBadOutput: true, wantErr: true},
@@ -231,6 +233,9 @@ func TestUserProfileDir(t *testing.T) {
 			system, mock := testutils.MockSystem(t)
 			if tc.cmdExeErr {
 				mock.SetControlArg(testutils.CmdExeErr)
+			}
+			if tc.cmdEncodingErr {
+				mock.SetControlArg(testutils.CmdEncodingErr)
 			}
 			if tc.emptyUserprofileEnvVar {
 				mock.SetControlArg(testutils.EmptyUserprofileEnvVar)

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -15,13 +15,12 @@ import (
 	"syscall"
 	"testing"
 
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
-
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/system"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 // SystemMock is used to override system's behaviour. Its control parameters are not thread safe.

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -619,7 +619,9 @@ func CmdExeMock(t *testing.T) {
 			return exitBadUsage
 		}
 
-		if argv[0] != "/U" || argv[1] != "/C" {
+		// The /C and /U flags could come in any relative order and are case insensitive.
+		flags := strings.ToLower(strings.Join(argv[0:2], ""))
+		if flags != "/u/c" && flags != "/c/u" {
 			fmt.Fprintf(errWriter, "Mock not implemented for args %q\n", argv)
 			return exitBadUsage
 		}

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -92,7 +92,8 @@ const (
 	WslpathBadOutput       = "UP4W_WSLPATH_BAD_OUTPUT"
 	EmptyUserprofileEnvVar = "UP4W_EMPTY_USERPROFILE_ENV_VAR"
 
-	CmdExeErr = "UP4W_CMDEXE_ERR"
+	CmdExeErr      = "UP4W_CMDEXE_ERR"
+	CmdEncodingErr = "UP4W_CMD_ENCODING_ERR"
 
 	WslInfoErr   = "UP4W_WSLINFO_ERR"
 	WslInfoIsNAT = "UP4W_WSLINFO_IS_NAT"
@@ -633,6 +634,12 @@ func CmdExeMock(t *testing.T) {
 
 		if envExists(CmdExeErr) {
 			return exitError
+		}
+
+		if envExists(CmdEncodingErr) {
+			// We want to print non-UTF-16 in this particular case.
+			fmt.Print("I am UTF-8 🦄 !\r\n")
+			return exitOk
 		}
 
 		outWriter := transform.NewWriter(os.Stdout, utf16le.NewEncoder())

--- a/wsl-pro-service/internal/testutils/mock_executables_linux.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_linux.go
@@ -10,7 +10,7 @@ import (
 
 // CmdExe mocks `cmd.exe $args...` on Linux.
 // It's special because we want this Cmd to output UTF-16, we cannot go through `go test`,
-// as it prevents us from priting arbitrary UTF-16 encoded text.
+// as it prevents us from printing arbitrary UTF-16 encoded text.
 // Thus, on Linux, we pipe the desired output to iconv (unless an encoding error is desired, for
 // which case the relevant control argument will be set in the mock).
 func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *exec.Cmd {
@@ -19,9 +19,13 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 	}
 
 	code, pipe, output := func() (exitCode, string, string) {
-		// Assune we'll output UTF-16LE unless otherwise specified, so we forecast piping
+		// Assume we'll output UTF-16LE unless otherwise specified, so we forecast piping
 		// the desired output into iconv.
 		pipe := " | iconv -f UTF-8 -t UTF-16LE "
+		if len(args) < 3 {
+			// mock not implemented for arguments
+			return exitBadUsage, pipe, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
+		}
 		// The /C and /U flags could come in any relative order and are case insensitive.
 		flags := strings.ToLower(strings.Join(args[0:2], ""))
 		if (flags != "/u/c" && flags != "/c/u") || (args[2] != "echo.%UserProfile%") {

--- a/wsl-pro-service/internal/testutils/mock_executables_linux.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_linux.go
@@ -40,12 +40,12 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 		if _, ok := m.controlArgs[CmdExeEncodingErr]; ok {
 			// For this case we'll avoid piping to iconv because we want to output
 			// another encoding (UTF-8 here, but could be anything else).
-			return exitOk, "", "I am UTF-8 🦄 !\r\n"
+			return exitOk, "", "I am UTF-8 🦄 !"
 		}
 
 		if _, ok := m.controlArgs[EmptyUserprofileEnvVar]; ok {
 			// cmd.exe would still print a new line.
-			return exitOk, pipe, "\r\n"
+			return exitOk, pipe, ""
 		}
 
 		return exitOk, pipe, windowsUserProfileDir
@@ -54,8 +54,8 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 	if code != exitOk {
 		// Print to stderr instead of stdout and exit with specified code.
 		//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
-		return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s' %s >&2; exit %d", output, pipe, code))
+		return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s\r\n' %s >&2; exit %d", output, pipe, code))
 	}
 	//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
-	return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s' %s ", output, pipe))
+	return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s\r\n' %s ", output, pipe))
 }

--- a/wsl-pro-service/internal/testutils/mock_executables_linux.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_linux.go
@@ -26,9 +26,9 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 			// mock not implemented for arguments
 			return exitBadUsage, pipe, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
 		}
-		// The /C and /U flags could come in any relative order and are case insensitive.
+		// The /U and /C flags could only come in this specific order but are case insensitive.
 		flags := strings.ToLower(strings.Join(args[0:2], ""))
-		if (flags != "/u/c" && flags != "/c/u") || (args[2] != "echo.%UserProfile%") {
+		if (flags != "/u/c") || (args[2] != "echo.%UserProfile%") {
 			// mock not implemented for arguments
 			return exitBadUsage, pipe, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
 		}
@@ -54,8 +54,8 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 	if code != exitOk {
 		// Print to stderr instead of stdout and exit with specified code.
 		//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
-		return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("printf '%s' %s >&2; exit %d", output, pipe, code))
+		return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s' %s >&2; exit %d", output, pipe, code))
 	}
 	//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
-	return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("printf '%s' %s ", output, pipe))
+	return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("echo '%s' %s ", output, pipe))
 }

--- a/wsl-pro-service/internal/testutils/mock_executables_linux.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_linux.go
@@ -1,0 +1,57 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// CmdExe mocks `cmd.exe $args...` on Linux.
+// It's special because we want this Cmd to output UTF-16, we cannot go through `go test`,
+// as it prevents us from priting arbitrary UTF-16 encoded text.
+// Thus, on Linux, we pipe the desired output to iconv (unless an encoding error is desired, for
+// which case the relevant control argument will be set in the mock).
+func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *exec.Cmd {
+	if !testing.Testing() {
+		panic("mockExec can only be used within a test")
+	}
+
+	code, pipe, output := func() (exitCode, string, string) {
+		// Assune we'll output UTF-16LE unless otherwise specified, so we forecast piping
+		// the desired output into iconv.
+		pipe := " | iconv -f UTF-8 -t UTF-16LE "
+		// The /C and /U flags could come in any relative order and are case insensitive.
+		flags := strings.ToLower(strings.Join(args[0:2], ""))
+		if (flags != "/u/c" && flags != "/c/u") || (args[2] != "echo.%UserProfile%") {
+			// mock not implemented for arguments
+			return exitBadUsage, pipe, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
+		}
+		// TODO: Implement the configured errors:
+		if _, ok := m.controlArgs[CmdExeErr]; ok {
+			return exitError, pipe, "Mock error"
+		}
+
+		if _, ok := m.controlArgs[CmdExeEncodingErr]; ok {
+			// For this case we'll avoid piping to iconv because we want to output
+			// another encoding (UTF-8 here, but could be anything else).
+			return exitOk, "", "I am UTF-8 🦄 !\r\n"
+		}
+
+		if _, ok := m.controlArgs[EmptyUserprofileEnvVar]; ok {
+			// cmd.exe would still print a new line.
+			return exitOk, pipe, "\r\n"
+		}
+
+		return exitOk, pipe, windowsUserProfileDir
+	}()
+
+	if code != exitOk {
+		// Print to stderr instead of stdout and exit with specified code.
+		//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
+		return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("printf '%s' %s >&2; exit %d", output, pipe, code))
+	}
+	//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
+	return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("printf '%s' %s ", output, pipe))
+}

--- a/wsl-pro-service/internal/testutils/mock_executables_windows.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_windows.go
@@ -10,7 +10,7 @@ import (
 
 // CmdExe mocks `cmd.exe $args...` on Windows.
 // It's special because we want this Cmd to output UTF-16, we cannot go through `go test`,
-// as it prevents us from priting arbitrary UTF-16 encoded text.
+// as it prevents us from printing arbitrary UTF-16 encoded text.
 // Thus, on Windows, we use the real cmd.exe with the /U flag (unless an encoding error is desired,
 // for which case the relevant control argument will be set in the mock).
 func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *exec.Cmd {
@@ -19,9 +19,12 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 	}
 
 	code, flags, output := func() (exitCode, string, string) {
-		// Assune we'll output UTF-16LE unless otherwise specified, so we forecast piping
-		// the desired output into iconv.
+		// Assume we'll output UTF-16LE (via the /U flag) unless otherwise specified.
 		realFlags := "/U"
+		if len(args) < 3 {
+			// mock not implemented for arguments
+			return exitBadUsage, realFlags, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
+		}
 		// The /U and /C flags could only come in this specific order but are case insensitive.
 		flags := strings.ToLower(strings.Join(args[0:2], ""))
 		if (flags != "/u/c") || (args[2] != "echo.%UserProfile%") {

--- a/wsl-pro-service/internal/testutils/mock_executables_windows.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_windows.go
@@ -38,12 +38,12 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 		if _, ok := m.controlArgs[CmdExeEncodingErr]; ok {
 			// For this case we'll avoid the /U flag because we want to output
 			// another encoding (the system's active ANSI CP here, but could be anything else).
-			return exitOk, nil, "I am an arbitrarily CP encoded message 🦄 !\r\n"
+			return exitOk, nil, "I am an arbitrarily CP encoded message 🦄 !"
 		}
 
 		if _, ok := m.controlArgs[EmptyUserprofileEnvVar]; ok {
-			// cmd.exe would still print a new line.
-			return exitOk, realFlags, "\r\n"
+			// cmd.exe will still print a new line.
+			return exitOk, realFlags, ""
 		}
 
 		return exitOk, realFlags, windowsUserProfileDir
@@ -53,7 +53,8 @@ func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *e
 	if code != exitOk {
 		// Print to stderr instead of stdout and exit with specified code.
 		// The single ampersand in cmd.exe implies executing the second command despite the
-		// result of the first.
+		// result of the first. We don't need to append '\r\n' because cmd's echo always
+		// prints it.
 		cmdStr = fmt.Sprintf("echo.'%s' 1>&2 & exit %d", output, code)
 	}
 

--- a/wsl-pro-service/internal/testutils/mock_executables_windows.go
+++ b/wsl-pro-service/internal/testutils/mock_executables_windows.go
@@ -1,0 +1,58 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// CmdExe mocks `cmd.exe $args...` on Windows.
+// It's special because we want this Cmd to output UTF-16, we cannot go through `go test`,
+// as it prevents us from priting arbitrary UTF-16 encoded text.
+// Thus, on Windows, we use the real cmd.exe with the /U flag (unless an encoding error is desired,
+// for which case the relevant control argument will be set in the mock).
+func (m *SystemMock) CmdExe(ctx context.Context, path string, args ...string) *exec.Cmd {
+	if !testing.Testing() {
+		panic("mockExec can only be used within a test")
+	}
+
+	code, flags, output := func() (exitCode, string, string) {
+		// Assune we'll output UTF-16LE unless otherwise specified, so we forecast piping
+		// the desired output into iconv.
+		realFlags := "/U"
+		// The /U and /C flags could only come in this specific order but are case insensitive.
+		flags := strings.ToLower(strings.Join(args[0:2], ""))
+		if (flags != "/u/c") || (args[2] != "echo.%UserProfile%") {
+			// mock not implemented for arguments
+			return exitBadUsage, realFlags, fmt.Sprintf("%q: Mock not implemented for args: %s", path, strings.Join(args, ""))
+		}
+		if _, ok := m.controlArgs[CmdExeErr]; ok {
+			return exitError, realFlags, "Mock error"
+		}
+
+		if _, ok := m.controlArgs[CmdExeEncodingErr]; ok {
+			// For this case we'll avoid the /U flag because we want to output
+			// another encoding (the system's active ANSI CP here, but could be anything else).
+			return exitOk, "", "I am an arbitrarily CP encoded message 🦄 !\r\n"
+		}
+
+		if _, ok := m.controlArgs[EmptyUserprofileEnvVar]; ok {
+			// cmd.exe would still print a new line.
+			return exitOk, realFlags, "\r\n"
+		}
+
+		return exitOk, realFlags, windowsUserProfileDir
+	}()
+
+	if code != exitOk {
+		// Print to stderr instead of stdout and exit with specified code.
+		// The single ampersand in cmd.exe implies executing the second command despite the
+		// result of the first.
+		//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
+		return exec.CommandContext(ctx, "C:\\Windows\\System32\\cmd.exe", flags, "/C", fmt.Sprintf("echo.'%s' 1>&2 & exit %d", output, code))
+	}
+	//nolint:gosec // G204 - false positive because we control the args (constructed in the closure above).
+	return exec.CommandContext(ctx, "C:\\Windows\\System32\\cmd.exe", flags, "/C", fmt.Sprintf("echo.'%s'", output))
+}


### PR DESCRIPTION
By default `cmd.exe` encodes text in ANSI code pages (the old style Windows of handling i18n). For a user named `João Martín😁` (even emojis are valid in Windows user names!) whose profile folder will most likely be `C:\Users\João Martín😁` (paths also accept emoji, but that also works in Linux as well), a command like `cd $(wslpath -au $( cmd.exe /C echo.%USERPROFILE%))` is bound to fail because the output of cmd.exe is not only incompatible with UTF-8 (as expected by default) but also unpredictable, as the the exact binary representation of anything above the ASCII charset depends on the system's configured code page and can be ambiguously interpreted. 

A more predictable approach is to output UTF-16, which `cmd.exe` supports if invoked with the `/U` flag. It doesn't support UTF-8, unfortunately. So the fix for this task is really just adding the `/U` flag and decoding the result with UTF-18.

Testing this is tricky, though. The standard approach to mocking executables a Go program subprocess during tests is to invoke a binary built with `go test` (usually this binary is self - argv[0]) passing a particular test name which matches a function implementing the mock. `go test` cannot be made to output UTF-16. When forcing that by sending the raw bytes I want printed is not enough. In UTF-16 Little Ending characters in the ASCII range are represented as `0xXX 0x00`. The environment doesn't like that terminating NULL and strips it out, making the output invalid UTF-16, the last character is always incomplete. When mocking `cmd.exe` we print `\r\n` in the end of the output, so we should expect the exact sequence `0x0d 0x00 0x0a 0x00` to appear in the end of the binary output. So we cannot rely on go-test-compiled binaries to mock cmd.exe as we need here. Instead, we use the SystemMock backend to construct a different command acting as the cmd.exe stub. On Linux that's just printf piped to iconv, with details of what to print and which code to exit with controlled by mock's control args set before execution. Although we don't currently test wsl-pro-service thoroughly on Windows, I left a suitable mock for that OS as well, subprocessing the real cmd.exe very similarly to what's done for Linux, should we decide in the future to clear out the other restrictions preventing this module to be tested on Windows.


One final interesting corner case: the decoding algorithm is unlikely to fail due ill-formed UTF-16 input, but rather it applies the famous replacement char (U+FFFD �) when the data doesn't make sense. So to be really cautious with invalid encodings, I'm sticking a validator in the middle of the decoding transformer pipeline. It's quite unfortunate we don't see that already available in the standard library or its extensions. So if we see a U+FFFD in the output, it's because it was in the input (it's both valid for paths as well as usernames on Windows).

---

UDENG-8926