### PR TITLE
maint(CI): end-to-end tests with tar images and running on GH hosted runners

### DIFF
--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -42,7 +42,7 @@ runs:
         channel: stable
         flutter-version: ${{ steps.flutter-version.outputs.contents }}
     - name: Setup MSBuild (PATH)
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Install certificate
       shell: powershell
       run: |

--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -39,6 +39,7 @@ runs:
         path: tools/flutter-version
     - uses: subosito/flutter-action@v2
       with:
+        cache: true
         channel: stable
         flutter-version: ${{ steps.flutter-version.outputs.contents }}
     - name: Setup MSBuild (PATH)

--- a/.github/actions/build-msix/action.yml
+++ b/.github/actions/build-msix/action.yml
@@ -29,9 +29,10 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version-file: go.work
+        cache-dependency-path: go.work
     - name: Read flutter version
       id: flutter-version
       uses: ./.github/actions/read-file

--- a/.github/actions/flutter-integration-test/action.yaml
+++ b/.github/actions/flutter-integration-test/action.yaml
@@ -23,8 +23,9 @@ runs:
         go-version-file: '${{ inputs.go-version-file }}'
     - uses: subosito/flutter-action@v2
       with:
-        channel: 'stable'
-        flutter-version: '${{ inputs.flutter-version }}'
+        cache: true
+        channel: "stable"
+        flutter-version: "${{ inputs.flutter-version }}"
     - name: Integration Test
       shell: bash
       working-directory: '${{ inputs.package-dir }}'

--- a/.github/actions/flutter-integration-test/action.yaml
+++ b/.github/actions/flutter-integration-test/action.yaml
@@ -18,9 +18,10 @@ runs:
     - uses: microsoft/setup-msbuild@v3
       if: runner.os == 'Windows'
     # Go is needed to build the agent for integration testing.
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v6
       with:
-        go-version-file: '${{ inputs.go-version-file }}'
+        cache-dependency-path: "${{ inputs.go-version-file }}"
+        go-version-file: "${{ inputs.go-version-file }}"
     - uses: subosito/flutter-action@v2
       with:
         cache: true
@@ -45,7 +46,7 @@ runs:
         # Default input is coverage/lcov.info and output is coverage/cobertura.xml
         dart pub global run cobertura convert
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-${{ matrix.package }}-${{ matrix.os }}-integration
         path: ${{ inputs.package-dir }}/coverage/*

--- a/.github/actions/flutter-integration-test/action.yaml
+++ b/.github/actions/flutter-integration-test/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: microsoft/setup-msbuild@v1
+    - uses: microsoft/setup-msbuild@v3
       if: runner.os == 'Windows'
     # Go is needed to build the agent for integration testing.
     - uses: actions/setup-go@v4

--- a/.github/actions/flutter-qa/action.yaml
+++ b/.github/actions/flutter-qa/action.yaml
@@ -22,6 +22,7 @@ runs:
   steps:
     - uses: subosito/flutter-action@v2
       with:
+        cache: true
         channel: 'stable'
         flutter-version: '${{ inputs.flutter-version }}'
     - name: Dart Codegen

--- a/.github/actions/get-wsl-image/action.yaml
+++ b/.github/actions/get-wsl-image/action.yaml
@@ -1,0 +1,141 @@
+# This action gets the latest WSL image, leveraging both the persistent behavior of our runners, and the GitHub cache
+name: Get WSL Image
+description: Downloads and caches an Ubuntu image for WSL assuming the URL provided follows the format of the official repositories.
+
+inputs:
+  base_url:
+    description: "The base URL to download the WSL image from"
+    required: false
+    default: "https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/current/"
+  arch:
+    description: "The architecture of the WSL image to download (amd64 or arm64)"
+    required: false
+    default: "amd64"
+  output_path:
+    description: "The path to save the downloaded WSL image to"
+    required: false
+    default: "ubuntu.wsl"
+outputs:
+  cache-key:
+    description: "The cache key for the WSL image, which is its SHA256 hash"
+    value: ${{ steps.compute-cache-key.outputs.cache-key }}
+  image-name:
+    description: "The name of the image we found"
+    value: ${{ steps.compute-cache-key.outputs.image-name }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute image cache key
+      id: compute-cache-key
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        shafile="${{ runner.temp }}/SHA256SUMS"
+        uri="${{ inputs.base_url }}/SHA256SUMS"
+        if ! curl --fail -o "$shafile" "${uri}"; then  
+            echo "::error:: Failed to download the checksum file from $uri."  
+            exit 1  
+        fi  
+
+        # Look for a line matching the pattern: <sha> *<name>-wsl-<arch>.wsl
+        arch="${{ inputs.arch }}"
+        line=$(grep -E "^[a-f0-9]+[[:space:]]+\*.*-wsl-${arch}\.wsl$" "$shafile")
+        if [ -z "$line" ]; then
+          echo "::error:: No WSL image found for architecture '$arch' in the $shafile file."
+          exit 2
+        fi
+
+        # Extract the SHA (first field), image name (second field without the *) and manifest.
+        sha=$(echo "$line" | awk '{print $1}')
+        image_name=$(echo "$line" | awk '{print $2}' | sed 's/^\*//')
+        image_manifest=$(echo "$image_name" | sed -E 's/\.wsl$/.manifest/')
+
+        echo "cache-key=$sha" >> "$GITHUB_OUTPUT"
+        echo "image-name=$image_name" >> "$GITHUB_OUTPUT"
+        echo "image-manifest=$image_manifest" >> "$GITHUB_OUTPUT"
+
+    - name: Validate image
+      id: check-locally
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        expected_sha="${{ steps.compute-cache-key.outputs.cache-key }}"
+        output_path="${{ inputs.output_path }}"
+
+        if [ -r "$output_path" ]; then
+          echo "Found local image at $output_path"
+          
+          # Compare the SHAs
+          if (echo "$expected_sha  $output_path" | sha256sum -c); then
+            echo "✅ Local image matches expected SHA. Using local file."
+            echo "is-valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ Local image SHA does not match expected SHA. Will need to download."
+            rm "$output_path"
+            echo "is-valid=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "No local image found at $output_path"
+          echo "is-valid=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Restore image cache
+      id: restore-cache
+      if: ${{ steps.check-locally.outputs.is-valid != 'true' }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ inputs.output_path }}
+        key: ${{ steps.compute-cache-key.outputs.cache-key }}
+        enableCrossOsArchive: true
+
+    - name: Download image
+      if: ${{ steps.check-locally.outputs.is-valid != 'true' && steps.restore-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        expected_sha="${{ steps.compute-cache-key.outputs.cache-key }}"
+        output_path="${{ inputs.output_path }}"
+        mkdir -p "$(dirname "$output_path")"
+
+        uri="${{ inputs.base_url }}/${{ steps.compute-cache-key.outputs.image-name }}"
+        if ! curl --fail -o "$output_path" "$uri"; then
+            echo "::error:: Failed to download the WSL image from $uri"
+            exit 1
+        fi
+
+        if ! (echo "$expected_sha  $output_path" | sha256sum -c); then
+            echo "::error:: Downloaded WSL image SHA does not match expected SHA."
+            exit 2
+        fi
+
+    - name: Save image to cache
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.output_path }}
+        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+        enableCrossOsArchive: true
+
+    - name: Save image manifest for future troubleshooting
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        uri="${{ inputs.base_url }}/${{ steps.compute-cache-key.outputs.image-manifest }}"
+        manifest_path="${{ runner.temp }}/image.manifest"
+        if ! curl --fail -o "$manifest_path" "$uri"; then
+            echo "::error:: Failed to download the WSL image manifest from $uri. This is not a critical failure, but may make troubleshooting harder in the future."
+        else
+            echo "Image manifest downloaded to $manifest_path"
+        fi
+    - name: Upload image manifest
+      uses: actions/upload-artifact@v7
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+      with:
+        name: ${{ steps.compute-cache-key.outputs.image-name }}.manifest
+        path: "${{ runner.temp }}/image.manifest"

--- a/.github/actions/get-wsl-image/action.yaml
+++ b/.github/actions/get-wsl-image/action.yaml
@@ -36,7 +36,7 @@ runs:
         uri="${{ inputs.base_url }}/SHA256SUMS"
         if ! curl --fail -o "$shafile" "${uri}"; then  
             echo "::error:: Failed to download the checksum file from $uri."  
-            exit 1  
+            exit 1
         fi  
 
         # Look for a line matching the pattern: <sha> *<name>-wsl-<arch>.wsl

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -30,6 +30,7 @@ jobs:
           ref: main
       - uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: common/go.mod
       - name: Set up git
           # This step needs to be done so that the private repo dependencies can be downloaded
@@ -88,6 +89,7 @@ jobs:
       - uses: actions/setup-go@v6
         name: Set up Go
         with:
+          cache-dependency-path: go.work
           go-version-file: go.work
       - name: Generate documentation
         run: |
@@ -134,6 +136,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: go.work
       - name: Set up private repo
         shell: bash

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -75,6 +75,7 @@ jobs:
           wsl --version
       - uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: go.work
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -139,4 +140,5 @@ jobs:
           # Uninstall certificate
           $thumbprint = (Get-PfxCertificate -FilePath "ci-artifacts\windows-agent\UbuntuProForWSL_*.cer").Thumbprint
           Remove-Item -Path "Cert:LocalMachine\TrustedPeople\${thumbprint}"
-
+          # Remove the registry entry for the manifest override:
+          Remove-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss" -Name DistributionListUrlAppend

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -84,6 +84,7 @@ jobs:
           path: ci-artifacts
       - name: Download WSL image
         uses: ./.github/actions/get-wsl-image
+        id: get-wsl-image
         with:
           base_url: "https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/current/"
           arch: "amd64"
@@ -92,7 +93,7 @@ jobs:
         shell: powershell
         working-directory: ci-artifacts
         run: |
-          Write-Output "::group::Set up the MSIX Package"
+          Write-Output "::group::Lay out the MSIX Package"
           Get-AppxPackage -Name "CanonicalGroupLimited.UbuntuPro" | Remove-AppxPackage -ErrorAction Ignore
 
           New-Item -Name "windows-agent" -ItemType Directory
@@ -105,10 +106,31 @@ jobs:
 
           Write-Output "::endgroup::"
 
-          Write-Output "::group::Set up WSL Pro Service"
+          Write-Output "::group::Lay out WSL Pro Service"
           New-Item -Name "wsl-pro-service" -ItemType Directory
           Move-Item -Path "wsl-pro-service_*/wsl-pro-service_*.deb" -Destination "wsl-pro-service/"
           Remove-Item -Recurse "wsl-pro-service_*/"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::Lay out the manifest override"
+          $manifest= @{
+              ModernDistributions=@{
+                  Ubuntu = @(
+                      @{
+                          Name = "Ubuntu-Preview"
+                          Default = $true
+                          FriendlyName = "Ubuntu base test image"
+                          Amd64Url = @{
+                              Url = "file:///$PWD/images/ubuntu.wsl"
+                              Sha256 = "0x${{ steps.get-wsl-image.outputs.cache-key }}"
+                          }
+                      })
+                  }
+              }
+
+          $manifestFile = "$PWD/images/test_manifest.json"
+          $manifest | ConvertTo-Json -Depth 5 | Out-File -encoding ascii  $manifestFile
+          Set-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss" -Name DistributionListUrlAppend -Value "file://$manifestFile" -Type String -Force
           Write-Output "::endgroup::"
 
       # Installing a debug version of VCLibs from the SDK is required, otherwise installing the Ubuntu pro debug appx will fail.

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -1,7 +1,9 @@
 name: Build and run end-to-end tests
 # Builds the project, and runs end-to-end tests using the generated artifacts.
 
-concurrency: azure-vm
+concurrency:
+  group: end-to-end-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   pull_request:
@@ -12,10 +14,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-
-env:
-  az_name: wsl-ci-3
-  az_resource_group: wsl
 
 jobs:
   build-wsl-pro-service:
@@ -57,64 +55,43 @@ jobs:
           run-code-analysis: true
 
       - name: Upload sideload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: UbuntuProForWSL+${{ github.sha }}-${{ matrix.mode }}
           path: |
             msix/UbuntuProForWSL/AppPackages/UbuntuProForWSL_*/UbuntuProForWSL_*.cer
             msix/UbuntuProForWSL/AppPackages/UbuntuProForWSL_*/UbuntuProForWSL_*.msixbundle
 
-  vm-setup:
-    name: Set up Azure VM
-    runs-on: ubuntu-latest
-    steps:
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_VM_CREDS }}
-      - name: Start the Runner
-        shell: bash
-        run: |
-          az vm start --name ${{ env.az_name }} --resource-group ${{ env.az_resource_group }}
-
   qa:
-    name: Run end-to-end tests on the Azure VM
-    runs-on: [self-hosted, Windows]
-    needs: [vm-setup, build-wsl-pro-service, build-ubuntu-pro-for-wsl]
+    name: Run end-to-end tests
+    runs-on: [windows-latest]
+    needs: [build-wsl-pro-service, build-ubuntu-pro-for-wsl]
     steps:
-      - name: Set up git
-        uses: canonical/ubuntu-pro-for-wsl/.github/actions/setup-git@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Set up Ubuntu
-        uses: Ubuntu/WSL/.github/actions/wsl-install@main
-        with:
-          # TODO: Migrate this to the tar-based 24.04
-          distro: "Ubuntu-Preview"
-          useStore: true
-      - name: Set up Go
-        # actions/setup-go is broken
-        shell: powershell
+      # GH runners come with WSL stable pre-installed.
+      - name: Sanity check WSL version
         run: |
-          winget install GoLang.Go --accept-source-agreements --accept-package-agreements --silent --verbose
-          # Cannot check for error: there is no way to distinguish the two:
-          # - Legitimate error
-          # - Error because no updates found (Golang.Go is already up to date)
-          #
-          # We can check that Go works, though.
-          go version
+          wsl --version
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           # name: is left blank so that all artifacts are downloaded
           path: ci-artifacts
-      - name: Set up artifacts
+      - name: Download WSL image
+        uses: ./.github/actions/get-wsl-image
+        with:
+          base_url: "https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/current/"
+          arch: "amd64"
+          output_path: "ci-artifacts/images/ubuntu.wsl"
+      - name: Layout the downloaded artifacts
         shell: powershell
         working-directory: ci-artifacts
         run: |
-          Write-Output "::group::Set up AppxPackage"
+          Write-Output "::group::Set up the MSIX Package"
           Get-AppxPackage -Name "CanonicalGroupLimited.UbuntuPro" | Remove-AppxPackage -ErrorAction Ignore
 
           New-Item -Name "windows-agent" -ItemType Directory
@@ -145,9 +122,7 @@ jobs:
           UP4W_TEST_BUILD_PATH: "../ci-artifacts"
           UP4W_TEST_PRO_TOKEN: "${{ secrets.UBUNTU_PRO_TOKEN }}"
         run: |
-          go env -w "GOPRIVATE=github.com/${{ github.repository }}"
-
-          go test .\end-to-end -shuffle=on -timeout 20m
+          go test -v .\end-to-end -shuffle=on -timeout 20m
           if ( "$LastExitCode" -ne "0" ) { Exit(1) }
       - name: Clean up
         if: always()
@@ -165,17 +140,3 @@ jobs:
           $thumbprint = (Get-PfxCertificate -FilePath "ci-artifacts\windows-agent\UbuntuProForWSL_*.cer").Thumbprint
           Remove-Item -Path "Cert:LocalMachine\TrustedPeople\${thumbprint}"
 
-  stop-vm:
-    name: Clean up the Azure VM
-    runs-on: ubuntu-latest
-    needs: [vm-setup, qa]
-    if: always()
-    steps:
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_VM_CREDS }}
-      - name: Deallocate the Runner
-        shell: bash
-        run: |
-          az vm deallocate --name ${{ env.az_name }} --resource-group ${{ env.az_resource_group }}

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -112,17 +112,41 @@ jobs:
           Remove-Item -Recurse "wsl-pro-service_*/"
           Write-Output "::endgroup::"
 
+          Write-Output "::group::Prepare the golden image"
+          wsl.exe --install --name Reference --from-file ./images/ubuntu.wsl --no-launch
+          wsl.exe -d Reference -u root -- apt-get update 
+          wsl.exe -d Reference -u root -- bash -ec 'apt-get install -y "$(wslpath -ua ./wsl-pro-service/*.deb )"'
+          wsl.exe -d Reference -u root -- bash -ec 'echo verbosity: 3 > /etc/wsl-pro-service.yaml'
+          wsl.exe -d Reference -u root -- adduser --disabled-password --quiet --gecos Ubuntu ubuntu
+          wsl.exe -d Reference -u root -- usermod ubuntu -aG sudo,adm
+          wsl.exe -d Reference -u root -- bash -ec 'cloud-init clean --logs || true'
+          wsl.exe -d Reference -u root -- bash -ec 'rm /etc/cloud/cloud-init.disabled || true'
+          wsl.exe --shutdown
+          wsl.exe --export Reference ./images/ubuntu-preview.tar.gz
+          wsl.exe --unregister Reference
+          $sha256 = (Get-FileHash -Path "./images/ubuntu-preview.tar.gz" -Algorithm SHA256 ).Hash
+          Write-Output "::endgroup::"
+
           Write-Output "::group::Lay out the manifest override"
           $manifest= @{
               ModernDistributions=@{
                   Ubuntu = @(
                       @{
-                          Name = "Ubuntu-Preview"
+                          Name = "Ubuntu"
                           Default = $true
                           FriendlyName = "Ubuntu base test image"
                           Amd64Url = @{
                               Url = "file:///$PWD/images/ubuntu.wsl"
                               Sha256 = "0x${{ steps.get-wsl-image.outputs.cache-key }}"
+                          }
+                      },
+                      @{
+                          Name = "Ubuntu-Preview"
+                          Default = $true
+                          FriendlyName = "Ubuntu golden test image"
+                          Amd64Url = @{
+                              Url = "file:///$PWD/images/ubuntu-preview.tar.gz"
+                              Sha256 = "0x$sha256"
                           }
                       })
                   }

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -89,7 +89,7 @@ jobs:
           base_url: "https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/current/"
           arch: "amd64"
           output_path: "ci-artifacts/images/ubuntu.wsl"
-      - name: Layout the downloaded artifacts
+      - name: Lay out the downloaded artifacts
         shell: powershell
         working-directory: ci-artifacts
         run: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -63,6 +63,7 @@ jobs:
         uses: subosito/flutter-action@v2
         if: matrix.needs-flutter != ''
         with:
+          cache: true
           channel: 'stable'
           flutter-version: ${{ steps.flutter-version.outputs.contents }}
       - name: Install Dart protoc plugin
@@ -374,6 +375,7 @@ jobs:
       - name: Set up flutter
         uses: subosito/flutter-action@v2
         with:
+          cache: true
           channel: 'stable'
           flutter-version: ${{ steps.flutter-version.outputs.contents }}
       - name: Download coverage artifacts

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -220,7 +220,7 @@ jobs:
       # The Windows Store needs to be built. The tests do it automatically, but they need
       # msbuild in the path.
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         if: matrix.subproject == 'storeapi/go-wrapper/microsoftstore' && matrix.os == 'windows'
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
         if: ${{ matrix.os == 'ubuntu' }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -123,6 +123,7 @@ jobs:
         if: matrix.package == 'ubuntupro'
         uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: windows-agent/go.mod
       - name: Read flutter version
         id: flutter-version
@@ -213,6 +214,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: ${{ matrix.subproject }}/go.mod
       - name: Set up git
         uses: ./.github/actions/setup-git
@@ -328,6 +330,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: windows-agent/go.mod
       - name: Install dependencies
         run: |
@@ -363,6 +366,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
+          cache-dependency-path: go.work
           go-version-file: windows-agent/go.mod
       - name: Install dependencies
         run: |

--- a/common/wsltestutils/wsl.go
+++ b/common/wsltestutils/wsl.go
@@ -138,7 +138,7 @@ func registerDistro(t *testing.T, ctx context.Context, distroName string, realDi
 			require.NotEmpty(t, appxDir, "could not find rootfs tarball. Is %s installed?", appx)
 			rootFsPath = filepath.Join(appxDir, "install.tar.gz")
 		}
-		return PowershellImportDistro(t, ctx, distroName, rootFsPath)
+		return PowershellInstallDistro(t, ctx, distroName, rootFsPath)
 	}
 
 	t.Cleanup(func() {

--- a/common/wsltestutils/wsl_linux.go
+++ b/common/wsltestutils/wsl_linux.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PowershellImportDistro uses powershell.exe to import a distro from a specific rootfs.
+// PowershellInstallDistro uses powershell.exe to install a distro from a specific rootfs image.
 // This implementation is a stub.
 //
 //nolint:revive // The context is better after the testing.T
-func PowershellImportDistro(t *testing.T, ctx context.Context, distroName string, rootFsPath string) (GUID string) {
+func PowershellInstallDistro(t *testing.T, ctx context.Context, distroName string, rootFsPath string) (GUID string) {
 	t.Helper()
 
 	require.Fail(t, "Attempted to register a distro on Linux", "To run this test on Linux, you must use the mock GoWSL back-end")

--- a/common/wsltestutils/wsl_windows.go
+++ b/common/wsltestutils/wsl_windows.go
@@ -13,22 +13,16 @@ import (
 	wsl "github.com/ubuntu/gowsl"
 )
 
-// PowershellImportDistro uses powershell.exe to import a distro from a specific rootfs.
-// If the rootfs is an empty string, an empty tarball will be used.
+// PowershellInstallDistro uses powershell.exe to install a distro from a specific rootfs image.
+// The distro instance is not launched yet.
+// It returns the GUID of the registered distro. The distro is automatically unregistered at the end of the test.
 //
 //nolint:revive // The context is better after the testing.T
-func PowershellImportDistro(t *testing.T, ctx context.Context, distroName string, rootFsPath string) (GUID string) {
+func PowershellInstallDistro(t *testing.T, ctx context.Context, distroName string, rootFsPath string) (GUID string) {
 	t.Helper()
 	tmpDir := t.TempDir()
 
-	require.False(t, wsl.MockAvailable(), "Called PowershellImportDistro with the gowslmock active. Use RegisterDistro for a generic implementation")
-
-	// Fake rootfs: the distro can be registered but won't run
-	if rootFsPath == "" {
-		rootFsPath = tmpDir + "/install.tar.gz"
-		err := os.WriteFile(rootFsPath, []byte{}, 0600)
-		require.NoError(t, err, "could not write empty file")
-	}
+	require.False(t, wsl.MockAvailable(), "Called PowershellInstallDistro with the gowslmock active. Use RegisterDistro for a generic implementation")
 
 	_, err := os.Lstat(rootFsPath)
 	require.NoError(t, err, "Setup: Could not stat rootFs:\n%s", rootFsPath)
@@ -37,12 +31,7 @@ func PowershellImportDistro(t *testing.T, ctx context.Context, distroName string
 	tk := time.AfterFunc(2*time.Minute, func() { powershellOutputf(t, `$env:WSL_UTF8=1 ; wsl --shutdown`) })
 	defer tk.Stop()
 
-	var vhdx string
-	if strings.HasSuffix(rootFsPath, ".vhdx") {
-		vhdx = "--vhd"
-	}
-
-	powershellOutputf(t, "$env:WSL_UTF8=1 ; wsl.exe --import %q %q %q %s", distroName, tmpDir, rootFsPath, vhdx)
+	powershellOutputf(t, "$env:WSL_UTF8=1 ; wsl.exe --install --name %q --location %q --from-file %q --no-launch", distroName, tmpDir, rootFsPath)
 	tk.Stop()
 
 	t.Cleanup(func() {

--- a/common/wsltestutils/wsl_windows.go
+++ b/common/wsltestutils/wsl_windows.go
@@ -35,7 +35,13 @@ func PowershellInstallDistro(t *testing.T, ctx context.Context, distroName strin
 	tk.Stop()
 
 	t.Cleanup(func() {
-		UnregisterDistro(t, ctx, distroName)
+		// Any other context might be already cancelled at this point, so we need a fresh one for the cleanup.
+		unctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		// #nosec G204 // The distro name is controlled by our tests.
+		if _, err := exec.CommandContext(unctx, "wsl.exe", "--unregister", distroName).CombinedOutput(); err != nil {
+			t.Logf("Cleanup: could not unregister distro %q: %v", distroName, err)
+		}
 	})
 
 	d := wsl.NewDistro(ctx, distroName)

--- a/end-to-end/cloud_init_test.go
+++ b/end-to-end/cloud_init_test.go
@@ -90,7 +90,7 @@ func TestCloudInitIntegration(t *testing.T) {
 		}
 		state, err := distro.State()
 		if err != nil {
-			t.Logf("could not determine if distro is registered: %v", err)
+			t.Logf("Could not determine if distro is registered: %v", err)
 			return false
 		}
 		return state == wsl.Stopped
@@ -104,7 +104,7 @@ func TestCloudInitIntegration(t *testing.T) {
 		attached, err1 := distroIsProAttached(t, ctx, distro)
 		tried, err2 := triedProAttach(t, distro.Name())
 		if err1 != nil && err2 != nil {
-			t.Logf("could not determine if distro tried to attach to Pro: %v", errors.Join(err1, err2))
+			t.Logf("Could not determine if distro tried to attach to Pro: %v", errors.Join(err1, err2))
 			return false
 		}
 		return attached || tried

--- a/end-to-end/cloud_init_test.go
+++ b/end-to-end/cloud_init_test.go
@@ -2,8 +2,10 @@ package endtoend_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -96,18 +98,26 @@ func TestCloudInitIntegration(t *testing.T) {
 	t.Log(runCommand(t, ctx, time.Minute, distro, "cloud-init status --wait"))
 
 	defer logWslProServiceOnError(t, ctx, distro)
+	defer logProClientOnError(t, distro.Name())
 
 	require.Eventually(t, func() bool {
-		attached, err := distroIsProAttached(t, ctx, distro)
-		if err != nil {
-			t.Logf("could not determine if distro is attached: %v", err)
+		attached, err1 := distroIsProAttached(t, ctx, distro)
+		tried, err2 := triedProAttach(t, distro.Name())
+		if err1 != nil && err2 != nil {
+			t.Logf("could not determine if distro tried to attach to Pro: %v", errors.Join(err1, err2))
 			return false
 		}
-		return attached
-	}, 10*time.Second, time.Second, "distro should have been Pro attached")
+		return attached || tried
+	}, 10*time.Second, time.Second, "distro should have tried to attach to Pro")
 
 	uid, err := distro.Command(ctx, "id -u testuser").CombinedOutput()
 	require.NoError(t, err, "cloud-init should have configured the default user, uid is %s", uid)
+	// Finally, give extra room for wsl-pro-service to talk to the agent.
+	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", name)
+	require.NoError(t, cmd.Start(), "Could not launch the distro for final assertions")
+	time.Sleep(1 * time.Second)
+	//nolint:errcheck // There is nothing we can do if this fails.
+	defer cmd.Process.Kill()
 
 	landscape.RequireReceivedInfo(t, proToken, []wsl.Distro{distro}, hostname)
 	landscape.RequireUninstallCommand(t, ctx, distro, info)

--- a/end-to-end/cloud_init_test.go
+++ b/end-to-end/cloud_init_test.go
@@ -2,6 +2,7 @@ package endtoend_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,13 +16,9 @@ import (
 )
 
 func TestCloudInitIntegration(t *testing.T) {
-	// TODO: Remove this line when cloud-init support for UP4W is released.
-	// Follow this PR for more information: https://github.com/canonical/cloud-init/pull/5116
-	t.Skip("This test depends on cloud-init support for UP4W being released.")
 	currentFuncName := t.Name()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	testSetup(t)
 	defer logWindowsAgentOnError(t)
@@ -56,17 +53,19 @@ func TestCloudInitIntegration(t *testing.T) {
 	require.NoError(t, err, "Setup: could not read cloud-init file")
 	cloudInitUserData := string(out)
 
+	name := "Ubuntu-Preview"
 	err = landscape.service.SendCommand(ctx, info.UID, &landscapeapi.Command{
 		Cmd: &landscapeapi.Command_Install_{
 			Install: &landscapeapi.Command_Install{
-				Id:        strings.Split(referenceDistroAppx, ".")[1], // CanonicalGroupLimited.[UbuntuPreview]
+				Id:        name,
 				Cloudinit: &cloudInitUserData,
 			},
 		},
+		RequestId: "Server123",
 	})
 	require.NoError(t, err, "Setup: could not send install command")
 
-	distro := wsl.NewDistro(ctx, referenceDistro)
+	distro := wsl.NewDistro(ctx, name)
 
 	//nolint:errcheck // Nothing we can do about it
 	defer distro.Unregister()
@@ -77,12 +76,19 @@ func TestCloudInitIntegration(t *testing.T) {
 			t.Logf("could not determine if distro is registered: %v", err)
 			return false
 		}
-		return ok
-	}, time.Minute, time.Second, "Distro should have been registered")
+		if !ok {
+			return false
+		}
+		state, err := distro.State()
+		if err != nil {
+			t.Logf("could not determine if distro is registered: %v", err)
+			return false
+		}
+		return state == wsl.Stopped
+	}, 10*time.Minute, 10*time.Second, "Distro should have been registered")
+	t.Log(runCommand(t, ctx, time.Minute, distro, "cloud-init status --wait"))
 
 	defer logWslProServiceOnError(t, ctx, distro)
-
-	runCommand(t, ctx, time.Minute, distro, "cloud-init status --wait")
 
 	require.Eventually(t, func() bool {
 		attached, err := distroIsProAttached(t, ctx, distro)
@@ -93,34 +99,32 @@ func TestCloudInitIntegration(t *testing.T) {
 		return attached
 	}, 10*time.Second, time.Second, "distro should have been Pro attached")
 
-	userName := runCommand(t, ctx, 10*time.Second, distro, "whoami")
-	require.Equal(t, "testuser", userName, "cloud-init should have configured the default user")
+	uid, err := distro.Command(ctx, "id -u testuser").CombinedOutput()
+	require.NoError(t, err, "cloud-init should have configured the default user, uid is %s", uid)
 
 	landscape.RequireReceivedInfo(t, proToken, []wsl.Distro{distro}, hostname)
 	landscape.RequireUninstallCommand(t, ctx, distro, info)
 }
 
 //nolint:revive // t always goes before ctx
-func runCommand(t *testing.T, ctx context.Context, timeout time.Duration, distro wsl.Distro, comand string) string {
+func runCommand(t *testing.T, ctx context.Context, timeout time.Duration, distro wsl.Distro, command string) string {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	out, err := distro.Command(ctx, comand).CombinedOutput()
+	out, err := distro.Command(ctx, command).CombinedOutput()
 	if err == nil {
-		return string(out)
+		return strings.TrimSpace(string(out))
 	}
 
 	// We check the context to see if it was a timeout.
 	// This makes the error message easier to understand.
-
 	select {
 	case <-ctx.Done():
 		require.Fail(t, "Timed out waiting for cloud-init to finish")
 	default:
 	}
 
-	require.NoError(t, err, "could not determine if cloud-init is done: %s. Output: %s", out, out)
-	return ""
+	return fmt.Sprintf("Stdout: %s. Stderr: %s", out, err)
 }

--- a/end-to-end/cloud_init_test.go
+++ b/end-to-end/cloud_init_test.go
@@ -16,6 +16,13 @@ import (
 )
 
 func TestCloudInitIntegration(t *testing.T) {
+	deinit, err := initializeCOM()
+	if err != nil {
+		deinit()
+		t.Fatalf("could not initialize COM: %v", err)
+	}
+	defer deinit()
+
 	currentFuncName := t.Name()
 
 	ctx := t.Context()

--- a/end-to-end/cloud_init_test.go
+++ b/end-to-end/cloud_init_test.go
@@ -110,14 +110,14 @@ func TestCloudInitIntegration(t *testing.T) {
 		return attached || tried
 	}, 10*time.Second, time.Second, "distro should have tried to attach to Pro")
 
-	uid, err := distro.Command(ctx, "id -u testuser").CombinedOutput()
-	require.NoError(t, err, "cloud-init should have configured the default user, uid is %s", uid)
-	// Finally, give extra room for wsl-pro-service to talk to the agent.
+	// Finally, wake the distro instance so wsl-pro-service can talk to the agent.
 	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", name)
 	require.NoError(t, cmd.Start(), "Could not launch the distro for final assertions")
-	time.Sleep(1 * time.Second)
 	//nolint:errcheck // There is nothing we can do if this fails.
 	defer cmd.Process.Kill()
+
+	uid, err := distro.Command(ctx, "id -u testuser").CombinedOutput()
+	require.NoError(t, err, "cloud-init should have configured the default user, uid is %s", uid)
 
 	landscape.RequireReceivedInfo(t, proToken, []wsl.Distro{distro}, hostname)
 	landscape.RequireUninstallCommand(t, ctx, distro, info)

--- a/end-to-end/landscape_utils_test.go
+++ b/end-to-end/landscape_utils_test.go
@@ -105,6 +105,7 @@ func (l landscape) LogOnError(t *testing.T) {
 func (l landscape) Stop() {
 	if l.stop != nil {
 		l.stop()
+		l.server.Stop()
 	}
 }
 
@@ -123,11 +124,15 @@ func (l landscape) RequireReceivedInfo(t *testing.T, wantToken string, wantDistr
 	require.Equal(t, wantToken, info.Token, "Landscape did not receive the right pro token")
 
 	// Validate distros
+	wantInstances := make([]string, len(wantDistros))
+	for i, d := range wantDistros {
+		wantInstances[i] = d.Name()
+	}
 	gotDistros := make([]string, 0)
 	for _, instance := range info.Instances {
 		gotDistros = append(gotDistros, instance.ID)
 	}
-	require.ElementsMatch(t, wantDistros, gotDistros, "Landscape did not receive the right distros")
+	require.ElementsMatch(t, wantInstances, gotDistros, "Landscape did not receive the right distros")
 
 	// Validate hostname
 	require.Equal(t, wantHostname, info.Hostname, "Landscape did not receive the right hostname from the agent")
@@ -158,5 +163,5 @@ func (l landscape) RequireUninstallCommand(t *testing.T, ctx context.Context, d 
 			t.Logf("While waiting for Landscape uninstall command to complete: %v", err)
 		}
 		return !reg
-	}, time.Minute, time.Second, "Landcape uninstall command never took effect")
+	}, time.Minute, time.Second, "Landscape uninstall command never took effect")
 }

--- a/end-to-end/landscape_utils_test.go
+++ b/end-to-end/landscape_utils_test.go
@@ -105,6 +105,8 @@ func (l landscape) LogOnError(t *testing.T) {
 func (l landscape) Stop() {
 	if l.stop != nil {
 		l.stop()
+	}
+	if l.server != nil {
 		l.server.Stop()
 	}
 }

--- a/end-to-end/landscape_utils_test.go
+++ b/end-to-end/landscape_utils_test.go
@@ -114,16 +114,20 @@ func (l landscape) RequireReceivedInfo(t *testing.T, wantToken string, wantDistr
 	t.Helper()
 
 	require.Eventually(t, func() bool {
-		return len(l.service.Hosts()) > 0
-	}, time.Minute, time.Second, "Landscape should have had at least one connection")
-
-	require.Len(t, l.service.Hosts(), 1, "Landscape should have had only one connection")
-	info := maps.Values(l.service.Hosts())[0]
+		return len(l.service.Hosts()) == 1
+	}, time.Minute, time.Second, "Landscape should have had exactly one connection")
 
 	// Validate token
-	require.Equal(t, wantToken, info.Token, "Landscape did not receive the right pro token")
+	require.Equal(t, wantToken, maps.Values(l.service.Hosts())[0].Token, "Landscape did not receive the right pro token")
 
 	// Validate distros
+	wantDistroCount := len(wantDistros)
+	require.Eventually(t, func() bool {
+		info := maps.Values(l.service.Hosts())[0]
+		return len(info.Instances) == wantDistroCount
+	}, 30*time.Second, time.Second, "Landscape should have received the right number of distros")
+
+	info := maps.Values(l.service.Hosts())[0]
 	wantInstances := make([]string, len(wantDistros))
 	for i, d := range wantDistros {
 		wantInstances[i] = d.Name()

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	wsl "github.com/ubuntu/gowsl"
@@ -41,7 +42,9 @@ const (
 	// The structure is expected to be:
 	// └──${prebuiltPath}
 	//    ├───images
-	//    │   └──ubuntu.wsl
+	//    │   ├──test_manifest.json # Optional, but allow direct use of wsl --install in tests.
+	//    │   ├──ubuntu.wsl
+	//    │   └──ubuntu-preview.tar.gz
 	//    ├───wsl-pro-service
 	//    │   └──wsl-pro-service_*.deb
 	//    └───windows-agent
@@ -70,7 +73,9 @@ func TestMain(m *testing.M) {
 		log.Fatalf(`Setup: environment variable %q is not set. It's expected to point to a directory with the following structure:
 	    ${prebuiltPath}
 	    ├───images
-	    │   └──ubuntu.wsl
+	    │   ├──test_manifest.json # Optional, but allow direct use of wsl --install in tests.
+	    │   ├──ubuntu.wsl
+	    │   └──ubuntu-preview.tar.gz
 	    ├───wsl-pro-service
 	    │   └──wsl-pro-service_*.deb
 	    └───windows-agent
@@ -84,14 +89,7 @@ func TestMain(m *testing.M) {
 	log.Printf("MSIX package located at %s", msixPath)
 	log.Printf("Deb package located at %s", debPkgPath)
 
-	ctx := context.Background()
-	imagePath := filepath.Join(buildPath, "images", referenceImage)
-	path, cleanup, err := generateTestImage(ctx, imagePath)
-	if err != nil {
-		log.Fatalf("Setup: %v\n", err)
-	}
-	defer cleanup()
-	testImagePath = path
+	testImagePath = filepath.Join(buildPath, "images", referenceImage)
 
 	m.Run()
 
@@ -99,6 +97,8 @@ func TestMain(m *testing.M) {
 		log.Printf("Cleanup: registry: %v\n", err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	cmd := powershellf(ctx, "Get-AppxPackage -Name %q | Remove-AppxPackage", up4wAppxPackage)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Printf("Cleanup: could not remove Appx: %v: %s", err, out)
@@ -248,93 +248,6 @@ func cleanupRegistry() error {
 	}
 
 	return nil
-}
-
-// generateTestImage fails if there is a distro instance named "Reference", unless the safety checks are overridden,
-// in which case it's removed. The source image is then registered, transformed, exported and unregistered.
-// The test image has a default user preconfigured to avoid wsl-setup from hanging on first boot.
-// It also contains the wsl-pro-service Debian package found in the project build directory.
-func generateTestImage(ctx context.Context, sourceImage string) (string, func(), error) {
-	// #nosec G706 // sourceImage is a controlled test input, not user input.
-	log.Printf("Setup: Generating test image from %q\n", sourceImage)
-	reference := "Reference"
-
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "UP4W_TEST_*")
-	if err != nil {
-		return "", nil, err
-	}
-	cleanup := func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			log.Printf("Setup: Cleanup: could not remove test tempdir: %v", err)
-		}
-	}
-	// Ensures cleanup() runs if we return early due to an error.
-	defer func() {
-		if err != nil {
-			cleanup()
-			return
-		}
-		// #nosec G706 // sourceImage is a controlled test input, not user input.
-		log.Printf("Setup: Generated test image from %q\n", sourceImage)
-	}()
-
-	d := wsl.NewDistro(ctx, reference)
-	if err := assertDistroUnregistered(d); err != nil {
-		return "", nil, err
-	}
-
-	out, err := powershellf(ctx, "wsl.exe --install --name %s --from-file %s --no-launch", reference, sourceImage).CombinedOutput()
-	if err != nil {
-		return "", nil, fmt.Errorf("could not register %s instance from image %q: %v. %s", reference, sourceImage, err, out)
-	}
-	// #nosec G706 // sourceImage is a controlled test input, not user input.
-	log.Printf("Setup: Installed %s instance from image %q\n", reference, sourceImage)
-
-	defer func() {
-		if err := d.Unregister(); err != nil {
-			// #nosec G706 // sourceImage is a controlled test input, not user input.
-			log.Printf("Setup: Failed to unregister %s instance from image %q after generating the test image\n", reference, sourceImage)
-		}
-	}()
-	// Transform the reference distro instance:
-	// Install wsl-pro-service from the deb package built with the project.
-	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- bash -ec 'apt-get update && apt-get install --yes "$(wslpath -ua %q)"'`, reference, debPkgPath).CombinedOutput()
-	if err != nil {
-		return "", nil, fmt.Errorf("could not install wsl-pro-service: %v. %s", err, out)
-	}
-	// Set wsl-pro-service verbosity to 3 to get more logs in case of failure. Quotes around the
-	// file contents wouldn't work.
-	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- bash -ec 'echo verbosity: 3 > /etc/wsl-pro-service.yaml'`, reference).CombinedOutput()
-	// #nosec G706 // sourceImage and reference are variables controlled by the test, not user input.
-	log.Printf("Setup: Installed wsl-pro-service into %s instance from image %q\n", reference, sourceImage)
-	// Create a default admin user to prevent wsl-setup from holding the first boot.
-	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- adduser --quiet --gecos Ubuntu ubuntu`, reference).CombinedOutput()
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to create the default user: %v\n%s", err, out)
-	}
-	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- usermod ubuntu -aG sudo,adm`, reference).CombinedOutput()
-	if err != nil {
-		log.Printf("failed to turn the default user into admin: %v\n%s", err, out)
-	}
-
-	// Make sure cloud-init finds a fresh instance to initialize. Those commands should always fail, but that's still a good preventive measure.
-	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- cloud-init clean --logs`, reference).CombinedOutput()
-	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- rm /etc/cloud/cloud-init.disabled`, reference).CombinedOutput()
-
-	if err := wsl.Shutdown(ctx); err != nil {
-		return "", nil, fmt.Errorf("could not shut down WSL: %v", err)
-	}
-
-	path := filepath.Join(tmpDir, "snapshot.tar.gz")
-	//#nosec G204 // We control the inputs.
-	out, err = exec.CommandContext(ctx, "wsl.exe", "--export", reference, path).CombinedOutput()
-	if err != nil {
-		return "", nil, fmt.Errorf("could not export test image: %v. %s", err, out)
-	}
-
-	log.Println("Setup: Exported tested image")
-
-	return path, cleanup, nil
 }
 
 func assertDistroUnregistered(d wsl.Distro) error {

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
-	wsl "github.com/ubuntu/gowsl"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
@@ -247,27 +246,6 @@ func cleanupRegistry() error {
 	}
 	if err != nil {
 		return fmt.Errorf("could not delete UbuntuPro key: %v", err)
-	}
-
-	return nil
-}
-
-func assertDistroUnregistered(d wsl.Distro) error {
-	registered, err := d.IsRegistered()
-	if err != nil {
-		return err
-	}
-
-	if !registered {
-		return nil
-	}
-
-	if os.Getenv(overrideSafety) == "" {
-		return fmt.Errorf("distro %q should not exist. Unregister it to agree to run this potentially destructive test", d.Name())
-	}
-
-	if err := d.Unregister(); err != nil {
-		return err
 	}
 
 	return nil

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
@@ -41,6 +40,8 @@ const (
 	// prebuiltPath is an env variable that, if set, uses a build at a certain path instead of building the project anew.
 	// The structure is expected to be:
 	// └──${prebuiltPath}
+	//    ├───images
+	//    │   └──ubuntu.wsl
 	//    ├───wsl-pro-service
 	//    │   └──wsl-pro-service_*.deb
 	//    └───windows-agent
@@ -48,27 +49,14 @@ const (
 	//
 	prebuiltPath = "UP4W_TEST_BUILD_PATH"
 
-	// referenceDistro is the WSL distro that will be used to generate the test image.
-	referenceDistro = "Ubuntu-Preview"
-
-	// referenceDistro is the WSL distro that will be used to generate the test image.
-	referenceDistroAppx = "CanonicalGroupLimited.UbuntuPreview"
+	// referenceImage is the WSL distro image that will be used to generate the test image.
+	referenceImage = "ubuntu.wsl"
 
 	// up4wAppxPackage is the Ubuntu Pro for WSL package.
 	up4wAppxPackage = "CanonicalGroupLimited.UbuntuPro"
 )
 
 func TestMain(m *testing.M) {
-	ctx := context.Background()
-
-	if err := assertAppxInstalled(ctx, "MicrosoftCorporationII.WindowsSubsystemForLinux"); err != nil {
-		log.Fatalf("Setup: %v\n", err)
-	}
-
-	if err := assertAppxInstalled(ctx, referenceDistroAppx); err != nil {
-		log.Fatalf("Setup: %v\n", err)
-	}
-
 	if err := assertCleanRegistry(); err != nil {
 		log.Fatalf("Setup: %v\n", err)
 	}
@@ -79,21 +67,26 @@ func TestMain(m *testing.M) {
 
 	buildPath := os.Getenv(prebuiltPath)
 	if buildPath == "" {
-		path, err := buildProject(ctx)
-		if err != nil {
-			log.Fatalf("Setup: %v\n", err)
-		}
-		buildPath = path
+		log.Fatalf(`Setup: environment variable %q is not set. It's expected to point to a directory with the following structure:
+	    ${prebuiltPath}
+	    ├───images
+	    │   └──ubuntu.wsl
+	    ├───wsl-pro-service
+	    │   └──wsl-pro-service_*.deb
+	    └───windows-agent
+	        └──UbuntuProForWSL_*.msixbundle
+	`, prebuiltPath)
 	}
 
 	if err := usePrebuiltProject(buildPath); err != nil {
 		log.Fatalf("Setup: %v\n", err)
 	}
-
 	log.Printf("MSIX package located at %s", msixPath)
 	log.Printf("Deb package located at %s", debPkgPath)
 
-	path, cleanup, err := generateTestImage(ctx, referenceDistro)
+	ctx := context.Background()
+	imagePath := filepath.Join(buildPath, "images", referenceImage)
+	path, cleanup, err := generateTestImage(ctx, imagePath)
 	if err != nil {
 		log.Fatalf("Setup: %v\n", err)
 	}
@@ -139,86 +132,9 @@ func usePrebuiltProject(buildPath string) (err error) {
 	return nil
 }
 
-func buildProject(ctx context.Context) (string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	buildPath, err := os.MkdirTemp(os.TempDir(), "UP4W-E2E-build")
-	if err != nil {
-		return "", fmt.Errorf("could not create temporary directory for build artifacts")
-	}
-
-	debPath := filepath.Join(buildPath, "wsl-pro-service")
-	winPath := filepath.Join(buildPath, "windows-agent")
-
-	if err := os.MkdirAll(debPath, 0600); err != nil {
-		return "", fmt.Errorf("could not create directory for WSL-Pro-Service Debian package artifacts")
-	}
-
-	if err := os.MkdirAll(winPath, 0600); err != nil {
-		return "", fmt.Errorf("could not create directory for Ubuntu Pro for WSL MSIX artifacts")
-	}
-
-	jobs := map[string]*exec.Cmd{
-		"Build Windows Agent":   powershellf(ctx, `..\tools\build\build-appx.ps1 -Mode end_to_end_tests -OutputDir %q`, winPath),
-		"Build Wsl Pro Service": powershellf(ctx, `..\tools\build\build-deb.ps1 -OutputDir %q`, debPath),
-	}
-
-	results := make(chan error)
-	for jobName, cmd := range jobs {
-		go func() {
-			log.Printf("Started job: %s\n", jobName)
-
-			logPath := strings.ReplaceAll(fmt.Sprintf("%s.log", jobName), " ", "")
-			if f, err := os.Create(logPath); err != nil {
-				log.Printf("%s: could not open log file %q for writing", jobName, logPath)
-			} else {
-				cmd.Stdout = f
-				cmd.Stderr = f
-				defer f.Close()
-			}
-
-			if err := cmd.Run(); err != nil {
-				cancel()
-				results <- fmt.Errorf("%q: %v. Check out %q for more details", jobName, err, logPath)
-				return
-			}
-
-			log.Printf("Finished job: %s\n", jobName)
-			results <- nil
-		}()
-	}
-
-	for range jobs {
-		err = errors.Join(err, <-results)
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("could not build project: %v", err)
-	}
-
-	log.Println("Project built")
-
-	return buildPath, nil
-}
-
-// assertAppxInstalled returns an error if the provided Appx is not installed.
-func assertAppxInstalled(ctx context.Context, appx string) error {
-	out, err := powershellf(ctx, `(Get-AppxPackage -Name %q).Status`, appx).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("could not determine if %q is installed: %v. %s", appx, err, out)
-	}
-	s := strings.TrimSpace(string(out))
-	if s != "Ok" {
-		return fmt.Errorf("appx %q is not installed", appx)
-	}
-
-	return nil
-}
-
-// powershellf is syntax sugar to run powrshell commands.
+// powershellf is syntax sugar to run powrshell commands with formatted arguments.
 func powershellf(ctx context.Context, command string, args ...any) *exec.Cmd {
-	//#nosec G204 // This is a test helper for which all callers have hardcoded inputs.
+	//#nosec G204,G702 // This is a test helper for which all callers have hardcoded inputs.
 	return exec.CommandContext(ctx, "powershell.exe",
 		"-NoProfile",
 		"-NoLogo",
@@ -334,74 +250,89 @@ func cleanupRegistry() error {
 	return nil
 }
 
-// generateTestImage fails if the sourceDistro is registered, unless the safety checks are overridden,
-// in which case the sourceDistro is removed.
-// The source distro is then registered, exported after first boot, and unregistered.
-func generateTestImage(ctx context.Context, sourceDistro string) (path string, cleanup func(), err error) {
-	log.Printf("Setup: Generating test image from %q\n", sourceDistro)
-	defer log.Printf("Setup: Generated test image from %q\n", sourceDistro)
+// generateTestImage fails if there is a distro instance named "Reference", unless the safety checks are overridden,
+// in which case it's removed. The source image is then registered, transformed, exported and unregistered.
+// The test image has a default user preconfigured to avoid wsl-setup from hanging on first boot.
+// It also contains the wsl-pro-service Debian package found in the project build directory.
+func generateTestImage(ctx context.Context, sourceImage string) (string, func(), error) {
+	// #nosec G706 // sourceImage is a controlled test input, not user input.
+	log.Printf("Setup: Generating test image from %q\n", sourceImage)
+	reference := "Reference"
 
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "UP4W_TEST_*")
 	if err != nil {
 		return "", nil, err
 	}
-	cleanup = func() {
+	cleanup := func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
 			log.Printf("Setup: Cleanup: could not remove test tempdir: %v", err)
 		}
 	}
+	// Ensures cleanup() runs if we return early due to an error.
+	defer func() {
+		if err != nil {
+			cleanup()
+			return
+		}
+		// #nosec G706 // sourceImage is a controlled test input, not user input.
+		log.Printf("Setup: Generated test image from %q\n", sourceImage)
+	}()
 
-	d := wsl.NewDistro(ctx, sourceDistro)
+	d := wsl.NewDistro(ctx, reference)
 	if err := assertDistroUnregistered(d); err != nil {
-		cleanup()
 		return "", nil, err
 	}
 
-	launcher, err := common.WSLLauncher(sourceDistro)
+	out, err := powershellf(ctx, "wsl.exe --install --name %s --from-file %s --no-launch", reference, sourceImage).CombinedOutput()
 	if err != nil {
-		cleanup()
-		return "", nil, err
+		return "", nil, fmt.Errorf("could not register %s instance from image %q: %v. %s", reference, sourceImage, err, out)
 	}
-
-	out, err := powershellf(ctx, "%s install --root --ui=none", launcher).CombinedOutput()
-	if err != nil {
-		cleanup()
-		return "", nil, fmt.Errorf("could not register %q: %v. %s", sourceDistro, err, out)
-	}
-
-	log.Printf("Setup: Installed %q\n", sourceDistro)
+	// #nosec G706 // sourceImage is a controlled test input, not user input.
+	log.Printf("Setup: Installed %s instance from image %q\n", reference, sourceImage)
 
 	defer func() {
 		if err := d.Unregister(); err != nil {
-			log.Printf("Setup: Failed to unregister %q after generating the test image\n", sourceDistro)
+			// #nosec G706 // sourceImage is a controlled test input, not user input.
+			log.Printf("Setup: Failed to unregister %s instance from image %q after generating the test image\n", reference, sourceImage)
 		}
 	}()
-
-	// From now on, all cleanups must be deferred because the distro
-	// must be unregistered before removing the directory it is in.
-
-	out, err = d.Command(ctx, fmt.Sprintf(`DEBIAN_FRONTEND=noninteractive bash -ec "apt update && apt install -y $(wslpath -ua '%s')"`, debPkgPath)).CombinedOutput()
+	// Transform the reference distro instance:
+	// Install wsl-pro-service from the deb package built with the project.
+	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- bash -ec 'apt-get update && apt-get install --yes "$(wslpath -ua %q)"'`, reference, debPkgPath).CombinedOutput()
 	if err != nil {
-		defer cleanup()
 		return "", nil, fmt.Errorf("could not install wsl-pro-service: %v. %s", err, out)
 	}
+	// Set wsl-pro-service verbosity to 3 to get more logs in case of failure. Quotes around the
+	// file contents wouldn't work.
+	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- bash -ec 'echo verbosity: 3 > /etc/wsl-pro-service.yaml'`, reference).CombinedOutput()
+	// #nosec G706 // sourceImage and reference are variables controlled by the test, not user input.
+	log.Printf("Setup: Installed wsl-pro-service into %s instance from image %q\n", reference, sourceImage)
+	// Create a default admin user to prevent wsl-setup from holding the first boot.
+	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- adduser --quiet --gecos Ubuntu ubuntu`, reference).CombinedOutput()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create the default user: %v\n%s", err, out)
+	}
+	out, err = powershellf(ctx, `wsl.exe -d %s -u root -- usermod ubuntu -aG sudo,adm`, reference).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to turn the default user into admin: %v\n%s", err, out)
+	}
 
-	log.Printf("Setup: Installed wsl-pro-service into %q\n", sourceDistro)
+	// Make sure cloud-init finds a fresh instance to initialize. Those commands should always fail, but that's still a good preventive measure.
+	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- cloud-init clean --logs`, reference).CombinedOutput()
+	_, _ = powershellf(ctx, `wsl.exe -d %s -u root -- rm /etc/cloud/cloud-init.disabled`, reference).CombinedOutput()
 
 	if err := wsl.Shutdown(ctx); err != nil {
-		defer cleanup()
 		return "", nil, fmt.Errorf("could not shut down WSL: %v", err)
 	}
 
-	path = filepath.Join(tmpDir, "snapshot.vhdx")
+	path := filepath.Join(tmpDir, "snapshot.tar.gz")
 	//#nosec G204 // We control the inputs.
-	out, err = exec.CommandContext(ctx, "wsl.exe", "--export", sourceDistro, path, "--vhd").CombinedOutput()
+	out, err = exec.CommandContext(ctx, "wsl.exe", "--export", reference, path).CombinedOutput()
 	if err != nil {
-		defer cleanup()
 		return "", nil, fmt.Errorf("could not export test image: %v. %s", err, out)
 	}
 
-	log.Println("Setup: Exported image")
+	log.Println("Setup: Exported tested image")
 
 	return path, cleanup, nil
 }
@@ -409,7 +340,7 @@ func generateTestImage(ctx context.Context, sourceDistro string) (path string, c
 func assertDistroUnregistered(d wsl.Distro) error {
 	registered, err := d.IsRegistered()
 	if err != nil {
-		return fmt.Errorf("ubuntu-preview: %v", err)
+		return err
 	}
 
 	if !registered {

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	wsl "github.com/ubuntu/gowsl"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -269,4 +271,16 @@ func assertDistroUnregistered(d wsl.Distro) error {
 	}
 
 	return nil
+}
+
+func initializeCOM() (func(), error) {
+	runtime.LockOSThread()
+	if err := windows.CoInitializeEx(0, windows.COINIT_MULTITHREADED); err != nil {
+		return runtime.UnlockOSThread, fmt.Errorf("could not initialize COM library: %v", err)
+	}
+
+	return func() {
+		windows.CoUninitialize()
+		runtime.UnlockOSThread()
+	}, nil
 }

--- a/end-to-end/main_test.go
+++ b/end-to-end/main_test.go
@@ -98,7 +98,7 @@ func TestMain(m *testing.M) {
 		log.Printf("Cleanup: registry: %v\n", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := powershellf(ctx, "Get-AppxPackage -Name %q | Remove-AppxPackage", up4wAppxPackage)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/end-to-end/manual_token_input_test.go
+++ b/end-to-end/manual_token_input_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestManualTokenInput(t *testing.T) {
-	// TODO: Remove this line when cloud-init support for UP4W is released.
-	// Follow this PR for more information: https://github.com/canonical/cloud-init/pull/5116
-	t.Skip("This test depends on cloud-init support for UP4W being released.")
+	t.Skip("This test is disabled due performance issues leading to too frequent failures")
 
 	type whenToken int
 	const (

--- a/end-to-end/organization_token_test.go
+++ b/end-to-end/organization_token_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestOrganizationProvidedToken(t *testing.T) {
-	// TODO: Remove this line when cloud-init support for UP4W is released.
-	// Follow this PR for more information: https://github.com/canonical/cloud-init/pull/5116
-	t.Skip("This test depends on cloud-init support for UP4W being released.")
+	t.Skip("This test is disabled due performance issues leading to too frequent failures")
 
 	type whenToken int
 	const (

--- a/end-to-end/purchase_test.go
+++ b/end-to-end/purchase_test.go
@@ -23,9 +23,7 @@ const (
 )
 
 func TestPurchase(t *testing.T) {
-	// TODO: Remove this line when cloud-init support for UP4W is released.
-	// Follow this PR for more information: https://github.com/canonical/cloud-init/pull/5116
-	t.Skip("This test depends on cloud-init support for UP4W being released.")
+	t.Skip("This test is disabled due performance issues leading to too frequent failures")
 
 	type whenToken int
 	const (

--- a/end-to-end/utils_test.go
+++ b/end-to-end/utils_test.go
@@ -277,7 +277,7 @@ func requireRegistryIsInitialized(t *testing.T, valueNames []string) {
 	values, err := key.ReadValueNames(len(valueNames))
 	require.NoError(t, err, "Setup: could not read the UbuntuPro registry key values")
 
-	for v := range valueNames {
+	for _, v := range valueNames {
 		require.Contains(t, values, v, "Setup: UbuntuPro registry key was not initialized as expected")
 	}
 }

--- a/end-to-end/utils_test.go
+++ b/end-to-end/utils_test.go
@@ -24,13 +24,16 @@ import (
 
 func testSetup(t *testing.T) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 
-	err := gowsl.Shutdown(ctx)
-	require.NoError(t, err, "Setup: could not shut WSL down")
-
-	err = stopAgent(ctx)
+	err := stopAgent(ctx)
 	require.NoError(t, err, "Setup: could not stop the agent")
+
+	// This should most likely fail on regular machines, but may be helpful in CI.
+	out, err := powershellf(ctx, "Restart-Service -Name WSLService -Force").CombinedOutput()
+	if err != nil {
+		t.Logf("Could not restart WSLService: %v. %s", err, out)
+	}
 
 	err = reinstallMSIX(ctx, msixPath)
 	require.NoError(t, err, "Setup: could not reinstall the agent")
@@ -42,6 +45,9 @@ func testSetup(t *testing.T) {
 	require.NoError(t, err, "Setup: local app data is polluted, potentially by a previous test")
 
 	t.Cleanup(func() {
+		// t.Context() is cancelled when t.Cleanup runs.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		err := errors.Join(
 			stopAgent(ctx),
 			cleanupRegistry(),
@@ -153,6 +159,19 @@ func stopAgent(ctx context.Context) error {
 	return fmt.Errorf("could not stop process %q: %v. %s", process, err, out)
 }
 
+func triedProAttach(t *testing.T, instanceName string) (bool, error) {
+	t.Helper()
+
+	const pattern = `"Executed with sys.argv: ['/usr/bin/pro', 'attach', '<REDACTED>'`
+	path := fmt.Sprintf(`\\wsl.localhost\%s\var\log\ubuntu-advantage.log`, instanceName)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("could not read log file at %q: %v", path, err)
+	}
+
+	return strings.Contains(string(contents), pattern), nil
+}
+
 //nolint:revive // testing.T must precede the context
 func distroIsProAttached(t *testing.T, ctx context.Context, d gowsl.Distro) (bool, error) {
 	t.Helper()
@@ -192,12 +211,29 @@ func logWslProServiceOnError(t *testing.T, ctx context.Context, d gowsl.Distro) 
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	out, err := d.Command(ctx, "journalctl -b --no-pager -u wsl-pro.service").CombinedOutput()
 	if err != nil {
 		t.Logf("could not access WSL Pro Service logs: %v\n%s\n", err, out)
 		return
 	}
 	t.Logf("WSL Pro Service logs:\n%s\n", out)
+}
+
+func logProClientOnError(t *testing.T, instanceName string) {
+	t.Helper()
+
+	if !t.Failed() {
+		return
+	}
+
+	out, err := os.ReadFile(fmt.Sprintf(`\\wsl.localhost\%s\var\log\ubuntu-advantage.log`, instanceName))
+	if err != nil {
+		t.Logf("could not access Pro Client logs: %v\n%s\n", err, out)
+		return
+	}
+	t.Logf("Pro Client logs:\n%s\n", out)
 }
 
 func logWindowsAgentOnError(t *testing.T) {

--- a/end-to-end/utils_test.go
+++ b/end-to-end/utils_test.go
@@ -62,7 +62,7 @@ func registerFromTestImage(t *testing.T, ctx context.Context) string {
 	t.Logf("Registering distro %q", distroName)
 	defer t.Logf("Registered distro %q", distroName)
 
-	_ = wsltestutils.PowershellImportDistro(t, ctx, distroName, testImagePath)
+	_ = wsltestutils.PowershellInstallDistro(t, ctx, distroName, testImagePath)
 	return distroName
 }
 

--- a/end-to-end/utils_test.go
+++ b/end-to-end/utils_test.go
@@ -230,7 +230,7 @@ func logProClientOnError(t *testing.T, instanceName string) {
 
 	out, err := os.ReadFile(fmt.Sprintf(`\\wsl.localhost\%s\var\log\ubuntu-advantage.log`, instanceName))
 	if err != nil {
-		t.Logf("could not access Pro Client logs: %v\n%s\n", err, out)
+		t.Logf("Could not access Pro Client logs: %v\n%s\n", err, out)
 		return
 	}
 	t.Logf("Pro Client logs:\n%s\n", out)

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 use (
 	./agentapi


### PR DESCRIPTION
This PR aims to revamp the end-to-end tests to:
- run in GH hosted runners
- use tar-based distro images instead of appx based.

By doing so we move from CI runs that can take between 30-45 minutes (excluding outliers) doing basically installation checks into a scenario where we do install, run the system end to end and assert on expected effects in less than 20 minutes.

The work is not complete yet, there are more improvements to come, but the current state is digestible enough.
Also, the current discoveries and fixes are making this PR way to big, reason why some fixes were moved into PRs #1620 and #1621 . Yet, there are a few blockers preventing enablement of more tests cases. Either I find a smart way to make GoWSL prevent contention against WSL or WSL itself becomes more resilient to concurrency. When working on this PR I saw it broken in multiple ways, from commands never completing to WSL instances failing to discover their own name... Because of that I'm limiting the enablement of test cases to just the integration of Landscape and cloud-init (after trying a lot to re-enable the manual token input test case :/)

A number of small peasant changes were done to either leverage caching features of certain GH actions (flutter-action, setup-go) or to upgrade them to the latest stable versions (upload-artifact, download-artifact, setup-msbuild).


A number of peasant fixes were made along the way to prevent timeouts on failure cases. Using WSL in go tests is quite tricky, we can easily face deadlocks because of calls jumping threads (if done inside goroutines) or just because of seemingly excessive I/O. Under the hood WSL and WSLAPI relies on COM, so I'm not exactly sure on the limitations at the moment, reason why I preventively included a COM setup call in main_test when facing some strange deadlocks. The calls going via GoWSL should be more predictable now. Yet, you'll see some being replaced by subprocessing wsl.exe instead, in hopes that makes the test setup and execution more reliable. I'd like to revisit those eventually, to learn more about the true limitations of that API.

The main_test setup stage was cleared from assumptions of appx distros as well as of building the MSIX for testing. CI always did that, so there is no need to preserve such complex function. We can replicate the same steps CI does locally when running those tests locally anyway. Similarly, I moved the preparation of the golden image (with a build of wsl-pro-service from CI installed and configured for verbose logging) out of the main_test.go into CI, where it's more visible and hopefully that also helps with WSL contention, because between those commands preparing the image and actually running the tests we have a buffer of time of `go test` compilation.

When reworking the GH workflow, I replicated the get-wsl-image from wsl-setup, then I setup a manifest override and register it so `wsl --install -d Ubuntu-Preview` will install the golden image and  `wsl --install Ubuntu` will install the cached image.

This PR depends on #1620 and #1621 which contains bug fixes or reliability improvements that allow the end to end tests to run in GH runners as proposed here. 

Closes #1551 as well.

---
UDENG-7028