### PR TITLE
fix(windows-agent): Handling DNS errors more gracefully

### DIFF
--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/ubuntu/decorate"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/connectivity"
 )
 
@@ -58,18 +57,7 @@ func newConnection(ctx context.Context, d serviceData) (conn *connection, err er
 		return nil, err
 	}
 
-	grpcConn, err := grpc.NewClient(conn.hostConf.hostagentURL,
-		grpc.WithTransportCredentials(creds),
-		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 1.6,
-				Jitter:     0.2,
-				MaxDelay:   120 * time.Second,
-			},
-			MinConnectTimeout: 60 * time.Second,
-		}),
-	)
+	grpcConn, err := grpc.NewClient(conn.hostConf.hostagentURL, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, err
 	}

--- a/windows-agent/internal/proservices/landscape/connection.go
+++ b/windows-agent/internal/proservices/landscape/connection.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/ubuntu/decorate"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/connectivity"
 )
 
@@ -57,15 +58,26 @@ func newConnection(ctx context.Context, d serviceData) (conn *connection, err er
 		return nil, err
 	}
 
-	log.Infof(ctx, "Landscape: connecting to %s", conn.hostConf.hostagentURL)
-
-	grpcConn, err := grpc.NewClient(conn.hostConf.hostagentURL, grpc.WithTransportCredentials(creds))
+	grpcConn, err := grpc.NewClient(conn.hostConf.hostagentURL,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  1.0 * time.Second,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   120 * time.Second,
+			},
+			MinConnectTimeout: 60 * time.Second,
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}
+	log.Infof(ctx, "Landscape: connecting to %s", grpcConn.CanonicalTarget())
 	conn.grpcConn = grpcConn
 
 	cl := landscapeapi.NewLandscapeHostAgentClient(grpcConn)
+
 	client, err := cl.Connect(ctx)
 	if err != nil {
 		return nil, err

--- a/windows-agent/internal/proservices/landscape/executor_test.go
+++ b/windows-agent/internal/proservices/landscape/executor_test.go
@@ -820,7 +820,7 @@ func testReceiveCommand(t *testing.T, distrosettings distroSettings, homedir str
 	if tb.conf == nil {
 		tb.conf = &mockConfig{
 			proToken:              "TOKEN",
-			landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr()),
+			landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr().String()),
 		}
 	}
 

--- a/windows-agent/internal/proservices/landscape/landscape_test.go
+++ b/windows-agent/internal/proservices/landscape/landscape_test.go
@@ -106,6 +106,7 @@ func TestConnect(t *testing.T) {
 	testCases := map[string]struct {
 		precancelContext   bool
 		serverNotAvailable bool
+		serverNotFound     bool
 		serverErrorCode    codes.Code // 0. codes.OK by default.
 
 		landscapeUIDReadErr  bool
@@ -140,6 +141,7 @@ func TestConnect(t *testing.T) {
 		"Error when the landscape UID cannot be retrieved":     {landscapeUIDReadErr: true, wantErr: true},
 		"Error when the landscape UID cannot be stored":        {landscapeUIDWriteErr: true, wantErr: true},
 		"Error when the server cannot be reached":              {serverNotAvailable: true, wantErr: true},
+		"Error when the server cannot be found":                {serverNotFound: true, wantErr: true},
 		"Error when the server returns permission denied":      {serverErrorCode: codes.PermissionDenied, wantErr: true},
 		"Error when the server returns invalid argument":       {serverErrorCode: codes.InvalidArgument, wantErr: true},
 		"Error when the first-contact SendUpdatedInfo fails":   {tokenErr: true, wantErr: true},
@@ -205,8 +207,12 @@ func TestConnect(t *testing.T) {
 				// Fixture exists: override the Landscape config
 				lconf = string(fixture)
 			}
+			address := lis.Addr().String()
+			if tc.serverNotFound {
+				address = "server.notfound.local:1234"
+			}
 
-			conf.landscapeClientConfig = executeLandscapeConfigTemplate(t, lconf, certPath, lis.Addr())
+			conf.landscapeClientConfig = executeLandscapeConfigTemplate(t, lconf, certPath, address)
 
 			if !tc.serverNotAvailable {
 				//nolint:errcheck // We don't care about these errors
@@ -345,7 +351,7 @@ func TestSendUpdatedInfo(t *testing.T) {
 
 			conf := &mockConfig{
 				proToken:              "TOKEN",
-				landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr()),
+				landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr().String()),
 			}
 
 			//nolint:errcheck // We don't care about these errors
@@ -574,7 +580,7 @@ func TestAutoReconnection(t *testing.T) {
 
 			conf := &mockConfig{
 				proToken:              "TOKEN",
-				landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr()),
+				landscapeClientConfig: executeLandscapeConfigTemplate(t, defaultLandscapeConfig, "", lis.Addr().String()),
 			}
 
 			db, err := database.New(ctx, t.TempDir())
@@ -833,7 +839,7 @@ func TestReconnect(t *testing.T) {
 
 			conf := &mockConfig{
 				proToken:              "TOKEN",
-				landscapeClientConfig: executeLandscapeConfigTemplate(t, lcapeConfig, certPath, lis.Addr()),
+				landscapeClientConfig: executeLandscapeConfigTemplate(t, lcapeConfig, certPath, lis.Addr().String()),
 			}
 
 			//nolint:errcheck // We don't care about these errors
@@ -1068,7 +1074,7 @@ func TestNotifyConfigUpdateWithAgentYaml(t *testing.T) {
 		})
 	}
 }
-func executeLandscapeConfigTemplate(t *testing.T, in string, certPath string, url net.Addr) string {
+func executeLandscapeConfigTemplate(t *testing.T, in string, certPath string, url string) string {
 	t.Helper()
 
 	tmpl := template.Must(template.New(t.Name()).Parse(in))
@@ -1077,7 +1083,7 @@ func executeLandscapeConfigTemplate(t *testing.T, in string, certPath string, ur
 		CertPath, HostURL string
 	}{
 		CertPath: certPath,
-		HostURL:  url.String(),
+		HostURL:  url,
 	}
 
 	out := bytes.Buffer{}

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"sync"
@@ -307,31 +306,22 @@ func (errc *errorCount) checkError(err error) error {
 		// Service must remain disabled if we don't have a Landscape config.
 		if target := (noConfigError{}); errors.As(err, &target) {
 			errc.noConfig++
-			return fmt.Errorf("service disabled: %w", target)
+			return err
 		}
 
 		code := status.Code(err)
 		// Or if the server rejects our request.
 		if code == codes.PermissionDenied || code == codes.InvalidArgument {
 			errc.serverRejection++
-			return fmt.Errorf("service disabled: %w", err)
+			return err
 		}
 		// Or if the DNS server doesn't find the host.
-		if code == codes.Unavailable {
-			var dnsErr *net.DNSError
-			if errors.As(err, &dnsErr) {
-				errc.nameResolution++
-				if dnsErr.IsNotFound {
-					return fmt.Errorf("service disabled: DNS server %q suggested possibly invalid host %q. %s",
-						dnsErr.Server, dnsErr.Name, dnsErr.Error())
-				}
-				return dnsErr
-			}
-			// In case a proxy intercepted the call and didn't report a beautiful DNSError.
-			if strings.Contains(err.Error(), "produced zero addresses") || strings.Contains(err.Error(), "no such host") {
-				errc.nameResolution++
-				return fmt.Errorf("service disabled: %w", err)
-			}
+		// I'd love to be able to find a DNSError in the chain, because they are quite rich of information,
+		// but gRPC type-erases it in a status error and the only way to check for it is to parse the error message.
+		if code == codes.Unavailable &&
+			(strings.Contains(err.Error(), "produced zero addresses") || strings.Contains(err.Error(), "no such host")) {
+			errc.nameResolution++
+			return err
 		}
 
 		errc.other++
@@ -339,7 +329,7 @@ func (errc *errorCount) checkError(err error) error {
 	}()
 
 	if errc.isSaturated() {
-		return lastError
+		return fmt.Errorf("service disabled: %w", lastError)
 	}
 	return nil
 }

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -160,6 +161,7 @@ func (s *Service) keepConnected() error {
 	const minWait = time.Second
 	const maxWait = 10 * time.Minute
 	wait := 0 * time.Second // No wait in the first iteration
+	errc := errorCount{}
 
 	s.running = make(chan struct{})
 	started := make(chan error)
@@ -245,10 +247,11 @@ func (s *Service) keepConnected() error {
 			default:
 			}
 
-			if checkErr := mustDisableService(err); checkErr != nil {
+			if checkErr := errc.checkError(err); checkErr != nil {
 				if !s.disabled.Load() {
 					// "Landscape: service disabled" not already logged.
 					log.Warningf(s.ctx, "Landscape: %v", checkErr)
+					log.Debugf(s.ctx, "Landscape: %s", errc.String())
 					s.disabled.Store(true)
 				}
 				continue
@@ -262,6 +265,7 @@ func (s *Service) keepConnected() error {
 
 			// Connection was long-lived. We don't need to wait before reconnecting.
 			wait = minWait
+			errc = errorCount{}
 		}
 	}()
 
@@ -273,24 +277,68 @@ func (s *Service) keepConnected() error {
 	}
 }
 
-// mustDisableService returns an error that wraps err if it requires disabling the service, otherwise it returns nil.
-func mustDisableService(err error) error {
-	// Service must remain disabled if we don't have a Landscape config.
-	if target := (noConfigError{}); errors.As(err, &target) {
-		return fmt.Errorf("service disabled: %w", target)
-	}
-	// Or if the server rejects our request.
-	if status.Code(err) == codes.PermissionDenied || status.Code(err) == codes.InvalidArgument {
-		return fmt.Errorf("service disabled: %w", err)
-	}
-	// Or if the DNS server doesn't find the host.
-	if status.Code(err) == codes.Unavailable {
-		// I wish there was an idiomatic way in gRPC to check if calling a DNS server succeeded but it server couldn't find the host.
-		if strings.Contains(err.Error(), "produced zero addresses") || strings.Contains(err.Error(), "no such host") {
+type errorCount struct {
+	noConfig        int
+	serverRejection int
+	nameResolution  int
+	other           int
+}
+
+// isSaturated returns true if the  error counts reached their maximum allowance, false otherwise.
+func (errc errorCount) isSaturated() bool {
+	// Just hardcoding the maximum counts for now. We might want to adjust this to become a constructor parameter.
+	return errc.noConfig > 0 || errc.serverRejection > 0 || errc.nameResolution > 6
+}
+
+// String returns a string representation of the error counts.
+func (errc errorCount) String() string {
+	return fmt.Sprintf("error counts: no config=%d, server rejections=%d, name resolution=%d, other=%d",
+		errc.noConfig, errc.serverRejection, errc.nameResolution, errc.other)
+}
+
+// checkError updates the error counts and returns an error that wraps err if it reaches the maximum error count allowance, otherwise it returns nil.
+func (errc *errorCount) checkError(err error) error {
+	lastError := func() error {
+		if err == nil {
+			return nil
+		}
+		// Service must remain disabled if we don't have a Landscape config.
+		if target := (noConfigError{}); errors.As(err, &target) {
+			errc.noConfig++
+			return fmt.Errorf("service disabled: %w", target)
+		}
+
+		code := status.Code(err)
+		// Or if the server rejects our request.
+		if code == codes.PermissionDenied || code == codes.InvalidArgument {
+			errc.serverRejection++
 			return fmt.Errorf("service disabled: %w", err)
 		}
-	}
+		// Or if the DNS server doesn't find the host.
+		if code == codes.Unavailable {
+			var dnsErr *net.DNSError
+			if errors.As(err, &dnsErr) {
+				errc.nameResolution++
+				if dnsErr.IsNotFound {
+					return fmt.Errorf("service disabled: DNS server %q suggested possibly invalid host %q. %s",
+						dnsErr.Server, dnsErr.Name, dnsErr.Error())
+				}
+				return dnsErr
+			}
+			// In case a proxy intercepted the call and didn't report a beautiful DNSError.
+			if strings.Contains(err.Error(), "produced zero addresses") || strings.Contains(err.Error(), "no such host") {
+				errc.nameResolution++
+				return fmt.Errorf("service disabled: %w", err)
+			}
+		}
 
+		errc.other++
+		return err
+	}()
+
+	if errc.isSaturated() {
+		return lastError
+	}
 	return nil
 }
 

--- a/windows-agent/internal/proservices/landscape/service.go
+++ b/windows-agent/internal/proservices/landscape/service.go
@@ -157,16 +157,15 @@ func (s *Service) Connect() (err error) {
 // - the active one drops.
 // - a reconnection is requested via connRetrier.
 func (s *Service) keepConnected() error {
-	const growthFactor = 2
-	const minWait = time.Second
-	const maxWait = 10 * time.Minute
-	wait := 0 * time.Second // No wait in the first iteration
-	errc := errorCount{}
-
 	s.running = make(chan struct{})
 	started := make(chan error)
 
 	go func() {
+		const growthFactor = 2
+		const minWait = time.Second
+		const maxWait = 10 * time.Minute
+		wait := 0 * time.Second // No wait in the first iteration
+		errc := errorCount{}
 		defer close(s.running)
 
 		defer s.disconnect()
@@ -287,6 +286,9 @@ type errorCount struct {
 // isSaturated returns true if the  error counts reached their maximum allowance, false otherwise.
 func (errc errorCount) isSaturated() bool {
 	// Just hardcoding the maximum counts for now. We might want to adjust this to become a constructor parameter.
+	// This should result in a maximum wait time of around 63s plus the time it takes to
+	// execute a coonection, which is typically 15s per attempt, 6 attempts in the worse case,
+	// total of 2 minutes, in theory, as gRPC hsa its own backoff mhechanism with bultin jitter.
 	return errc.noConfig > 0 || errc.serverRejection > 0 || errc.nameResolution > 6
 }
 


### PR DESCRIPTION
We were very optimistc about the DNS resolution process. A lot could go wrong in the wild outside of our (and our users) control, causing DNS errors to be more common **and more transient** than we expected.

I looked into gRPC internal retrials, hedging and backoff mechanisms in hopes to find a way to differentiate wrong server addresses from transient or fatal name resolution errors, but there is no one-size-fits-all solution for that. Thus, I'm relying on our existing backoff mechanism, with a different duration than the broader backoff mechanism already implemented. After all, DNS errors still could be a mistaken input, for which is not worth taking forever to let the user know.

I'm also slightly adjusting the gRPC internal backoff mechanism mainly to add some jitter to the retry duration, which is a common practice to avoid thundering herd problems.

---

UDENG-9295