### PR TITLE
fix(ci): Improvements to dependabot and publish workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,49 +1,20 @@
 version: 2
 updates:
+  # General Go dependency updates for all Go modules in the repository.
   - package-ecosystem: "gomod"
-    directory: "/agentapi"
+    directories:
+      - "/agentapi"
+      - "/common"
+      - "/contractsapi"
+      - "/end-to-end"
+      - "/generate"
+      - "/mocks"
+      - "/storeapi/go-wrapper/microsoftstore"
+      - "/tools"
+      - "/windows-agent/"
+      - "/wsl-pro-service"
     commit-message:
-      prefix: "deps(agentapi): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "gomod"
-    directory: "/windows-agent"
-    commit-message:
-      prefix: "deps(windows-agent): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "gomod"
-    directory: "/common"
-    commit-message:
-      prefix: "deps(common): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "gomod"
-    directory: "/end-to-end"
-    commit-message:
-      prefix: "deps(end-to-end): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "gomod"
-    directory: "/tools"
-    commit-message:
-      prefix: "deps(tools): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "gomod"
-    directory: "/wsl-pro-service"
-    commit-message:
-      prefix: "deps(wsl-pro-service): "
+      prefix: "deps(go): "
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -58,25 +29,22 @@ updates:
       interval: "weekly"
       day: "thursday"
 
+  # So we update grpc and protobuf packages exclusively.
   - package-ecosystem: "pub"
-    # So we update grpc and protobuf packages
     directory: "/agentapi/dart"
     commit-message:
       prefix: "deps(agentapi): "
     schedule:
       interval: "weekly"
       day: "thursday"
+
+  # Other Dart packages update more often.
   - package-ecosystem: "pub"
-    directory: "/gui/packages/p4w_ms_store"
+    directories:
+      - "/gui/packages/p4w_ms_store"
+      - "/gui/packages/ubuntupro"
     commit-message:
-      prefix: "deps(gui-p4w_ms_store): "
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-  - package-ecosystem: "pub"
-    directory: "/gui/packages/ubuntupro"
-    commit-message:
-      prefix: "deps(gui-ubuntupro): "
+      prefix: "deps(gui): "
     schedule:
       interval: "weekly"
       day: "thursday"

--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -216,12 +216,11 @@ jobs:
         working-directory: './wiki'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # The appinstaller file output is relative to the main repo root.
+        # The appinstaller file output is an absolute path.
         run: |
-          $appinstallerFile="..\${{ steps.bundle.outputs.appinstaller-path }}"
           $folder = ".\pre-release\"
           New-Item -Path "$folder" -ItemType Directory -Force
-          Copy-Item "$appinstallerFile" "$folder"
+          Copy-Item "${{ steps.bundle.outputs.appinstaller-path }}" "$folder"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$folder"


### PR DESCRIPTION
There was a line in the `publish-msix` workflow missing updates: it assumed the App Installer file path from a previous step was a relative path but our recent changes made it into an absolute path. This fixes the error seen at: https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/29419467880/job/87368259346#step:11:23.

Another small improvement I've long desired to make is grouping dependabot's PRs across the monorepo. Right now we can see 5 PRs opened by the bot to upgrade a single dependency (`go-grpc` in this case, PRs #1711, #1712, #1713, #1714 and #1715). Should we have the proposed configuration changes already in place that case would have resulted in a single PR updating the dependency at once for all 5 affected Go modules in this workspace. Refer to the dependabot documentation for more information: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-updates-across-directories-in-a-monorepo.

I kept the top-level `agentapi` Dart upgrades separate from the `gui` related packages because it only contains proto bindings, and we don't touch that quite often.