### PR TITLE
feat(wsl-pro-service): Hack systemd to read WSL2_DISTRO_NAME from PID 2

### DIFF
--- a/wsl-pro-service/internal/streams/server.go
+++ b/wsl-pro-service/internal/streams/server.go
@@ -130,6 +130,7 @@ func (s *Server) Serve(service CommandService) error {
 	if err != nil {
 		return NewSystemError("could not serve: %v", err)
 	}
+	log.Debugf(s.ctx, "Server: sending preface messages from instance %s", info.GetWslName())
 
 	if err := client.SendInfo(info); err != nil {
 		return fmt.Errorf("could not serve: could not send first Connnected message: %v", err)

--- a/wsl-pro-service/internal/system/backend.go
+++ b/wsl-pro-service/internal/system/backend.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 )
 
 type realBackend struct{}
@@ -21,7 +22,11 @@ func (b realBackend) Hostname() (string, error) {
 
 // GetenvWslDistroName obtains the value of environment variable WSL_DISTRO_NAME.
 func (b realBackend) GetenvWslDistroName() string {
-	return os.Getenv("WSL_DISTRO_NAME")
+	name := os.Getenv("WSL_DISTRO_NAME")
+	if strings.TrimSpace(name) != "" {
+		return name
+	}
+	return os.Getenv("WSL2_DISTRO_NAME")
 }
 
 // ProExecutable returns the full command to run the pro executable with the provided arguments.

--- a/wsl-pro-service/internal/system/system.go
+++ b/wsl-pro-service/internal/system/system.go
@@ -155,7 +155,7 @@ func (s *System) WslDistroName(ctx context.Context) (name string, err error) {
 		return env, nil
 	}
 
-	cmd := s.backend.WslpathExecutable(ctx, "-w", "/")
+	cmd := s.backend.WslpathExecutable(ctx, "-wa", "/")
 	out, err := runCommand(cmd)
 	if err != nil {
 		return "", fmt.Errorf("could not get distro root path: %v. Output: %s", err, string(out))
@@ -166,6 +166,9 @@ func (s *System) WslDistroName(ctx context.Context) (name string, err error) {
 	fields := strings.Split(string(out), `\`)
 	if len(fields) < 4 {
 		return "", fmt.Errorf("could not parse distro name from path %q", out)
+	}
+	if fields[3] == "" {
+		return "", fmt.Errorf("parsed distro name is empty from wslpath output %q", out)
 	}
 
 	s.wslDistroNameCache = fields[3]

--- a/wsl-pro-service/internal/system/system_test.go
+++ b/wsl-pro-service/internal/system/system_test.go
@@ -22,9 +22,10 @@ import (
 type mockBehaviour int
 
 const (
-	mockOK        mockBehaviour = iota // A mock that mimicks the happy path
-	mockError                          // A mock that returns an error
-	mockBadOutput                      // A mock that returns a bad value with no error
+	mockOK               mockBehaviour = iota // A mock that mimicks the happy path
+	mockError                                 // A mock that returns an error
+	mockBadOutput                             // A mock that returns a bad value with no error
+	mockIncompleteOutput                      // A mock that returns an incomplete value with no error (used for testing parsing errors due to missing fields)
 )
 
 func TestNew(t *testing.T) {
@@ -159,8 +160,9 @@ func TestWslDistroName(t *testing.T) {
 		"Success reading from WSL_DISTRO_NAME": {},
 		"Success using wslpath":                {distroNameEnvDisabled: true},
 
-		"Error when WSL_DISTRO_NAME is empty and wslpath fails":            {distroNameEnvDisabled: true, distroNameWslPath: mockError, wantErr: true},
-		"Error when WSL_DISTRO_NAME is empty and wslpath returns bad text": {distroNameEnvDisabled: true, distroNameWslPath: mockBadOutput, wantErr: true},
+		"Error when WSL_DISTRO_NAME is empty and wslpath fails":                   {distroNameEnvDisabled: true, distroNameWslPath: mockError, wantErr: true},
+		"Error when WSL_DISTRO_NAME is empty and wslpath returns bad text":        {distroNameEnvDisabled: true, distroNameWslPath: mockBadOutput, wantErr: true},
+		"Error when WSL_DISTRO_NAME is empty and wslpath returns incomplete text": {distroNameEnvDisabled: true, distroNameWslPath: mockIncompleteOutput, wantErr: true},
 	}
 
 	for name, tc := range testCases {
@@ -180,6 +182,8 @@ func TestWslDistroName(t *testing.T) {
 				mock.SetControlArg(testutils.WslpathErr)
 			case mockBadOutput:
 				mock.SetControlArg(testutils.WslpathBadOutput)
+			case mockIncompleteOutput:
+				mock.SetControlArg(testutils.WslpathIncompleteOutput)
 			default:
 				require.Fail(t, "Unknown enum value for distroNameWslPath", "Value: %d", tc.distroNameWslPath)
 			}

--- a/wsl-pro-service/internal/testutils/mock_executables.go
+++ b/wsl-pro-service/internal/testutils/mock_executables.go
@@ -90,9 +90,10 @@ const (
 	LandscapeEnableErr  = "UP4W_LANDSCAPE_ENABLE_ERR"
 	LandscapeDisableErr = "UP4W_LANDSCAPE_DISABLE_ERR"
 
-	WslpathErr             = "UP4W_WSLPATH_ERR"
-	WslpathBadOutput       = "UP4W_WSLPATH_BAD_OUTPUT"
-	EmptyUserprofileEnvVar = "UP4W_EMPTY_USERPROFILE_ENV_VAR"
+	WslpathErr              = "UP4W_WSLPATH_ERR"
+	WslpathBadOutput        = "UP4W_WSLPATH_BAD_OUTPUT"
+	WslpathIncompleteOutput = "UP4W_WSLPATH_INCOMPLETE_OUTPUT"
+	EmptyUserprofileEnvVar  = "UP4W_EMPTY_USERPROFILE_ENV_VAR"
 
 	CmdExeErr         = "UP4W_CMDEXE_ERR"
 	CmdExeEncodingErr = "UP4W_CMD_ENCODING_ERR"
@@ -506,6 +507,11 @@ func WslPathMock(t *testing.T) {
 
 			if envExists(WslpathBadOutput) {
 				fmt.Fprintf(os.Stdout, "Bad output\r\nBad\toutput\r\n")
+				return exitOk
+			}
+
+			if envExists(WslpathIncompleteOutput) {
+				fmt.Fprint(os.Stdout, "\\\\wsl.localhost\\\n")
 				return exitOk
 			}
 

--- a/wsl-pro-service/services/wsl-pro.service
+++ b/wsl-pro-service/services/wsl-pro.service
@@ -5,6 +5,8 @@ ConditionVirtualization=wsl
 [Service]
 Type=notify
 NotifyAccess=all
+ExecStartPre=-/usr/bin/bash -c 'grep -z "WSL2_DISTRO_NAME" /proc/2/environ | tr "\\0" "\\n" > /run/wsl_distro.env'
+EnvironmentFile=-/run/wsl_distro.env
 ExecStart=/usr/libexec/wsl-pro-service
 Restart=always
 RestartSec=20min


### PR DESCRIPTION
Logs like those should be impossible, but CI showed some:

```
Apr 02 18:22:37 runnervm3zftq wsl-pro-service[178]: DEBUG
github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/streams/server.go:146
(*Server).Serve() Server: sent preface messages to all streams
Apr 02 18:22:37 runnervm3zftq wsl-pro-service[178]: DEBUG
D:/a/ubuntu-pro-for-wsl/ubuntu-pro-for-wsl/common/grpc/logconnections/logconnections.go:62
loggedServerStream.RecvMsg() Requesting with parameters: Data:
0x36305e994d50
Apr 02 18:22:37 runnervm3zftq wsl-pro-service[178]: WARNING
github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/daemon/daemon.go:194
(*Daemon).serveOnce() Daemon: disconnected from Windows host: serve
error: could not receive ProAttachCmd: rpc error: code = Unknown desc =
WslInstance: could not handle landscape config commands: could not
complete handshake: no WSL name received
Apr 02 18:22:37 runnervm3zftq wsl-pro-service[178]: INFO
github.com/canonical/ubuntu-pro-for-wsl/wsl-pro-service/internal/daemon/daemon.go:144
(*Daemon).Serve.func2() Reconnecting to Windows host in 60 seconds
```
We already expect that systemd units can't find the environment variable WSL_DISTRO_NAME, reason why we leverage `wslpath -w /` to compute the instance name. It's surprising to see that command output `\\wsl.localhos\` without the distro name. That is an internal failure to WSL, an IPC that returns an empty string instead of the instance name.

To make wsl-pro-service more resilient to that problem and surface it better in case it happens, here we're modifying logs to allow inspecting the instance name from within wsl-pro-service and we also add a check for empty WSL Distro Name.

Finally, because PID 2 is guaranteed to be the forked /init which has the original environment variables set by the host, while PID 1, the original /init cleared out its environment just before executing systemd, we hack systemd to inspect the environment of PID 2 to extract the environment variable `WSL2_DISTRO_NAME`. Thus if we're running without systemd, we can read WSL_DISTRO_NAME, otherwise we can rely on systemd to tell us the value of WSL2_DISTRO_NAME from PID 2. If the permission model changes and prevents systemd from reading that value, at least the unit won't fail to launch because both `ExecStartPre` and `EnvironmentFile` values are prefixed with  a dash (`-`) making them "optional" to the service startup.

This is a spin off of PR #1614 - I noticed this behaviour in CI runs like https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/24078970002/job/70236059578?pr=1614#step:9:367, where the agent doesn't receive the WSL instance name when the new instance connects, because the instance itself didn't get the name, although it didn't notice because the underlying calls didn't fail, just resulted in empty strings.