### PR TITLE
fix(ci): Unbreak TICS workflows

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -334,7 +334,7 @@ jobs:
           go-version-file: windows-agent/go.mod
       - name: Install dependencies
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 # Latest still not requireing Go 1.25.
       - name: Download coverage artifacts
         uses: actions/download-artifact@v7
         with:
@@ -369,7 +369,7 @@ jobs:
           go-version-file: windows-agent/go.mod
       - name: Install dependencies
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 # Latest still not requireing Go 1.25.
       - name: Read flutter version
         id: flutter-version
         uses: ./.github/actions/read-file


### PR DESCRIPTION
The latest version of staticcheck requires Go 1.25 We're not there yet.
Here's one example of CI run broken by that requirement: https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/22348701089/job/64670979798#step:5:9