### PR TITLE
feat(CI): Skip publishing the MSIX sometimes

### DIFF
--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '*'
+      - '**'
+      - '!docs/**'
+      - '!wsl-pro-service/**'
 jobs:
   publish-msix:
     permissions:

--- a/wsl-pro-service/debian/changelog
+++ b/wsl-pro-service/debian/changelog
@@ -1,11 +1,14 @@
-wsl-pro-service (0.1.19) resolute; urgency=medium
+wsl-pro-service (0.1.19ubuntu) resolute; urgency=medium
 
-  * Packaging fixes to prevent lintian errors.
+  * Packaging fixes to prevent lintian errors, including compliance with DEP17
+    (LP: #2139225)
   * Better sync with cloud-init.
   * Improved Go version detection for packaging.
   * Upgrade Go to 1.24 and multiple dependencies.
+  * Subprocess cmd.exe in unicode mode to prevent problems with non-ascii
+    chars in paths.
 
- -- Carlos Nihelton <cnihelton@ubuntu.com>  Wed, 17 Dec 2025 18:15:30 -0300
+ -- Carlos Nihelton <cnihelton@ubuntu.com>  Tue, 10 Feb 2026 11:45:30 -0300
 
 wsl-pro-service (0.1.18build1) resolute; urgency=medium
 

--- a/wsl-pro-service/debian/changelog
+++ b/wsl-pro-service/debian/changelog
@@ -7,6 +7,12 @@ wsl-pro-service (0.1.19) resolute; urgency=medium
 
  -- Carlos Nihelton <cnihelton@ubuntu.com>  Wed, 17 Dec 2025 18:15:30 -0300
 
+wsl-pro-service (0.1.18build1) resolute; urgency=medium
+
+  * No-change mass rebuild for Ubuntu 26.04 (LP: #2132257)
+
+ -- Sebastien Bacher <seb128@debian.org>  Mon, 02 Feb 2026 21:52:55 +0100
+
 wsl-pro-service (0.1.18) plucky; urgency=medium
 
   * Pin Go toolchain to 1.23.8 to fix the following security vulnerabilities:


### PR DESCRIPTION
Times when we want to tag the repo for a documentation refresh or to release just wsl-pro-service and the recent git commits don't justify also publishing the Windows app.

---
UDENG-8603