### PR TITLE
fix(CI): Avoid publishing on docs-specific tags

### DIFF
--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -5,7 +5,7 @@ on:
   push:
     tags:
       - '**'
-      - '!docs/**'
+      - '!*.post[0-9]+' # Reserved for documentation-only releases.
       - '!wsl-pro-service/**'
 jobs:
   publish-msix:


### PR DESCRIPTION
We reserve post-release semver tags for docs-only updates, as RTD doesn't support prefixed tags like `docs/1.2.3`. The latest version of the docs website was built on tag `1.0.6.post1`, proving it works. So CI must not trigger for such pattern.

---

UDENG-10622