### PR TITLE
fix(windows-agent): Delivers tasks to newly connected WSL instances

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 use (
 	./agentapi

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/config"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewTLSCertificates(t *testing.T) {
@@ -45,6 +48,62 @@ func TestNewTLSCertificates(t *testing.T) {
 			}
 			require.NoError(t, err, "NewTLSCertificates failed")
 			require.NotEmpty(t, c, "NewTLSCertificates should have returned a non-empty value")
+		})
+	}
+}
+
+func TestNewInstanceHook(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		breakConfig bool
+		proToken    string
+		lcape       string
+		props       distro.Properties
+
+		wantErr   bool
+		taskCount int
+	}{
+		"Success":                       {proToken: "token", lcape: "[client]", taskCount: 2},
+		"Success with a pro token only": {proToken: "token", taskCount: 1},
+		"Success with no tasks":         {taskCount: 0},
+		"No tasks when the instance is already pro attached": {proToken: "token", props: distro.Properties{ProAttached: true}, wantErr: false, taskCount: 0},
+		"Error when the config cannot be loaded":             {breakConfig: true, wantErr: true},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Set up the config.
+			privateDir := t.TempDir()
+			fileData := struct {
+				Landscape    map[string]string
+				Subscription map[string]string
+			}{
+				Subscription: make(map[string]string),
+				Landscape:    make(map[string]string),
+			}
+			if tc.proToken != "" {
+				fileData.Subscription["user"] = tc.proToken
+			}
+			if tc.lcape != "" {
+				fileData.Landscape["config"] = tc.lcape
+			}
+			if tc.breakConfig {
+				require.NoError(t, os.MkdirAll(filepath.Join(privateDir, "config"), 0700), "Setup: could not write directory that should break config file")
+			} else {
+				b, err := yaml.Marshal(fileData)
+				require.NoError(t, err, "Setup: could not marshal config data")
+				require.NoError(t, os.WriteFile(filepath.Join(privateDir, "config"), b, 0600), "Setup: could not write config file")
+			}
+			ctx := t.Context()
+			conf := config.New(ctx, privateDir)
+			tsks, err := newInstanceTasks(conf, tc.props)
+			if tc.wantErr {
+				require.Error(t, err, "NewInstanceTasks should have failed")
+				return
+			}
+			require.NoError(t, err, "NewInstanceTasks failed")
+			require.Len(t, tsks, tc.taskCount, "NewInstanceTasks returned unexpected number of tasks")
 		})
 	}
 }

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -3,6 +3,7 @@ package proservices
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,12 +16,16 @@ import (
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/cloudinit"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/config"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/database"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/task"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/landscape"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/registrywatcher"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/ui"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/wslinstance"
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/tasks"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/ubuntupro"
 	"github.com/sirupsen/logrus"
+	"github.com/ubuntu/decorate"
 	wsl "github.com/ubuntu/gowsl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -110,8 +115,20 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 	}
 	s.landscapeService = landscape
 
-	s.wslInstanceService = wslinstance.New(ctx, s.db, s.landscapeService.Controller())
+	// When a new instance connects to the wslinstance service we'll greet it with some tasks.
+	onNewInstance := func(d *distro.Distro) {
+		// When a new instance connects to the wslinstance service we'll greet it with some tasks.
+		dtasks, err := newInstanceTasks(conf, d.Properties())
+		if len(dtasks) > 0 {
+			err = errors.Join(err, d.SubmitDeferredTasks(dtasks...))
+		}
+		if err != nil {
+			log.Warningf(ctx, "%v", err)
+			return
+		}
+	}
 
+	s.wslInstanceService = wslinstance.New(ctx, s.db, onNewInstance, s.landscapeService.Controller())
 	conf.SetUbuntuProNotifier(func(ctx context.Context, token string) {
 		ubuntupro.Distribute(ctx, s.db, token)
 		landscape.NotifyUbuntuProUpdate(ctx, token)
@@ -145,6 +162,25 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 
 	s.creds = credentials.NewTLS(certs.agentTLSConfig())
 	return s, nil
+}
+
+// newInstanceTasks returns the initial tasks to be executed when a new instance connects to the WSLInstance service.
+func newInstanceTasks(conf *config.Config, p distro.Properties) (t []task.Task, err error) {
+	defer decorate.OnError(&err, "when new instance %q connected to WSLInstance service", p.DistroID)
+
+	pro, source, err := conf.Subscription()
+	if err != nil {
+		return nil, err
+	}
+	// There is a Pro subscription bu tthe instance is not attached.
+	if pro != "" && source != config.SourceNone && !p.ProAttached {
+		t = append(t, tasks.ProAttachment{Token: pro})
+	}
+	l, source, err := conf.LandscapeClientConfig()
+	if err == nil && l != "" && source != config.SourceNone {
+		t = append(t, tasks.LandscapeConfigure{Config: l})
+	}
+	return t, err
 }
 
 // Stop deallocates resources in the services.

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -3,7 +3,6 @@ package proservices
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,9 +118,14 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 	onNewInstance := func(d *distro.Distro) {
 		// When a new instance connects to the wslinstance service we'll greet it with some tasks.
 		dtasks, err := newInstanceTasks(conf, d.Properties())
-		if len(dtasks) > 0 {
-			err = errors.Join(err, d.SubmitDeferredTasks(dtasks...))
+		if err != nil {
+			log.Warningf(ctx, "%v", err)
+			return
 		}
+		if len(dtasks) == 0 {
+			return
+		}
+		err = d.SubmitDeferredTasks(dtasks...)
 		if err != nil {
 			log.Warningf(ctx, "%v", err)
 			return

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -116,20 +116,17 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 
 	// When a new instance connects to the wslinstance service we'll greet it with some tasks.
 	onNewInstance := func(d *distro.Distro) {
+		props := d.Properties()
+		var e error
+		defer doOnError(&e, func(err error) {
+			log.Warningf(ctx, "Failed to deliver initial tasks for new instance %q: %v", props.DistroID, err)
+		})
 		// When a new instance connects to the wslinstance service we'll greet it with some tasks.
-		dtasks, err := newInstanceTasks(conf, d.Properties())
-		if err != nil {
-			log.Warningf(ctx, "%v", err)
+		dtasks, e := newInstanceTasks(conf, props)
+		if e != nil || len(dtasks) == 0 {
 			return
 		}
-		if len(dtasks) == 0 {
-			return
-		}
-		err = d.SubmitDeferredTasks(dtasks...)
-		if err != nil {
-			log.Warningf(ctx, "%v", err)
-			return
-		}
+		e = d.SubmitDeferredTasks(dtasks...)
 	}
 
 	s.wslInstanceService = wslinstance.New(ctx, s.db, onNewInstance, s.landscapeService.Controller())
@@ -233,4 +230,11 @@ func (m Manager) RegisterGRPCServices(ctx context.Context, isWslNetAvailable boo
 func InitWSLAPI() {
 	d := wsl.NewDistro(context.Background(), "Whatever")
 	_, _ = d.GetConfiguration()
+}
+
+// doOnError is a helper function to defer execution of a callback if the given error pointer is not nil.
+func doOnError(err *error, onError func(error)) {
+	if *err != nil {
+		onError(*err)
+	}
 }

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -176,7 +176,7 @@ func newInstanceTasks(conf *config.Config, p distro.Properties) (t []task.Task, 
 	if err != nil {
 		return nil, err
 	}
-	// There is a Pro subscription bu tthe instance is not attached.
+	// There is a Pro subscription but the instance is not attached.
 	if pro != "" && source != config.SourceNone && !p.ProAttached {
 		t = append(t, tasks.ProAttachment{Token: pro})
 	}

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -12,12 +12,16 @@ import (
 
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	grpclog "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/testutils"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/wsltestutils"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/consts"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/registrywatcher/registry"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	wsl "github.com/ubuntu/gowsl"
+	wslmock "github.com/ubuntu/gowsl/mock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -53,7 +57,7 @@ func TestNew(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			publicDir := t.TempDir()
 			privateDir := t.TempDir()
@@ -198,6 +202,141 @@ func TestRegisterGRPCServices(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "Clients should succeed in calling any RPC")
+		})
+	}
+}
+
+// TestOnNewInstanceCreatesTask verifies that when a distro connects to the WSLInstance
+// gRPC service for the first time, the onNewInstance hook registered by the proservices
+// Manager submits a ProAttachment task whose token matches the one stored in the registry.
+func TestOnNewInstanceCreatesTask(t *testing.T) {
+	if wsl.MockAvailable() {
+		t.Parallel()
+	}
+
+	testcases := map[string]struct {
+		alreadyAttached bool
+		wantCommands    bool
+	}{
+		"When the instance is not already attached, onNewInstance should submit a ProAttachment task": {wantCommands: true},
+		"When the instance is already attached, onNewInstance should not submit a ProAttachment task": {alreadyAttached: true},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+
+			if wsl.MockAvailable() {
+				ctx = wsl.WithMock(ctx, wslmock.New())
+				t.Parallel()
+			}
+
+			publicDir := t.TempDir()
+			privateDir := t.TempDir()
+
+			// Populate the registry with a Pro token *before* New() so that the registry watcher's
+			// initial read picks it up and the config contains the subscription when the distro connects.
+			reg := registry.NewMock()
+			k, err := reg.HKCUCreateKey("Software/Canonical/UbuntuPro")
+			require.NoError(t, err, "Setup: could not create Ubuntu Pro registry key")
+			defer reg.CloseKey(k)
+
+			const wantToken = "test-pro-token"
+			err = reg.WriteValue(k, "UbuntuProToken", wantToken, false)
+			require.NoError(t, err, "Setup: could not write UbuntuProToken to the registry mock")
+
+			s, err := proservices.New(ctx, publicDir, privateDir, proservices.WithRegistry(reg))
+			require.NoError(t, err, "Setup: New should return no error")
+			defer s.Stop(ctx)
+
+			server := s.RegisterGRPCServices(ctx, true)
+
+			var cfg net.ListenConfig
+			lis, err := cfg.Listen(ctx, "tcp", "localhost:0")
+			require.NoError(t, err, "Setup: could not create a listener")
+			defer lis.Close()
+
+			serverDone := make(chan struct{})
+			go func() {
+				defer close(serverDone)
+				_ = server.Serve(lis)
+			}()
+			defer func() {
+				server.Stop()
+				<-serverDone
+			}()
+
+			// Register a fake distro so the DB's Get/Create path succeeds (requires a real WSL entry).
+			distroName, _ := wsltestutils.RegisterDistro(t, ctx, false)
+
+			// Dial the gRPC server using TLS credentials identical to those used in TestRegisterGRPCServices.
+			creds := loadClientCertificates(t, filepath.Join(publicDir, common.CertificatesDir))
+			conn, err := grpc.NewClient(lis.Addr().String(),
+				grpc.WithTransportCredentials(creds),
+				grpc.WithStreamInterceptor(grpclog.StreamClientInterceptor(log.StandardLogger())),
+			)
+			require.NoError(t, err, "Setup: could not create a gRPC client connection")
+			defer conn.Close()
+			conn.Connect()
+
+			wslClient := agentapi.NewWSLInstanceClient(conn)
+
+			// Open all three streams that the server requires before making the connection "ready",
+			// effectively mocking the wsl-pro-service unit inside an instance.
+			connStream, err := wslClient.Connected(ctx)
+			require.NoError(t, err, "Setup: could not open Connected stream")
+
+			proStream, err := wslClient.ProAttachmentCommands(ctx)
+			require.NoError(t, err, "Setup: could not open ProAttachmentCommands stream")
+
+			lpeStream, err := wslClient.LandscapeConfigCommands(ctx)
+			require.NoError(t, err, "Setup: could not open LandscapeConfigCommands stream")
+
+			// Perform the handshakes. Order must match what the wslinstance server expects: first send
+			// DistroInfo on the Connected stream, then send the WSL name on the two command streams.
+			err = connStream.Send(&agentapi.DistroInfo{WslName: distroName, ProAttached: tc.alreadyAttached})
+			require.NoError(t, err, "Setup: could not send DistroInfo on Connected stream")
+
+			sendWslNameMsg := func(send func(*agentapi.MSG) error) {
+				t.Helper()
+				require.NoError(t, send(&agentapi.MSG{Data: &agentapi.MSG_WslName{WslName: distroName}}),
+					"Setup: could not send WSL name on command stream")
+			}
+			sendWslNameMsg(proStream.Send)
+			sendWslNameMsg(lpeStream.Send)
+
+			// The server sends a ProAttachCmd once all streams are ready and onNewInstance runs.
+			// Receive it with a generous timeout to avoid flakiness.
+			type recvResult struct {
+				cmd *agentapi.ProAttachCmd
+				err error
+			}
+			recvCh := make(chan recvResult, 1)
+			go func() {
+				cmd, err := proStream.Recv()
+				recvCh <- recvResult{cmd, err}
+			}()
+
+			const timeout = 20 * time.Second
+			select {
+			case result := <-recvCh:
+				if tc.wantCommands {
+					require.NoError(t, result.err, "ProAttachmentCommands stream should have received a command")
+					require.Equal(t, wantToken, result.cmd.GetToken(), "ProAttachCmd token should match the registry-provided token")
+				} else {
+					require.Error(t, result.err, "ProAttachmentCommands stream should not have received any commands")
+				}
+			case <-time.After(timeout):
+				if tc.wantCommands {
+					t.Fatal("timed out waiting for ProAttachCmd from the server")
+				}
+			}
+
+			if tc.wantCommands {
+				// Acknowledge the command so the server's SendProAttachment call completes cleanly.
+				require.NoError(t, proStream.Send(&agentapi.MSG{Data: &agentapi.MSG_Result{Result: ""}}),
+					"could not acknowledge ProAttachCmd")
+			}
 		})
 	}
 }

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -216,10 +216,12 @@ func TestOnNewInstanceCreatesTask(t *testing.T) {
 
 	testcases := map[string]struct {
 		alreadyAttached bool
+		breakConfig     bool
 		wantCommands    bool
 	}{
 		"When the instance is not already attached, onNewInstance should submit a ProAttachment task": {wantCommands: true},
 		"When the instance is already attached, onNewInstance should not submit a ProAttachment task": {alreadyAttached: true},
+		"When the subscription cannot be retrieved":                                                   {breakConfig: true},
 	}
 
 	for name, tc := range testcases {
@@ -241,13 +243,19 @@ func TestOnNewInstanceCreatesTask(t *testing.T) {
 			require.NoError(t, err, "Setup: could not create Ubuntu Pro registry key")
 			defer reg.CloseKey(k)
 
-			const wantToken = "test-pro-token"
-			err = reg.WriteValue(k, "UbuntuProToken", wantToken, false)
-			require.NoError(t, err, "Setup: could not write UbuntuProToken to the registry mock")
-
 			s, err := proservices.New(ctx, publicDir, privateDir, proservices.WithRegistry(reg))
 			require.NoError(t, err, "Setup: New should return no error")
 			defer s.Stop(ctx)
+
+			const wantToken = "test-pro-token"
+			if tc.breakConfig {
+				path := filepath.Join(privateDir, "config")
+				require.NoError(t, os.Remove(path), "Setup: could not remove the config file")
+				require.NoError(t, os.Mkdir(path, 0640), "Setup: could not break the config file")
+			} else {
+				err = reg.WriteValue(k, "UbuntuProToken", wantToken, false)
+				require.NoError(t, err, "Setup: could not write UbuntuProToken to the registry mock")
+			}
 
 			server := s.RegisterGRPCServices(ctx, true)
 

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -336,14 +336,14 @@ func TestOnNewInstanceCreatesTask(t *testing.T) {
 				}
 			case <-time.After(timeout):
 				if tc.wantCommands {
-					t.Fatal("timed out waiting for ProAttachCmd from the server")
+					t.Fatal("Timed out waiting for ProAttachCmd from the server")
 				}
 			}
 
 			if tc.wantCommands {
 				// Acknowledge the command so the server's SendProAttachment call completes cleanly.
 				require.NoError(t, proStream.Send(&agentapi.MSG{Data: &agentapi.MSG_Result{Result: ""}}),
-					"could not acknowledge ProAttachCmd")
+					"Could not acknowledge ProAttachCmd")
 			}
 		})
 	}

--- a/windows-agent/internal/proservices/wslinstance/wslinstance.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance.go
@@ -20,24 +20,32 @@ type LandscapeController interface {
 	SendUpdatedInfo(context.Context) error
 }
 
+// NewInstanceFunc is a callback type for when a new instance connects. It receives the distro that just connected.
+type NewInstanceFunc func(*distro.Distro)
+
 // Service is the WSL Instance GRPC service implementation.
 type Service struct {
 	agentapi.UnimplementedWSLInstanceServer
 
-	db        *database.DistroDB
-	landscape LandscapeController
+	db            *database.DistroDB
+	onNewInstance NewInstanceFunc
+	landscape     LandscapeController
 
 	clients   map[string]*client
 	clientsMu sync.Mutex
 }
 
 // New returns a new service handling WSL Instance API.
-func New(ctx context.Context, db *database.DistroDB, landscape LandscapeController) (s *Service) {
+func New(ctx context.Context, db *database.DistroDB, onNew NewInstanceFunc, landscape LandscapeController) (s *Service) {
 	log.Debug(ctx, "Building new GRPC WSLInstance server")
+	if onNew == nil {
+		onNew = func(*distro.Distro) {}
+	}
 	return &Service{
-		db:        db,
-		landscape: landscape,
-		clients:   make(map[string]*client),
+		db:            db,
+		onNewInstance: onNew,
+		landscape:     landscape,
+		clients:       make(map[string]*client),
 	}
 }
 
@@ -75,6 +83,8 @@ func (s *Service) Connected(stream agentapi.WSLInstance_ConnectedServer) (err er
 		return err
 	}
 
+	// Notify about the new instance connected.
+	s.onNewInstance(d)
 	// Load deferred tasks
 	d.EnqueueDeferredTasks()
 

--- a/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
+++ b/windows-agent/internal/proservices/wslinstance/wslinstance_test.go
@@ -80,7 +80,7 @@ func TestServe(t *testing.T) {
 
 			landscape := &landscapeCtlMock{}
 
-			service := wslinstance.New(ctx, db, landscape)
+			service := wslinstance.New(ctx, db, nil, landscape)
 			server := grpc.NewServer()
 			agentapi.RegisterWSLInstanceServer(server, service)
 
@@ -209,7 +209,7 @@ func TestSendCommands(t *testing.T) {
 
 	landscape := &landscapeCtlMock{}
 
-	service := wslinstance.New(ctx, db, landscape)
+	service := wslinstance.New(ctx, db, nil, landscape)
 	server := grpc.NewServer()
 	agentapi.RegisterWSLInstanceServer(server, service)
 

--- a/windows-agent/internal/ubuntupro/ubuntupro.go
+++ b/windows-agent/internal/ubuntupro/ubuntupro.go
@@ -22,7 +22,9 @@ func Distribute(ctx context.Context, db *database.DistroDB, ubuntuProToken strin
 	}
 
 	var err error
-	for _, distro := range db.GetAll() {
+	instances := db.GetAll()
+	log.Debugf(ctx, "Distributing Ubuntu Pro token to %d distros", len(instances))
+	for _, distro := range instances {
 		err = errors.Join(err, distro.SubmitTasks(task))
 	}
 


### PR DESCRIPTION
There is a possibility of Pro being configured after a WSL instance being registered but before it connects to the Windows agent's wslinstance gRPC service. When the connection happens the current implementation just assumes the instance was provisioned after the configuration, thus it does nothing about the instance.

I'm changing it to conditionally send tasks to that instance instead. Also, implementing a test to ensure we deliver tasks to new instances connecting to the agent if they are not already pro attached.

A nice side effect is that if for some reason (a naughty user?) an existing instance assumed to be pro-attached loose that state, it should be recovered on the next reconnection to the Windows agent.

This is a spin off of the PR #1614 - I found this bug while working on that task.