### PR TITLE
docs: rename Landscape dashboard to web portal

### DIFF
--- a/docs/explanation/pro-explanation.md
+++ b/docs/explanation/pro-explanation.md
@@ -72,7 +72,7 @@ attached, the application can be used to [configure
 Landscape](../howto/set-up-landscape-client.md).
 
 If you are using Landscape SaaS, the configuration is as simple as supplying
-the account name for the {term}`Landscape dashboard`.
+the account name for the {term}`Landscape web portal`.
 
 With Landscape configured, a central administrator can create {term}`WSL profiles <WSL profile>` on
 Landscape that can then be used to [remotely deploy instances](tut::deploy)

--- a/docs/howto/custom-rootfs-multiple-targets.md
+++ b/docs/howto/custom-rootfs-multiple-targets.md
@@ -89,7 +89,7 @@ $CLOUD_INIT_FILE="~\Downloads\init.yaml"
 
 The `PARENT_COMPUTER_IDS` environment variable contains a list of IDs internally assigned to
 Windows machines already registered to Landscape. The values used in this guide are examples,
-and you can get IDs for your machines in the Landscape dashboard or through the
+and you can get IDs for your machines in the Landscape web portal or through the
 Landscape REST API.
 ```
 
@@ -259,7 +259,7 @@ foreach ($COMPUTER_ID in $PARENT_COMPUTER_IDS) {
 `````
 
 When that completes, you'll be able to find activities in the Landscape
-dashboard about the installation of a new WSL instance for each of the Windows
+web portal about the installation of a new WSL instance for each of the Windows
 machines listed.
 
 ## Summarising the steps in a single script

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -38,7 +38,7 @@ instance
 
 instance (disambiguation)
     In the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/wsl/),
-    "distribution" is used to refer to an instance. In the Landscape dashboard,
+    "distribution" is used to refer to an instance. In the Landscape web portal,
     "instance" also refers to a Windows machine that runs WSL.
 
     Related topic(s): {term}`instance`, {term}`distro`, {term}`Landscape`
@@ -48,7 +48,7 @@ Landscape
     website](https://ubuntu.com/landscape) and [Landscape
     documentation](https://documentation.ubuntu.com/landscape/).
 
-    Related topic(s): {term}`Landscape client`, {term}`Landscape dashboard`, {term}`Landscape server`
+    Related topic(s): {term}`Landscape client`, {term}`Landscape web portal`, {term}`Landscape server`
 
 Landscape client
     A systemd unit running inside every instance of Ubuntu on WSL. The
@@ -58,7 +58,7 @@ Landscape client
 
     Related topic(s): {term}`Landscape`, {term}`Landscape server`, {term}`Ubuntu`, {term}`WSL`
 
-Landscape dashboard
+Landscape web portal
     A browser-based GUI interface for Landscape where WSL instances can be
     managed.
 
@@ -205,7 +205,7 @@ WSL profile
     A set of configurations defined in Landscape for deploying pre-configured
     WSL instances.
 
-    Related topic(s): {term}`Landscape`, {term}`Landscape dashboard`
+    Related topic(s): {term}`Landscape`, {term}`Landscape web portal`
 
 WSL version
     WSL is available in two versions: WSL 1 and WSL 2. WSL 2 is the latest,

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -80,7 +80,7 @@ Instructions for restoring the backup can be found at the end of the tutorial.
 
 ### A Landscape server must be set up and available
 
-You need a {term}`Landscape server` set up and access to the Landscape dashboard in a browser.
+You need a {term}`Landscape server` set up and access to the Landscape web portal in a browser.
 
 [Landscape SaaS edition](https://documentation.ubuntu.com/landscape/what-is-landscape/#editions-of-landscape)
 is bundled with your Pro subscription and can be set up as follows:
@@ -103,7 +103,7 @@ If you choose Manual configuration, you only require the FQDN of your Landscape 
 
 ```{note}
 If you are using Landscape SaaS, enter `landscape.canonical.com` for the FQDN
-and the account name from your Landscape dashboard.
+and the account name from the Landscape web portal.
 ```
 
 When you continue, a status screen will confirm that your configuration is complete.
@@ -114,12 +114,12 @@ When you continue, a status screen will confirm that your configuration is compl
 
 ```{admonition} Usage of the term "instance"
 :class: warning
-In the Landscape dashboard, an "instance" refers to the Windows host running WSL.
+In the Landscape web portal, an "instance" refers to the Windows host running WSL.
 
 In this documentation, we often use "instance" to refer to instances of WSL running on the Windows host.
 ```
 
-Refresh the Landscape dashboard.
+Refresh the Landscape web portal.
 
 Go to {guilabel}`Instances`, and review the pending instances.
 
@@ -135,7 +135,7 @@ Select the Windows host and assign it the tag "wsl-target".
 WSL profiles on Landscape enable the deployment of custom Ubuntu instances to
 your Windows machine.
 
-Go to **Profiles > WSL profiles** in the dashboard and add a WSL profile.
+Go to **Profiles > WSL profiles** in the web portal and add a WSL profile.
 
 Complete the fields as follows:
 


### PR DESCRIPTION
Updates language to match Landscape's current convention.

Closes: https://github.com/canonical/ubuntu-pro-for-wsl/issues/1637

UDENG-10445