### PR TITLE
fix(windows-agent): Landscape sourced from Registry doesn't load on restart

### DIFF
--- a/windows-agent/internal/config/config.go
+++ b/windows-agent/internal/config/config.go
@@ -327,6 +327,7 @@ func (c *Config) UpdateRegistryData(ctx context.Context, data RegistryData, db *
 	}
 
 	// Ubuntu Pro subscription
+	// We store it in the config now because we don't duplicate org data inside the config file.
 	c.configState.Subscription.Organization = data.UbuntuProToken
 	if hasChanged(data.UbuntuProToken, &c.configState.Subscription.Checksum) {
 		log.Debug(ctx, "Config: new Ubuntu Pro subscription received from the registry")
@@ -343,9 +344,10 @@ func (c *Config) UpdateRegistryData(ctx context.Context, data RegistryData, db *
 	if err != nil {
 		log.Errorf(ctx, "Config: removing Landscape configuration from registry: %v", err)
 	}
+	// Ditto for not duplicating org data.
+	c.Landscape.OrgConfig = conf
 	if hasChanged(conf, &c.Landscape.Checksum) {
 		log.Debug(ctx, "Config: new Landscape configuration received from the registry")
-		c.Landscape.OrgConfig = conf
 
 		// We must resolve the landscape config in case a lower priority config becomes active
 		resolv, _ := c.Landscape.resolve()

--- a/windows-agent/internal/config/config_test.go
+++ b/windows-agent/internal/config/config_test.go
@@ -576,14 +576,15 @@ func TestUpdateRegistryData(t *testing.T) {
 			c := config.New(ctx, dir)
 
 			var calledUbuntuProNotifier int
-			c.SetUbuntuProNotifier(func(context.Context, string) {
+			proNotifier := func(context.Context, string) {
 				calledUbuntuProNotifier++
-			})
-
+			}
 			var calledLandscapeNotifier int
-			c.SetLandscapeNotifier(func(context.Context, string, string) {
+			lcapeNotifier := func(context.Context, string, string) {
 				calledLandscapeNotifier++
-			})
+			}
+			c.SetUbuntuProNotifier(proNotifier)
+			c.SetLandscapeNotifier(lcapeNotifier)
 
 			// Enter a first set of data to override the defaults
 			err = c.UpdateRegistryData(ctx, config.RegistryData{
@@ -648,7 +649,11 @@ func TestUpdateRegistryData(t *testing.T) {
 			require.Equal(t, want, lcape, "LandscapeClientConfig did not return the Landscape config we wrote")
 			require.Equal(t, config.SourceRegistry, src, "Landscape config did not come from registry")
 
-			// Enter the second set of data again
+			// Enter the second set of data again, this time against a fresh config,
+			// simulating the restart of the agent.
+			c = config.New(ctx, dir)
+			c.SetUbuntuProNotifier(proNotifier)
+			c.SetLandscapeNotifier(lcapeNotifier)
 			err = c.UpdateRegistryData(ctx, config.RegistryData{
 				UbuntuProToken:  proToken2,
 				LandscapeConfig: landscapeConf2,


### PR DESCRIPTION
When the Windows agent restarts, it's supposed to check out its configuration from the registry and from its internal serialized config data. Importantly, that serialized representation excludes data from the registry so we don't duplicate org data for good. That means when `UpdateRegistryData()` runs it must assume the org fields of the config are empty. We did so for the Pro token, but for the Landscape data the assignment was broken in commit ee58d0c34c7f387a0de639ea6516a8aff2eb6911.

This PR restores the functionality and rearranges the test so it can better simulate what happens with the agent at runtime, revealing the bug if the test runs without the patch 1f5e78528eee07092467668bf7f2b9289082149b in config.go.

UDENG-9074