### PR TITLE
docs: structure streamlining

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,11 +229,13 @@ redirects = {
     # deprecated tutorials
     "tutorials/dotnet-systemd": "../../",
     "tutorials/interop": "../../",
-    # tutorials that have since been converted to howto guides
+    # renamed tutorials
+    "tutorials/vscode": "../../tutorials/develop-with-ubuntu-wsl",
+    # tutorials that have converted to howto guides
     "tutorials/cloud-init": "../../howto/cloud-init",
     "tutorials/data-science-and-engineering": "../../howto/data-science-and-engineering",
     "tutorials/gpu-cuda": "../../howto/gpu-cuda",
-    "tutorials/vscode": "../../tutorials/develop-with-ubuntu-wsl",
+    "tutorials/deployment": "../../howto/deploy-with-landscape-web-portal",
     # change in diataxis names
     "guides/": "../../howto/",
     "guides/contributing": "../../howto/contributing",

--- a/docs/explanation/compare-wsl-versions.md
+++ b/docs/explanation/compare-wsl-versions.md
@@ -41,9 +41,9 @@ The differences between WSL 1 and WSL 2 and how it affects Ubuntu can be summari
 | Graphical application support                                         |    {bdg-danger}`No`    | {bdg-success}`Yes` |
 | [Snap](https://snapcraft.io/) support                                 |    {bdg-danger}`No`    | {bdg-success}`Yes` |
 | [cloud-init](https://cloud-init.io/) support                          |    {bdg-danger}`No`    | {bdg-success}`Yes` |
-| [Ubuntu Pro for WSL](../tutorials/getting-started-with-up4w/) support |    {bdg-danger}`No`    | {bdg-success}`Yes` |
-| [Landscape]({term}`Landscape client`) support                            |    {bdg-danger}`No`    | {bdg-success}`Yes` |
-| [Ubuntu Pro Client]({term}`Ubuntu Pro client`) support                   | {bdg-warning}`Partial` | {bdg-success}`Yes` |
+| {term}`Ubuntu Pro for WSL` support                                    |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| {term}`Landscape client` support                                      |    {bdg-danger}`No`    | {bdg-success}`Yes` |
+| {term}`Ubuntu Pro client` support                                     | {bdg-warning}`Partial` | {bdg-success}`Yes` |
 
 ### How this affects Ubuntu for WSL
 
@@ -53,7 +53,7 @@ While Ubuntu works on WSL 1, the experience may be degraded relative to WSL 2. T
 
 ### How this affects Ubuntu Pro for WSL
 
-[Pro for WSL](../tutorials/getting-started-with-up4w/) relies on systemd for much of its functionality, including automatic Pro attachment, so it does not support WSL 1. For the same reason, the [{term}`Landscape client`] tool for remote management of Ubuntu instances is also not supported on WSL 1. You can still manually attach your WSL 1 instance to [Ubuntu Pro](https://documentation.ubuntu.com/pro/) using the [{term}`Ubuntu Pro client`], although some of Ubuntu Pro's features may not work on WSL 1.
+{term}`Pro for WSL` relies on systemd for much of its functionality, including automatic Pro attachment, so it does not support WSL 1. For the same reason, the {term}`Landscape client` tool for remote management of Ubuntu instances is also not supported on WSL 1. You can still manually attach your WSL 1 instance to [Ubuntu Pro](https://documentation.ubuntu.com/pro/) using the {term}`Ubuntu Pro client`, although some of Ubuntu Pro's features may not work on WSL 1.
 
 ### Switching WSL versions
 

--- a/docs/explanation/security-overview.md
+++ b/docs/explanation/security-overview.md
@@ -198,7 +198,7 @@ application.
 This is most relevant for deployment scenarios in which multiple Windows hosts
 are being managed centrally, using software like Landscape or Intune.
 
-> [Get started with Ubuntu Pro for WSL](howto::up4w)
+> [Get started with Ubuntu Pro for WSL](tut::up4w)
 
 ### Firewall configuration
 

--- a/docs/howto/custom-rootfs-multiple-targets.md
+++ b/docs/howto/custom-rootfs-multiple-targets.md
@@ -5,6 +5,7 @@ myst:
       "Scale up your deployment of a custom rootfs using Ubuntu Pro for WSL's Landscape integration."
 ---
 
+(howto::landscape-api)=
 # Deploy a custom rootfs to multiple Windows machines with Ubuntu Pro for WSL and the Landscape API
 
 ```{include} ../includes/pro_content_notice.txt

--- a/docs/howto/deploy-with-landscape-web-portal.md
+++ b/docs/howto/deploy-with-landscape-web-portal.md
@@ -14,16 +14,13 @@ myst:
     :end-before: <!-- Include end pro -->
 ```
 
-In this tutorial you will learn how Ubuntu Pro for WSL can help you
-deploy Ubuntu to remote Windows machines using {term}`Landscape`.
+This guide shows you how to use Ubuntu Pro for WSL and Landscape
+to deploy Ubuntu to remote Windows machines using {term}`Landscape`.
 
-## What you will do
+It uses the Landscape web portal for deployment. If you want to know about
+using the Landscape API, we have a [guide](howto::landscape-api) for that too.
 
-- Register a Windows host instance with Landscape
-- Create a custom {term}`WSL profile` on Landscape
-- Deploy Ubuntu with the custom profile to a remote Windows machine
-
-## What you need
+## Prerequisites
 
 * Windows 11 (recommended) or Windows 10 with minimum version 21H2 on a physical machine
 * A minimum of 16GB RAM and 8-core processor
@@ -33,13 +30,13 @@ deploy Ubuntu to remote Windows machines using {term}`Landscape`.
 
 ```{tip}
 It is recommended that you complete the [getting
-started](./getting-started-with-up4w.md) tutorial to familiarise yourself with
+started](tut::up4w) tutorial to familiarise yourself with
 installation and configuration of the Pro for WSL app.
 ```
 
 ### WSL must be installed and configured
 
-You need WSL installed and configured to follow this tutorial.
+You need WSL installed and configured to follow this guide.
 
 Installation instructions are provided in the [official Microsoft
 documentation](https://learn.microsoft.com/en-us/windows/wsl/install).
@@ -48,8 +45,8 @@ documentation](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 You will be remotely deploying Ubuntu-24.04 on a Windows machine using Landscape.
 
-Uninstall any pre-existing instance of Ubuntu-24.04 on the machine before you
-start the tutorial.
+Uninstall any pre-existing instance of Ubuntu-24.04 on the machine before
+following the guide.
 
 To check if an Ubuntu-24.04 instance exists, run the following in PowerShell:
 
@@ -74,7 +71,7 @@ If you have an existing Ubuntu-24.04 instance, run the following commands:
 This stops any running instance of Ubuntu-24.04, creates a backup folder,
 generates a compressed backup of the distro, and uninstalls the instance.
 
-Instructions for restoring the backup can be found at the end of the tutorial.
+Instructions for restoring the backup can be found at the end of the guide.
 
 ````
 

--- a/docs/howto/index-remote-deployment.md
+++ b/docs/howto/index-remote-deployment.md
@@ -2,29 +2,54 @@
 
 # Remote deployment
 
+A key feature of Pro for WSL is that it enables deployment and management
+of WSL instances. For example, an administrator in an organization can remotely
+deploy custom Ubuntu configurations and images on multiple Windows machines,
+using tools like Landscape and Intune.
+
 These guides help you deploy and manage WSL instances using Ubuntu Pro for WSL
-with remote management tools.
+with remote management tools. They are not intended to reflect full production
+deployments but provide guidance on key steps, which can be adapted to your
+specific production environments.
 
 ## Landscape
 
-Manage Ubuntu on WSL with Landscape from Canonical.
+Landscape is a systems adminstration tool from Canonical. Pro for WSL supports
+Landscape natively and a Lanscape client is installed in each Ubuntu instance.
+The guides below show you how to configure the Landscape client, and deploy WSL
+using the Landscape web portal or API.
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
-Configure the Landscape client with Ubuntu Pro for WSL <set-up-landscape-client>
-Create WSL instances on multiple Windows machines with the Landscape API <custom-rootfs-multiple-targets>
+Deploy Ubuntu instances with the Landscape web portal <deploy-with-landscape-web-portal>
+Deploy instances with the Landscape API <custom-rootfs-multiple-targets>
+Configure the Landscape client with the Pro app <set-up-landscape-client>
 ```
 
 ## Intune
 
-Manage Ubuntu on WSL with Microsoft's Intune.
+Intune is a cloud-based endpoint management tool from Microsoft. The guides
+below are focused on helping Intune administrators ensure that that the Ubuntu
+Pro for WSL's background agent is operating on remote Windows machines.
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
-Enforce the Ubuntu Pro for WSL background agent startup remotely using the Windows Registry <enforce-agent-startup-remotely-registry>
-Start the Ubuntu Pro for WSL background agent remotely <start-agent-remotely>
+Enforce the Pro agent startup remotely using the Windows Registry <enforce-agent-startup-remotely-registry>
+Start the Pro agent remotely with Intune <start-agent-remotely>
+```
+
+## Custom images
+
+It may be necessary to customize an Ubuntu image before deploying it within an organization.
+The following step-by-step guide shows you how to customize an Ubuntu image for WSL.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Customize an Ubuntu image for WSL <custom-ubuntu-distro>
 ```

--- a/docs/howto/index-remote-deployment.md
+++ b/docs/howto/index-remote-deployment.md
@@ -14,8 +14,8 @@ specific production environments.
 
 ## Landscape
 
-Landscape is a systems adminstration tool from Canonical. Pro for WSL supports
-Landscape natively and a Lanscape client is installed in each Ubuntu instance.
+Landscape is a systems administration tool from Canonical. Pro for WSL supports
+Landscape natively and a Landscape client is installed in each Ubuntu instance.
 The guides below show you how to configure the Landscape client, and deploy WSL
 using the Landscape web portal or API.
 

--- a/docs/howto/index-setup.md
+++ b/docs/howto/index-setup.md
@@ -15,9 +15,8 @@ Run a full Ubuntu development environment on Windows.
 
 Install Ubuntu on WSL <install-ubuntu-wsl2>
 Upgrade Ubuntu <upgrade-ubuntu>
-Manage and configure instances of Ubuntu on WSL <manage-and-configure>
-Automatic setup of Ubuntu on WSL with cloud-init <cloud-init>
-Customise an Ubuntu distro for WSL <custom-ubuntu-distro>
+Manage and configure Ubuntu instances <manage-and-configure>
+Automatic setup of Ubuntu with cloud-init <cloud-init>
 ```
 
 ## The Ubuntu Pro for WSL application
@@ -30,6 +29,6 @@ Secure and manage Ubuntu on WSL with an Ubuntu Pro subscription.
 
 Install Ubuntu Pro for WSL and add a Pro token <set-up-up4w>
 Verify Pro subscription and attachment <verify-subscribe-attach>
-Uninstalling Ubuntu Pro for WSL, Ubuntu WSL apps and WSL <uninstalling>
+Uninstall Pro for WSL, Ubuntu distros, and WSL <uninstalling>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,10 @@ developers to run a GNU/Linux environment on Windows. The Ubuntu distribution
 for WSL is tightly integrated with the Windows OS, supporting features
 including remote development with popular IDEs and cross-OS file management.
 
-[Ubuntu Pro for WSL](./explanation/pro-explanation) is an automation tool for managing
-instances of Ubuntu on WSL. If you are responsible for a fleet of Windows
-devices, Pro for WSL will help you to monitor, customise and secure WSL at scale.
+[Ubuntu Pro for WSL](./explanation/pro-explanation) is a tool for managing
+Ubuntu on WSL. It enables automatic attachment of your Pro subscription
+to Ubuntu instances, and remote deployment with Landscape. If you are responsible for a fleet of Windows
+devices, Pro for WSL helps you monitor, customize, and secure WSL at scale.
 
 Ubuntu on WSL provides a fully-featured Ubuntu experience on Windows, suitable
 for learning Linux, developing a personal open-source project or building for
@@ -36,7 +37,7 @@ production in an enterprise environment.
 
 This documentation uses the [Diátaxis structure](https://diataxis.fr/).
 
-* [Tutorials](/tutorials/index) take you through practical, end-to-end learning experiences.
+* [Tutorials](/tutorials/index) take you through practical, end-to-end learning experiences for WSL and Pro.
 * [How-to guides](/howto/index) provide you with the steps necessary for completing specific tasks.
 * [References](/reference/index) give you concise and factual information to support your understanding.
 * [Explanations](/explanation/index) include topic overviews and additional context on the software.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ production in an enterprise environment.
 
 |                    |                                                                     |
 |--------------------|---------------------------------------------------------------------|
-|**Get started** | [Set up an development environment on Windows with Ubuntu on WSL](/tutorials/develop-with-ubuntu-wsl/) |
+|**Get started** | [Set up a development environment on Windows with Ubuntu on WSL](/tutorials/develop-with-ubuntu-wsl/) |
 |**Install Ubuntu** | [Install Ubuntu on WSL](/howto/install-ubuntu-wsl2.md) • [Available releases](/reference/distributions/) • [Upgrade your installation](/howto/upgrade-ubuntu) |
 |**Configuration** | [Instance configuration methods](/reference/instance_configuration/) • [Automate configuration with cloud-init](/howto/cloud-init/) |
 |**Security** | [Enable Pro](/howto/set-up-up4w) • [Security overview](/explanation/security-overview/) • [Firewall requirements](/reference/firewall_requirements/) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ to Ubuntu instances, and remote deployment with Landscape. If you are responsibl
 devices, Pro for WSL helps you monitor, customize, and secure WSL at scale.
 
 Ubuntu on WSL provides a fully-featured Ubuntu experience on Windows, suitable
-for learning Linux, developing a personal open-source project or building for
+for learning Linux, developing a personal open-source project, or building for
 production in an enterprise environment.
 
 ## In this documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Thinking about using Ubuntu on WSL for your next project? Get in touch!
 :hidden:
 :titlesonly:
 
-Ubuntu on WSL <self>
+Home <self>
 Tutorials </tutorials/index>
 How-to guides </howto/index>
 Reference </reference/index>

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,13 +22,15 @@ production in an enterprise environment.
 
 ## In this documentation
 
-* **Getting started**: [Setting up a development environment from scratch with Ubuntu on WSL](/tutorials/develop-with-ubuntu-wsl/)
-* **Installation and setup**: [Install Ubuntu on WSL](/howto/install-ubuntu-wsl2.md) • [Distro release reference](/reference/distributions/) • [Upgrade Ubuntu](/howto/upgrade-ubuntu) • [Install Pro for WSL](/howto/set-up-up4w)
-* **WSL for enterprise:** [What is Pro for WSL?](./explanation/pro-explanation) • [Remote deployment of WSL with Landscape](/tutorials/deployment/) • [Attaching a Pro subscription using the Windows registry](/howto/set-up-up4w/) • [Configuring the Landscape client](/howto/set-up-landscape-client/) • [Using the Landscape API](/howto/custom-rootfs-multiple-targets/) • [Enforcing Pro agent startup](/howto/enforce-agent-startup-remotely-registry/) • [Starting the agent remotely with InTune](/howto/start-agent-remotely/)
-* **Security and Ubuntu Pro**: [Security overview](/explanation/security-overview/) • [Securing WSL with Pro](/tutorials/getting-started-with-up4w/) • [Firewall requirements](/reference/firewall_requirements/)
-* **Configuration and customisation**: [Instance configuration reference](/reference/instance_configuration/) • [Automating configuration with cloud-init](/howto/cloud-init/) • [Customising an Ubuntu image for WSL](/howto/custom-ubuntu-distro/) • [Differences between WSL 1 and WSL 2](/explanation/compare-wsl-versions/)
-* **GPU and graphics**: [Enabling GPU acceleration with CUDA](/howto/gpu-cuda/) • [Creating data visualisations](/howto/data-science-and-engineering/)
-* **DevOps**:  [GitHub actions for WSL](/reference/actions/) • [Running a WSL GitHub workflow on Azure](/howto/run-workflows-azure/)  
+|                    |                                                                     |
+|--------------------|---------------------------------------------------------------------|
+|**Get started** | [Set up an development environment on Windows with Ubuntu on WSL](/tutorials/develop-with-ubuntu-wsl/) |
+|**Install Ubuntu** | [Install Ubuntu on WSL](/howto/install-ubuntu-wsl2.md) • [Available releases](/reference/distributions/) • [Upgrade your installation](/howto/upgrade-ubuntu) |
+|**Configuration** | [Instance configuration methods](/reference/instance_configuration/) • [Automate configuration with cloud-init](/howto/cloud-init/) |
+|**Security** | [Enable Pro](/howto/set-up-up4w) • [Security overview](/explanation/security-overview/) • [Firewall requirements](/reference/firewall_requirements/) |
+|**Deployment** | [Deployment guides](/howto/index-remote-deployment/) • [Custom images](/howto/custom-ubuntu-distro/) • [Reference architecture](/explanation/ref-arch-explanation)
+|**GPU and graphics** | [Enable GPU acceleration with CUDA](/howto/gpu-cuda/) • [Create data visualisations](/howto/data-science-and-engineering/) |
+|**DevOps** |  [GitHub actions for WSL](/reference/actions/) • [Run a WSL GitHub workflow on Azure](/howto/run-workflows-azure/) |
 
 ## How the documentation is organised
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,7 +20,7 @@ Information on how to configure Ubuntu for WSL instances.
 ```{toctree}
 :titlesonly:
 
-instance_configuration
+WSL instance configuration <instance_configuration>
 ```
 
 If you are interested in automated testing of applications in Ubuntu WSL, read:

--- a/docs/reference/instance_configuration.md
+++ b/docs/reference/instance_configuration.md
@@ -17,7 +17,7 @@ Each configuration method has a different scope and use-case. Depending on the m
 | [`.wslconfig`](ref::.wslconfig)   | General settings that apply to all WSL instances                   | `%UserProfile%\.wslconfig`, in the Windows file system                                     |
 | [`wsl.conf`](ref::wsl.conf)   | Settings for a specific WSL instance only                          | `/etc/wsl.conf`, while inside a WSL instance                                               |
 | [Cloud-init](ref::cloud-init)     | Ubuntu provisioning settings for instances of a named distribution | `<Distro Name>.userdata` files in `%UserProfile%\.cloud-init\`, in the Windows file system |
-| [Ubuntu Pro for WSL](ref::up4w)   | Pro settings that apply to all compatible Ubuntu instances         | Installable [graphical application ](howto::up4w)                                          |
+| [Ubuntu Pro for WSL](ref::up4w)   | Pro settings that apply to all compatible Ubuntu instances         | Installable [graphical application ](tut::up4w)                                          |
 
 (ref::wsl-settings)=
 
@@ -90,7 +90,7 @@ Finally, install that distribution as you would normally, and the cloud-init con
 
 Ubuntu Pro for WSL is a graphical application that automatically configures all compatible instances of Ubuntu on WSL to attach to your [Ubuntu Pro](https://ubuntu.com/pro) subscription.
 
-> [Read more about using Pro for WSL](howto::up4w)
+> [Read more about using Pro for WSL](tut::up4w)
 
 ## Further reading
 

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -235,7 +235,7 @@ You should again get confirmation of successful Pro-attachment for the new insta
 This is only the start of what you can do with Pro for WSL.
 
 If you need to create and manage large numbers of Ubuntu WSL instances
-you will probably want to use the Windows registry.
+you will probably want to use the Windows registry for installing the Pro app.
 By using the Windows registry you can associate a Pro token with
 each new WSL instance using your organisation's own deployment solution.
 
@@ -244,7 +244,7 @@ each new WSL instance using your organisation's own deployment solution.
 Landscape support is also built-in to Pro for WSL.
 With a single configuration file, you can create and manage
 multiple WSL instances that will automatically be registered
-with your Landscape server:
+with your Landscape server.
 
 > For more information, please refer to our guide on how to [deploy WSL instances with Pro for WSL and Landscape](tut::deploy).
 

--- a/docs/tutorials/getting-started-with-up4w.md
+++ b/docs/tutorials/getting-started-with-up4w.md
@@ -6,7 +6,7 @@ myst:
       "Ubuntu Pro for WSL is a Windows application that automatically attaches your Ubuntu Pro subscription to every Ubuntu instance created on WSL."
 ---
 
-(howto::up4w)=
+(tut::up4w)=
 # Get started with Ubuntu Pro for WSL
 
 ```{include} ../includes/pro_content_notice.txt
@@ -246,7 +246,7 @@ With a single configuration file, you can create and manage
 multiple WSL instances that will automatically be registered
 with your Landscape server:
 
-> For more information, please refer to our tutorial on how to [deploy WSL instances with Pro for WSL and Landscape](./deployment.md).
+> For more information, please refer to our guide on how to [deploy WSL instances with Pro for WSL and Landscape](tut::deploy).
 
 Our documentation includes several other [how-to guides](../howto/index)
 for completing specific tasks, [reference](../reference/index) material

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,29 +10,35 @@ Pro for WSL application.
 Start by learning to set up a development environment with Ubuntu on WSL by
 building and testing a small web project.
 
+If you are unfamiliar with Ubuntu, Windows, or WSL, this is the best place
+to start. It guides you step-by-step through installing WSL and Ubuntu,
+and the creation of a small web server in Ubuntu from Visual Studio Code
+running on Windows. It also has useful beginner tips, including customizing
+the name of the Ubuntu distro during installation.
+
 ```{toctree}
 :titlesonly:
 
-Develop with Ubuntu on WSL <develop-with-ubuntu-wsl>
+Get started with Ubuntu on WSL for development <develop-with-ubuntu-wsl>
 ```
 
 ## Ubuntu Pro for WSL
 
-Then learn to automatically Pro-attach your Ubuntu WSL instances with the
-Pro for WSL application.
+Pro is a subscription offered by Canonical that enhances the security of
+Ubuntu. The Pro for WSL application is separate to the Ubuntu distro, and
+makes it easy to attach the subscription to all Ubuntu instances on a machine.
+
+The Pro app also integrates with Landscape, making it possible to remotely
+manage Ubuntu instances on a Windows machine.
+
+If you or your organization are interested in using Pro with WSL, the tutorial
+below will get you started by guiding you through installing the app on a
+Windows machine and automatically attaching your Pro subscription to Ubuntu
+instances.
 
 ```{toctree}
 :titlesonly:
 
-Get started with Ubuntu Pro for WSL <getting-started-with-up4w>
-```
-
-If you are interested in remote management of WSL instances, you can also learn
-how Pro for WSL's Landscape integration can be used to deploy Ubuntu WSL instances.
-
-```{toctree}
-:titlesonly:
-
-Deploy WSL instances with Ubuntu Pro for WSL and Landscape <deployment>
+Get started securing WSL with Ubuntu Pro <getting-started-with-up4w>
 ```
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -25,7 +25,7 @@ Get started with Ubuntu on WSL for development <develop-with-ubuntu-wsl>
 ## Ubuntu Pro for WSL
 
 Pro is a subscription offered by Canonical that enhances the security of
-Ubuntu. The Pro for WSL application is separate to the Ubuntu distro, and
+Ubuntu. The Ubuntu Pro for WSL application is separate to the Ubuntu distro, and
 makes it easy to attach the subscription to all Ubuntu instances on a machine.
 
 The Pro app also integrates with Landscape, making it possible to remotely


### PR DESCRIPTION
This PR makes several changes aimed at improving the structure and cohesion of the documentation.
There will likely be future PRs that address similar issues, but this is a start.

## Simplified, readable homepage

We can take a more curated approach to the grid of links that are presented to the reader. We don't need to link to everything. For example, instead of linking to all of the deployment guides, which can be quite technical and specialized, we can present them with a link to a page "Deployment guides" that provides an overview of those topics:

<img width="1455" height="334" alt="image" src="https://github.com/user-attachments/assets/9661606b-e148-4182-82f1-ba7248f33460" />

Borrowing from the Landscape docs homepage, we also add the links to a table, which improves the visual clarity of the presentation.

I also changed some of the row labels. Instead of one big Enterprise section, we divide the topics more neatly between security and deployment for example.

## Better onboarding text on landing pages

Some of the landing pages didn't include much text to situate the reader. This was particularly stark when the deployment landing page was linked from the homepage.

More descriptive text has been added to key landing pages in this PR:

<img width="1448" height="923" alt="image" src="https://github.com/user-attachments/assets/8950cb3f-6d20-4ca3-a93e-31e8b692db88" />

## Standalone tutorials for distro and Pro

We currently have three tutorials. Where possible, it is preferable to have one tutorial that acts as an entry-point to the documentation and the product. That is difficult in our case, because we have both the distro and the app to document.

Here, I propose we stick to two: one for distro, one for app. Entry-points to both pieces of software. These each will need more work in future, including adding tear down instructions, to make them work better as tutorials.

The deployment guide is to be moved to the how-to section. It is a clear, step-by-step guide for users who already know about Pro and WSL. We can also group it neatly with the other deployment guides for easier discoverability. To help with that, I also make it clear that it uses the web portal, as distinct from the API.

## Simplified link text, where appropriate

Generally, but not always, I have tried to follow the principle that we should limited repeated use of "Ubuntu on WSL" and "Ubuntu Pro for WSL" and try to compress to Ubuntu or WSL or instance or Pro, where from the context in which the words appear it is clear what is being referred to.

For the grid of links in the homepage, but also the links in the side navigation, I have tried to compress where possible.
For example, in the sidenav, if "Install Ubuntu on WSL" appears, and is followed by "Upgrade Ubuntu", it is OK to have "Automatic setup of Ubuntu ~~on WSL~~ with cloud-init". Note that this only affects the link text in the sidenav and we are not changing the URL or the page title.

## Reorganization of individual pages

The custom images guide is now linked under the Deployment section.

Previously it was under the install section in the sidenav and the configuration section in the homepage.

It is likely that many users would be interested in configuration, both manually and automatically with cloud-init.

Customizing an image seems like a more specialized and non-routine operation, which is more likely to be of interest to users doing deployments.

## Replace Ubuntu on WSL self link with Home

There is a link to the homepage labelled "Ubuntu on WSL" at the top. To make it more obvious that this goes back to the homepage, we should call it "home".

UDENG-10943