### PR TITLE
feat: Implement AGENTS.md and surrounding documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ instance (a.k.a "the instance") into Canonical security and compliance services,
 and Ubuntu Pro, by automatically enforcing its configuration to all existing and future instances.
 It's made of components running on Ubuntu on WSL (Linux) and on the Windows host, described below:
 
-- **wsl-pro-service**: A systemd unit distributed as a Debian package in the `main` pocket of the
+- **wsl-pro-service**: A systemd unit distributed as a Debian package in the `main` component of the
 Ubuntu archive (thus security and maintainability are key values). It runs inside each Ubuntu on WSL
 instance and communicates with the host to apply configuration and report status.
 - **ubuntu-pro-agent.exe** (a.k.a. the `agent`): A command line program running on the host with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 ## Description
 
 **Ubuntu Pro for WSL** is a multi component system that automates enrollment of any **Ubuntu on WSL**
-instance (a.k.a "the instance") into Canonical security and compliance services, such as Landscape
-and Ubuntu Pro, by automatically enforcing its configuration to all existing and future instances.
-It's made of components running on Ubuntu on WSL (Linux) and on the Windows host, described below:
+instance into Canonical security and compliance services, such as Landscape and Ubuntu Pro, by
+automatically enforcing its configuration to all existing and future instances. It's made of
+components running on Ubuntu on WSL (Linux) and on the Windows host, described below:
 
 - **wsl-pro-service**: A systemd unit distributed as a Debian package in the `main` component of the
 Ubuntu archive (thus security and maintainability are key values). It runs inside each Ubuntu on WSL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# Ubuntu Pro for WSL Guide for Coding Agents
+
+## Description
+
+**Ubuntu Pro for WSL** is a multi component system that automates enrollment of **Ubuntu on WSL**
+instances (a.k.a the _instances_ ) into Canonical security and compliance services, such as Landscape
+and Ubuntu Pro, by automatically enforcing its configuration to all existing and future instances.
+It's made of components running on Ubuntu on WSL (Linux) and on the Windows host, described below:
+
+- **wsl-pro-service**: A systemd unit distributed as a Debian package in the `main` pocket of the
+Ubuntu archive (thus security and maintainability are key values). It runs inside each Ubuntu on WSL
+instance and communicates with the host to apply configuration and report status.
+- **ubuntu-pro-agent.exe** (a.k.a. the `agent`): A command line program running on the host with
+user privileges. It's the core of this system, responsible for managing the configuration and
+enrollment status of all Ubuntu on WSL instances.
+- **ubuntupro.exe** (a.k.a the `gui`): A graphical user interface running on Windows to configure
+the `agent` serving both end users and developers on testing and debugging.
+- **ubuntu-pro-agent-launcher.exe** (a.k.a. the `launcher`): An invisible Win32 window that hosts
+the `agent` under a pseudo console, allowing it to run in the background without console windows
+popping up every time it interacts with WSL via API or command line.
+- **ubuntu.com/wsl/docs** (a.k.a the `docs`): The official documentation for Ubuntu on WSL and Pro
+for WSL, hosted on the Ubuntu website.
+
+The source code of all those components is hosted at https://github.com/canonical/ubuntu-pro-for-wsl
+as a polyglot monorepo.
+
+
+## Features in a nutshell
+
+### Ubuntu Pro
+
+When configured with a Pro Token, this system enforces all _instances_ to automatically
+attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM) `apt`
+repositories and other security features. It supports a hierarchy of sources of a token:
+
+- OEM (coming soon), with the highest precedence.
+- Organization - deployed via a Windows registry key (friendly to remote management solutions)
+- Microsoft Store subscription purchase - triggered via the GUI, a Canonical Contracts backend
+deliver a Pro token once the entitlement is validated against the MS Store Graph API.
+- Manual input - via the GUI, from which the user can attach and detach in bulk.
+
+### Landscape
+
+If provided, a Landscape client configuration template is expanded and applied to all _instances_,
+making them connect to a Landscape server of choice, from where sysadmins can monitor and enforce
+compliance. The following sources are hierarchically supported:
+
+- Organization - via registry key as before, with the highest precedence.
+- User - manual input via the GUI.
+
+The `agent` communicates with the configured Landscape server and runs commands on its behalf, such
+as to keep an _instance_ alive, install and uninstall _instances_.
+
+
+## Collaboration with other Canonical tools
+
+To enforce Pro attachment and Landscape configuration at first boot time, we leverage `cloud-init`.
+Actions taken after first boot are intermediated by `wsl-pro-service` itself.
+While we act on configuring the `landscape-client`, it remains the one communicating with the server
+about the particular _instance_ it's running on.
+
+## Tech stack
+
+**Go** is the preferred programming language and we strive to work with its latest major version,
+constrained by the Ubuntu archive or quality tools like Tiobe TiCS. We deviate from Go only in the
+following constrained scenarios:
+
+| Scenario | Language / Tools | Components | Reasoning |
+|----------|------------------|------------|-----------|
+| Graphical user interface is required | Dart / Flutter | `gui` | Well known in the organization |
+| Bridge into the Flutter native layer | C++ | `gui` | Imposed by Flutter for Desktop |
+| Tight and self-contained integration with Windows and Microsoft Store APIs | C++ | `launcher`, `agent` (via DLLs) and `gui` via Flutter plugins | Easiest to integrate |
+| High level IPC | protobuf | `agent`, `gui`, `wsl-pro-service` communicate via `gRPC` | Team's preference |
+| Packaging for Ubuntu | `debhelper` | `wsl-pro-service` | Functionality requires it to be a system package |
+| Packaging for Windows | XML / `winappCli` | `agent`, `gui` and `launcher` packaged as MSIX | Best user experience and security |
+| High level build orchestration on Windows | PowerShell | | Native and powerful enough |
+| Low level build system for C++ | CMake | `launcher` and parts of the `agent` and `gui` | Simplest and most widely used for C++ |
+| CI/CD | YAML + PowerShell or Bash / GitHub Actions | | Native to GitHub and widely used |
+| User documentation | `myST` + `sphinx` + `Read the Docs` | `docs` | Organization standard |
+
+Except for the `wsl-pro-service`, which heavily assumes Linux, and the C++ abstractions, which are
+allowed to tightly couple to Windows features, **all high level components must be written in a
+cross platform manner, even if targetting only Windows**. This allows for better testability.
+
+## Folder structure
+
+- `agentapi/` - protobuf bindings for the `agent` to `gui` and `wsl-pro-service` `gRPC` communication.
+- `common/` - Go constants, logic and test helpers shared between the `agent` and `wsl-pro-service`.
+- `contractsapi/` - Canonical Contracts API client in Go used for the integration with Microsoft
+     Store subscription management.
+- `docs/` - Official documentation for Ubuntu on WSL and Pro for WSL, hosted on the Ubuntu website.
+- `docs/internal/` - Development documentation, like architectural decision records, domain language
+     mapping and coding standards, targetting AI agents and developers, not published on the website.
+- `end-to-end/` - High level end-to-end tests in Go that exercise the entire system, installing test
+     versions of the packages and asserting state on Windows and WSL instances.
+- `generate/` - Code generation support for things like Gettext-based translations in Go.
+- `gui/` - Flutter plugin and Graphical user interface for Ubuntu Pro for WSL.
+- `img/` - Images used in the README.md file.
+- `launcher/` - C++ code for the `launcher` that hosts the `agent` under a pseudo console.
+- `mocks/` - Mock implementations of the gRPC and REST services for unit and integration testing.
+- `msix/` - MSIX packaging declarations and assets.
+- `storeapi/` - C++ sources, its tests and a Go wrapper abstracting the native APIs for Microsoft
+    Store subscription management.
+- `tools/` - Implements the legacy `tools.go` idiom and some build time helpers, like
+    `tools\build\compute_version.go`.
+- `windows-agent/` - Go sources for the `agent`.
+- `wsl-pro-service/` - Go sources for the `wsl-pro-service` and its packaging as a Debian package.
+
+Some files in the root of the repository deserve special mention:
+
+- `build.ps1` - PowerShell build orchestration script for Windows, invoked by CI and developers,
+    used to compile, layout and package all Windows components.
+- `CMakeLists.txt` - CMake build system entry point for the C++ components.
+- `CMakePresets.json` - Implements presets for triggering MSVC static code analysis and clang-tidy.
+- `Makefile` - only used by the TiCS tool, should mimic all steps taken in CI in a single invocation
+   so that TiCS can visualize the entire build process, otherwise not used by developers or CI.
+
+
+## Internal references
+
+To learn more about the design and implementation of this system, consult the following internal
+documentation:
+
+- `docs/internal/adr.md` - Architectural decision records (ADRs) describing the true hard-to-change
+   core decisions that steer and constrain the desing and implementation of this system, grouped by
+   different areas of implementation (packaging, security, integration, etc).
+- `docs/internal/domain.md` - Defines the ubiquitous language, describing the meaning of terms and
+    their usage in the codebase and, to less extent, user facing text, acting as a glossary to avoid
+    repeating descriptions and keep the terminology sharp and concise.
+
+Those must be kept up-to-date as terms or decisions are introduced or changed to keep them useful.
+Only true hard-to-reverse, surprising without context or the result of a real trade-off decisions
+should be recorded in the ADRs.
+
+When writing code, follow the per language coding standards:
+
+| Language | File |
+|----------|------|
+| C++ | `docs/internal/cpp-standards.md` |
+| Dart | `docs/internal/dart-standards.dart.md` |
+| Go | `docs/internal/go-standards.md` |
+
+When writing or reviewing for the documentation website, follow `docs/internal/docs-standards.md`.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,6 @@ When configured with a Pro Token, this system enforces all _instances_ to automa
 attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM), `apt`
 repositories and other security features. It supports a hierarchy of sources of a token:
 
-- OEM (coming soon), with the highest precedence.
 - Organization - deployed via a Windows registry key (friendly to remote management solutions)
 - Microsoft Store subscription purchase - triggered via the GUI, a Canonical Contracts backend
 deliver a Pro token once the entitlement is validated against the MS Store Graph API.
@@ -136,8 +135,6 @@ When writing code, follow the per language coding standards:
 
 | Language | File |
 |----------|------|
-| C++ | `docs/internal/cpp-standards.md` |
-| Dart | `docs/internal/dart-standards.dart.md` |
 | Go | `docs/internal/go-standards.md` |
 
 When writing or reviewing for the documentation website, follow `docs/internal/docs-standards.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,5 +137,3 @@ When writing code, follow the per language coding standards:
 |----------|------|
 | Go | `docs/internal/go-standards.md` |
 
-When writing or reviewing for the documentation website, follow `docs/internal/docs-standards.md`.
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ as to keep an _instance_ alive, install or uninstall _instances_.
 
 To enforce Pro attachment and Landscape configuration at first boot time, we leverage `cloud-init`.
 Actions taken after first boot are mediated by `wsl-pro-service` itself.
-While we act on configuring the `landscape-client`, it remains the one communicating with the server
-about the particular _instance_ it's running on.
+The `landscape-client` is configured through the Pro for WSL app, but still has the role of
+communicating with the server about the instance it is running on.
 
 ## Tech stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-# Ubuntu Pro for WSL Guide for Coding Agents
+# Ubuntu Pro for WSL: Guide for coding agents
 
 ## Description
 
-**Ubuntu Pro for WSL** is a multi component system that automates enrollment of **Ubuntu on WSL**
-instances (a.k.a the _instances_ ) into Canonical security and compliance services, such as Landscape
+**Ubuntu Pro for WSL** is a multi component system that automates enrollment of any **Ubuntu on WSL**
+instance (a.k.a "the instance") into Canonical security and compliance services, such as Landscape
 and Ubuntu Pro, by automatically enforcing its configuration to all existing and future instances.
 It's made of components running on Ubuntu on WSL (Linux) and on the Windows host, described below:
 
@@ -25,12 +25,12 @@ The source code of all those components is hosted at https://github.com/canonica
 as a polyglot monorepo.
 
 
-## Features in a nutshell
+## Summary of features
 
 ### Ubuntu Pro
 
 When configured with a Pro Token, this system enforces all _instances_ to automatically
-attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM) `apt`
+attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM), `apt`
 repositories and other security features. It supports a hierarchy of sources of a token:
 
 - OEM (coming soon), with the highest precedence.
@@ -49,13 +49,13 @@ compliance. The following sources are hierarchically supported:
 - User - manual input via the GUI.
 
 The `agent` communicates with the configured Landscape server and runs commands on its behalf, such
-as to keep an _instance_ alive, install and uninstall _instances_.
+as to keep an _instance_ alive, install or uninstall _instances_.
 
 
-## Collaboration with other Canonical tools
+## Integration with other Canonical tools
 
 To enforce Pro attachment and Landscape configuration at first boot time, we leverage `cloud-init`.
-Actions taken after first boot are intermediated by `wsl-pro-service` itself.
+Actions taken after first boot are mediated by `wsl-pro-service` itself.
 While we act on configuring the `landscape-client`, it remains the one communicating with the server
 about the particular _instance_ it's running on.
 
@@ -76,7 +76,7 @@ following constrained scenarios:
 | High level build orchestration on Windows | PowerShell | | Native and powerful enough |
 | Low level build system for C++ | CMake | `launcher` and parts of the `agent` and `gui` | Simplest and most widely used for C++ |
 | CI/CD | YAML + PowerShell or Bash / GitHub Actions | | Native to GitHub and widely used |
-| User documentation | `myST` + `sphinx` + `Read the Docs` | `docs` | Organization standard |
+| User documentation | `myST` + `sphinx` + `Python` + `Read the Docs` | `docs` | Organization standard |
 
 Except for the `wsl-pro-service`, which heavily assumes Linux, and the C++ abstractions, which are
 allowed to tightly couple to Windows features, **all high level components must be written in a
@@ -122,14 +122,14 @@ To learn more about the design and implementation of this system, consult the fo
 documentation:
 
 - `docs/internal/adr.md` - Architectural decision records (ADRs) describing the true hard-to-change
-   core decisions that steer and constrain the desing and implementation of this system, grouped by
+   core decisions that steer and constrain the design and implementation of this system, grouped by
    different areas of implementation (packaging, security, integration, etc).
 - `docs/internal/domain.md` - Defines the ubiquitous language, describing the meaning of terms and
     their usage in the codebase and, to less extent, user facing text, acting as a glossary to avoid
     repeating descriptions and keep the terminology sharp and concise.
 
 Those must be kept up-to-date as terms or decisions are introduced or changed to keep them useful.
-Only true hard-to-reverse, surprising without context or the result of a real trade-off decisions
+Only decisions that are hard-to-reverse, surprising without context, or the result of a trade-off,
 should be recorded in the ADRs.
 
 When writing code, follow the per language coding standards:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ as a polyglot monorepo.
 ### Ubuntu Pro
 
 When configured with a Pro Token, this system enforces all _instances_ to automatically
-attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM), `apt`
+attach to Ubuntu Pro using that token, granting access to Extended Support Maintenance (ESM)
 repositories and other security features. It supports a hierarchy of sources of a token:
 
 - Organization - deployed via a Windows registry key (friendly to remote management solutions)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ the `agent` serving both end users and developers on testing and debugging.
 - **ubuntu-pro-agent-launcher.exe** (a.k.a. the `launcher`): An invisible Win32 window that hosts
 the `agent` under a pseudo console, allowing it to run in the background without console windows
 popping up every time it interacts with WSL via API or command line.
-- **ubuntu.com/wsl/docs** (a.k.a the `docs`): The official documentation for Ubuntu on WSL and Pro
-for WSL, hosted on the Ubuntu website.
+- **ubuntu.com/wsl/docs**: The official documentation for Ubuntu on WSL and Pro for WSL, hosted on
+the Ubuntu website.
 
 The source code of all those components is hosted at https://github.com/canonical/ubuntu-pro-for-wsl
 as a polyglot monorepo.

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -2,10 +2,24 @@
 artifact
 artifacts
 autocompletion
+declaratively
 enablement
+Hyrum
+hoc
 Remediations
 remediations
+reachability
+unary
+unconfigured
+uninstallation
+swappable
+tamperable
+tamperability
+Unmanaged
+unmanaged
 unregistering
+virtualized
+virtualizes
 
 # Tools and brands
 AppArmor
@@ -18,6 +32,7 @@ CIS
 CMake
 cmake
 Codecov
+conhost
 chrony
 Ctrl
 cuda
@@ -33,6 +48,7 @@ Intune
 livepatch
 macOS
 makefile
+MSBuild
 MSIX
 npm
 OOBE
@@ -69,6 +85,7 @@ autoload
 automount
 autopkgtest
 autopkgtests
+backoff
 backporting
 binfmt
 cdimage
@@ -95,16 +112,21 @@ JWT
 localhost
 LTS
 MotD
+mutex
 Numbat
 os
 pem
 PRs
 repo
 rootfs
+retryable
 SLA
 SRU
 SSL
 ssl
+sideload
+Sideload
+sideloaded
 tcp
 TLS
 toolchain

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,6 +280,7 @@ extensions = [
 # Excludes files or directories from processing
 exclude_patterns = [
     ".venv*",
+    "internal",
 ]
 
 # Adds custom CSS files, located under 'html_static_path' or remotely

--- a/docs/internal/adr.md
+++ b/docs/internal/adr.md
@@ -21,8 +21,8 @@ Numbered sequentially, grouped by section. 'Who' and 'when' are captured by Git.
 ### 1.02 - Package wsl-pro-service as deb for image inclusion
 
 * **Problem/Context**: Must touch system binaries, run as root, and be present at first boot.
-* **Decision**: Package as deb, seeded in the image via Ubuntu archive main pocket — our scope doesn't
-  fit a confined snap.
+* **Decision**: Package as deb, seeded in the image via Ubuntu archive `main` component — our scope
+  doesn't fit a confined snap.
 * **Consequences**:
   - Positive: Simple to reason about; shells out to pro client/landscape-register instead of needing
     IPC; leverages systemd.

--- a/docs/internal/adr.md
+++ b/docs/internal/adr.md
@@ -9,8 +9,8 @@ Numbered sequentially, grouped by section. 'Who' and 'when' are captured by Git.
 
 ### 1.01 - Package Windows components as MSIX
 
-* **Problem/Context**: Windows packaging options are mostly complex, third-party, and lack Package
-  Identity, needed for in-app purchases.
+* **Problem/Context**: Windows packaging options are mostly complex and third-party. They also lack Package
+  Identity needed for in-app purchases.
 * **Decision**: Use MSIX — first-party, modern, tool-supported, and more secure than MSI.
 * **Consequences**:
   - Positive: Declarative, easier to maintain; clean Store upgrades/uninstall; easy OEM install; App

--- a/docs/internal/adr.md
+++ b/docs/internal/adr.md
@@ -1,0 +1,303 @@
+# Architectural Decision Records
+
+Decisions that are hard to reverse, surprising without context, and the result of a real trade-off.
+Numbered sequentially, grouped by section. 'Who' and 'when' are captured by Git.
+
+---
+
+## 1. Packaging and deployment
+
+### 1.01 - Package Windows components as MSIX
+
+* **Problem/Context**: Windows packaging options are mostly complex, third-party, and lack Package
+  Identity, needed for in-app purchases.
+* **Decision**: Use MSIX — first-party, modern, tool-supported, and more secure than MSI.
+* **Consequences**:
+  - Positive: Declarative, easier to maintain; clean Store upgrades/uninstall; easy OEM install; App
+    Container confinement builds trust.
+  - Negative: App Container FS/Registry virtualization overhead; no per-user services; some low-level
+    Win32 APIs unavailable.
+
+### 1.02 - Package wsl-pro-service as deb for image inclusion
+
+* **Problem/Context**: Must touch system binaries, run as root, and be present at first boot.
+* **Decision**: Package as deb, seeded in the image via Ubuntu archive main pocket — our scope doesn't
+  fit a confined snap.
+* **Consequences**:
+  - Positive: Simple to reason about; shells out to pro client/landscape-register instead of needing
+    IPC; leverages systemd.
+  - Negative: Debian packaging is non-trivial and needs security review for main; weaker confinement
+    than a snap.
+
+### 1.03 - The agent runs as a per-user MSIX startup task, not a Windows service
+
+* **Problem/Context**: The agent must run continuously, but MSIX apps can't ship a per-user Windows
+  service — only a startup task, enabled by the OS only after first user interaction.
+* **Decision**: Package as the non-elevated per-user MSIX startup task `UbuntuProAutoStart`, which
+  launches the Launcher (never the agent binary directly); the GUI relaunches the Launcher if the
+  agent is down; a documented registry remediation marks the task "Enabled by Policy" for fleet tools.
+* **Consequences**:
+  - Positive: Store-compliant, no admin rights, natural per-user HKCU config.
+  - Negative: Agent runs only for the logged-in user; first-interaction requirement blocks zero-touch
+    deployment (mitigated, not solved, by the racy registry remediation); update restarts need manual
+    RegisterApplicationRestart wiring.
+
+### 1.04 - The agent is hosted under an invisible pseudo-console by a separate launcher process
+
+* **Problem/Context**: The agent must run invisibly, but WSL API spawns console processes and Windows
+  has no API to suppress the console window a non-console parent triggers.
+* **Decision**: Compile the agent as a console app hosted under an invisible ConPTY created by a
+  separate windowless Win32 process, the Launcher (a skinny conhost stand-in), which drains console
+  output, handles restart-on-update, and is the launch target for both the MSIX startup task and the
+  GUI.
+* **Consequences**:
+  - Positive: No console windows ever appear; killing the Launcher cleanly shuts down the agent
+    (including the address file).
+  - Negative: Extra C++ component whose lifetime packaging/GUI must coordinate; agent's console I/O
+    goes through a synthetic console.
+
+### 1.05 - MSIX registry write virtualization is disabled for the Canonical keys
+
+* **Problem/Context**: MSIX virtualizes the registry by default, but the agent needs
+  RegNotifyChangeKeyValue (which doesn't work under virtualization) and sysadmins need to target real
+  registry keys.
+* **Decision**: Disable write virtualization for HKCU\Software\Canonical\UbuntuPro (and ...\Ubuntu),
+  via the restricted capabilities runFullTrust and `unvirtualizedResources`; the agent treats the
+  registry as a read-only Configuration Source.
+* **Consequences**:
+  - Positive: Live change notifications work; remote-deployed config visible as written; one canonical
+    location for org config.
+  - Negative: Registry state isn't isolated and survives uninstall, requiring manual cleanup docs; the
+    restricted capabilities add Store-certification scrutiny.
+
+### 1.06 - Pre-releases are tagged M.9999[ab]p; one git-derived version feeds all components
+
+* **Problem/Context**: MSIX needs a four-part numeric version (MSBuild rejects the fourth element for
+  alpha/beta encoding), yet a plain numeric pre-release tag would make Read the Docs publish it as
+  latest stable.
+* **Decision**: Stable releases: M.m.p. Pre-releases: M.9999[ab]p (minor 9999 = "not for stable
+  channel"; a bare M.9999.p tag must fail CI). The full `git describe` string is the single version
+  identity, injected at build time into every component (Go `ldflags`, Flutter `--dart-define`, MSIX
+  manifest, .appinstaller).
+* **Consequences**:
+  - Positive: One coherent version across Go/C++/Flutter/MSIX; correct Read the Docs stable/latest
+    publishing; every build traces to a commit.
+  - Negative: Magic-number convention contributors must learn; would collide with a hypothetical
+    stable 1.9999.x series.
+
+### 1.07 - Non-Store installs self-update via an .appinstaller pinned to a stable releases URI
+
+* **Problem/Context**: Corporate environments often block the Store, so sideloaded MSIX needs its own
+  update channel; AppInstaller checks the URI baked in at install time, which existing installs can't
+  change.
+* **Decision**: The published .appinstaller points at the stable "latest release" GitHub download URI,
+  which must always resolve to the latest version; update checks run on launch and periodically in the
+  background; the build script patches version into manifest and .appinstaller each release.
+* **Consequences**:
+  - Positive: Automatic updates without Store dependence; one channel for all sideloaded installs.
+  - Negative: The asset URI can never change without orphaning existing installs; sideload auto-update
+    is limited on Windows 10.
+
+## 2. Security
+
+### 2.01 - Secure the Public Directory via WSL 9P Extended Attributes
+
+* **Problem/Context**: The agent writes runtime state (gRPC address, TLS material, cloud-init data) to
+  the Public Directory, projected into every instance via 9P/DrvFs; by default 9P maps files to the
+  unprivileged WSL user, exposing private keys and letting any process tamper with them.
+* **Decision**: Stamp every node created under the Public Directory with NT Extended Attributes
+  ($LXUID=0, $LXGID=0, $LXMOD — directories 040700, files 0100600) at creation, so 9P projects it as
+  root-owned. Centralized in the `securefiles` custodian component, with a plain `os` fallback (no EA
+  stamping) on non-Windows for cross-platform build/test.
+* **Consequences**:
+  - Positive: Confidentiality/integrity/availability hold inside every instance; attributes are
+    stamped before content is written; `common/certs` stays a pure in-memory generator.
+  - Negative: Depends on WSL 9P EA behavior via github.com/Microsoft/go-winio; the parent directory
+    remains tamperable by the WSL user (accepted limitation).
+
+## 3. Integration
+
+### 3.01 - Distro instances dial the agent; commands flow as reverse unary calls
+
+* **Problem/Context**: The agent must push Commands to running instances and read their state, but
+  under WSL networking instances have no stable, host-routable address.
+* **Decision**: Only wsl-pro-service initiates connections: it discovers the agent via the address
+  file in the Public Directory, resolves the host address per WSL networking mode, dials with mTLS,
+  and serves Reverse unary calls over the client-initiated streams of its Control stream — replacing
+  the earlier double-server design.
+* **Consequences**:
+  - Positive: Works under any WSL networking mode or instance count with zero host-side discovery;
+    no listeners/firewall changes inside instances.
+  - Negative: Inverts gRPC roles, requiring a custom streams package; the agent can't reach a
+    disconnected instance.
+
+### 3.02 - Microsoft Store purchases are resolved into Pro tokens via a Contracts Server round-trip
+
+* **Problem/Context**: A Microsoft Store subscription entitlement exists only in Microsoft's systems;
+  the agent can't verify it locally or issue a Pro Token, and must not embed Canonical credentials.
+* **Decision**: Follow Microsoft's recommended validation pattern: the agent gets an ephemeral Azure
+  AD token, has the Store runtime mint a User JWT bound to it and to an anonymous user hash, and
+  submits it to the Contracts Server, which validates against the Store Graph API and returns the Pro
+  Token. REST payloads are a cross-repository public contract kept in sync with Canonical's cloud-contracts
+  codebase by convention.
+* **Consequences**:
+  - Positive: Authoritative server-side validation; no Canonical/Entra credentials in the client;
+    native Store purchase UX.
+  - Negative: Pro attachment needs Contracts Server reachability; schemas must be manually synced
+    across repositories; token freshness depends on polling billing-period expiration.
+
+### 3.03 - mTLS with a per-startup self-signed CA and one shared client key pair
+
+* **Problem/Context**: The agent-instance channel crosses the Public Directory trust boundary — any
+  local process could otherwise connect — and a public CA doesn't fit (no DNS name, dynamic addresses).
+* **Decision**: At every startup the agent generates a fresh self-signed root CA, an agent cert, and
+  one client key pair shared by the GUI and all instances, written to the Public Directory under Secure
+  Projection. Both sides require/verify peer certs (TLS 1.3 min); certs expire after 30 days, rotating
+  naturally on restart; clients re-read material on every (re)connection and pin the fixed server name
+  "UP4W".
+* **Consequences**:
+  - Positive: No external PKI, zero user setup; compromise window bounded by process lifetime + cert
+    expiry; reuses ADR-2.01 secure projection.
+  - Negative: Every restart rotates the PKI, invalidating existing connections until instances re-read
+    it; all clients share one TLS identity, so the agent can't cryptographically distinguish
+    instances (WSL name is self-asserted; accepted as one trust domain per Windows user); the fixed
+    server-name override looks like a bypass and invites accidental "fixes".
+
+### 3.04 - One C++ core for Microsoft Store APIs, with thin per-language bridges
+
+* **Problem/Context**: Both the agent (Go) and GUI (Dart/Flutter) need Store subscription/purchase
+  functionality, but WinRT Store APIs are only ergonomic from C++/WinRT; per-language implementation
+  would duplicate logic.
+* **Decision**: `storeapi/base` implements the logic once against a swappable context; `storeapi/dll`
+  exposes a minimal C ABI (negative-integer error codes, explicit memory ownership) loaded lazily by
+  the agent's Go wrapper; the GUI imports the C++ from source via its Flutter plugin — bridges stay as
+  thin as possible.
+* **Consequences**:
+  - Positive: One source of truth for subscription logic, testable independent of the WinRT runtime.
+  - Negative: Error codes/enums duplicated and manually synced across C++/Go/Dart; memory ownership
+    crosses the ABI; DLL located at runtime via fallback search paths.
+
+## 4. Configuration
+
+### 4.01 - Configuration sources are strictly ordered, and higher sources veto lower ones
+
+* **Problem/Context**: A Pro Token (and Landscape config) can come from several Configuration Sources
+  (registry/Organization, Microsoft Store, GUI/User); without ordering, writes would conflict and
+  organizations couldn't guarantee fleet-wide policy.
+* **Decision**: Model each parameter as per-source slots resolved by fixed precedence (Organization >
+  Microsoft Store > User). Lower-precedence writes are rejected while a higher one is active; when the
+  higher value disappears, the next lower source activates.
+* **Consequences**:
+  - Positive: Predictable resolution and authoritative fleet policy; GUI can show the active source
+    and go read-only when org-managed.
+  - Negative: Users see "higher priority subscription active" errors needing explanation; veto logic
+    with checksum-based change detection adds complexity; the planned OEM source requires touching the
+    ordering.
+
+### 4.02 - Organization-provided configuration is never persisted to disk
+
+* **Problem/Context**: Registry-supplied Pro Tokens/Landscape config are org-managed policy; copying
+  them into the agent's Private Directory store would create a stale-able second copy of
+  organizational secrets and blur the source of truth.
+* **Decision**: The store persists only User/Store-sourced values. Organization values live in memory
+  only (excluded from serialization), re-read from the registry at every start, and tracked by a
+  persisted SHA-512 checksum for change detection without storing the data.
+* **Consequences**:
+  - Positive: Single source of truth for org data; no org token at rest; registry edits need no
+    migration/cache invalidation.
+  - Negative: Agent can't resolve org config without a registry read at startup; change detection
+    depends on checksums; load/serialization code must carefully preserve in-memory org fields.
+
+### 4.03 - Configuration is delivered via cloud-init at first boot and via wsl-pro-service afterwards
+
+* **Problem/Context**: Pro/Landscape config must apply to future instances and already-running ones;
+  cloud-init applies only at first boot, while wsl-pro-service only exists once an instance is
+  running — neither channel covers the other's case.
+* **Decision**: Write config for future/uninitialized instances as cloud-init user data into the
+  Public Directory; deliver changes after first boot as Tasks over the instance's Control stream via
+  wsl-pro-service.
+* **Consequences**:
+  - Positive: Zero-touch, race-free provisioning via the ecosystem-standard path; Landscape can deploy
+    pre-configured instances declaratively.
+  - Negative: Two mechanisms must stay consistent; cloud-init data can't reconfigure an initialized
+    instance; reset semantics differ per channel (empty Command detaches/disables vs. cloud-init data
+    simply removed).
+
+## 5. Runtime behavior
+
+### 5.01 - Distro instance start-ups are serialized process-wide
+
+* **Problem/Context**: Multiple instances starting simultaneously can freeze WSL and the whole
+  machine — a WSL platform limitation hit during bulk operations (attachment, Landscape installs,
+  keep-awake cycles).
+* **Decision**: A single process-wide mutex serializes all instance wake-ups; every start-up path must
+  hold it, so concurrent starts queue.
+* **Consequences**:
+  - Positive: Bulk operations can't freeze the host.
+  - Negative: Bulk wake-ups are slower; the constraint is invisible in code, so removing the mutex
+    looks like a safe optimization but would reintroduce the freeze.
+
+### 5.02 - wsl-pro-service gives up connecting and lets systemd restart it on a long delay
+
+* **Problem/Context**: wsl-pro-service is preinstalled in Ubuntu on WSL images and routinely runs
+  where the agent doesn't exist; endless retries would spam the journal and delay boot — yet the
+  instance must still converge when an agent does appear, without a reboot.
+* **Decision**: Retry connecting with bounded in-process exponential backoff; on exhaustion, exit
+  successfully and let systemd (Restart=always) restart it after a long delay.
+* **Consequences**:
+  - Positive: Silent, cheap idling on agent-less machines (no journal spam/boot delay); automatic
+    recovery within a bounded time once the agent appears.
+  - Negative: A merely transient failure also waits out the long delay — systemd can't vary restart
+    delay by exit condition — baking a slow worst-case reaction time into the product.
+
+### 5.03 - The distro name is discovered by reading WSL2_DISTRO_NAME from PID 2's environment
+
+* **Problem/Context**: wsl-pro-service needs its instance's name (Control stream handshake, Landscape
+  metadata, logging), but WSL exposes it only in the WSL init process's environment, which systemd
+  services don't inherit, and there's no supported API to learn it.
+* **Decision**: The systemd unit extracts WSL2_DISTRO_NAME from PID 2's environment (the forked WSL
+  /init, which retains host-provided variables PID 1 cleared when executing systemd) into a runtime
+  environment file; Go code then falls back through WSL_DISTRO_NAME, WSL2_DISTRO_NAME, and parsing
+  `wslpath` output.
+* **Consequences**:
+  - Positive: Reliable name resolution from unit start, across WSL versions.
+  - Negative: Depends on an undocumented WSL process-layout invariant (PID 2 = forked /init); failures
+    are silent (empty name means an arbitrary connection identity); must be revisited if Microsoft
+    ships a supported mechanism.
+
+### 5.04 - Distro instances are kept awake by a reference-counted keep-awake poll, not shut down explicitly
+
+* **Problem/Context**: An instance must stay running for its wsl-pro-service control stream to process
+  Tasks, but WSL shuts it down once nothing external holds it open, and the agent has no OS primitive
+  to pin it up short of interacting with it.
+* **Decision**: Each instance carries a reference-counted awake lock (`LockAwake`/`ReleaseAwake`);
+  while count > 0, a background loop periodically pokes the instance to defeat WSL's idle shutdown,
+  restarting the poke loop across instance restarts. Releasing the last lock doesn't shut the instance
+  down — it just stops artificially keeping it alive, leaving WSL's idle timeout in control.
+* **Consequences**:
+  - Positive: Reliable task delivery regardless of open terminals; the agent never has to explicitly
+    stop an instance to end keep-awake.
+  - Negative: The agent silently keeps instances running/consuming resources whenever work is pending,
+    which can surprise users; polling interval trades responsiveness vs. overhead; removing the poke
+    loop looks like safe cleanup but would silently reintroduce undelivered tasks.
+
+## 6. Testing
+
+### 6.01 - End-to-end tests install the production MSIX and drive the real system
+
+* **Problem/Context**: Unit/integration tests can't cover packaging, registry watching, startup tasks,
+  or real WSL registration — exactly where the components integrate. The Microsoft Store runtime is
+  especially hard to mock: real WinRT APIs need a deployed, Store-associated app and a signed-in user,
+  making the production purchase path untestable on a dev machine or CI.
+* **Decision**: The end-to-end suite runs on a Windows+WSL host, installs the real MSIX and
+  wsl-pro-service deb, registers real distro instances, and starts the agent through the GUI (the
+  production entrypoint), while external services are redirected to mocks via compile-time switches
+  shared with production binaries. For the Store, WinRT is abstracted behind a context interface whose
+  mock talks HTTP to a configurable REST mock, using magic trigger inputs for specific error paths,
+  shared by C++ and Go tests.
+* **Consequences**:
+  - Positive: Full-system fidelity including packaging regressions; the only tests exercising the real
+    deployment path end to end; deterministic purchase/subscription flows without a Store account.
+  - Negative: Requires a dedicated self-hosted Windows runner and mutates the host; slow and fragile,
+    so some tests ship disabled; test/production binaries differ at compile time; the Store mock can
+    drift from real WinRT, and its magic-string protocol implicitly couples C++ tests and the Go mock.

--- a/docs/internal/domain.md
+++ b/docs/internal/domain.md
@@ -1,0 +1,227 @@
+# Domain Model
+
+Ubiquitous language for Ubuntu Pro for WSL. This is a glossary — definitions only, no implementation
+details, no specs, no scratch-pad content. Keep entries sorted alphabetically.
+
+---
+
+### Address File
+
+The file the *Windows Agent* writes under the *Public Directory* at every startup, holding its
+current gRPC listening address. Removed on clean shutdown, rewritten on every restart (which also
+rotates the mTLS material, per ADR 3.03). *wsl-pro-service* and other clients read it to locate a
+running agent, since the agent has no fixed or discoverable dial address.
+
+### Agent
+
+See *Windows Agent*.
+
+### Command
+
+An instruction the *Windows Agent* sends to a distro instance over its *control stream* (apply a *Pro
+Token*, or apply a *Landscape* client configuration). Declarative: carries the desired end state, and
+an empty payload resets to unconfigured — empty Pro token detaches, empty Landscape config disables
+registration. Contrast with commands a *Landscape* server sends to the *Landscape Host Agent*, a
+separate channel.
+
+### Configuration Source
+
+The provenance of a configuration parameter (*Pro Token* or *Landscape* client configuration): *User*
+(manual GUI input), *Microsoft Store* (a *Microsoft Store subscription* purchase), or *Organization*
+(a registry key deployed by remote management). Strictly ordered by precedence — Organization >
+Microsoft Store > User — and a lower-precedence source cannot replace an active higher-precedence
+value.
+
+### Contracts Server
+
+Canonical's hosted backend bridging Microsoft Store purchases to Ubuntu Pro. The *Windows Agent*
+calls it to obtain an ephemeral Azure AD token and validate a *Microsoft Store subscription*
+entitlement (presented as a *User JWT*), receiving the *Pro Token* in exchange.
+
+### Control stream
+
+The long-lived gRPC streams a distro instance's *wsl-pro-service* opens to the *Windows Agent* and
+keeps open for the connection's life: one instance-state stream plus one command stream per command
+type (Pro attachment, Landscape). The only channel between a distro instance and the agent. Every
+stream opens with a handshake carrying the instance's WSL name, binding all its streams to one
+identity.
+
+### Deferred Task
+
+A *Task* submitted without waking the distro instance: it waits until the instance next runs (e.g.
+its next connection) before executing.
+
+### Distro
+
+Ambiguous shorthand: either the Linux distribution as a distributable package (what `wsl --install`
+downloads, tar-based or msix) or a materialized *Distro instance*. Code uses `distro` pervasively in
+the latter sense; in prose, prefer *Distro instance* for a materialized system.
+
+### Distro identity
+
+The (name, GUID) pair uniquely identifying a distro instance. Name alone isn't stable — WSL allows
+unregistering and re-registering under the same name — so the *Windows Agent* validates the stored
+GUID against the system and treats a mismatch as a different instance, invalidating the old entry.
+
+### Distro Database
+
+The *Windows Agent*'s persisted registry of managed distro instances, held in the *Private
+Directory*. Each entry stores a *Distro identity* and configuration state, validated against the
+system so a stale entry (name reused by a different GUID) is detected and invalidated. Reconciled at
+runtime against distro instances WSL reports with no entry — *Unmanaged distro instances* — which
+become managed on first `wsl-pro-service` connection.
+
+### Distro instance
+
+A named Ubuntu on WSL system registered with WSL — a materialized instance of a *Distro* package,
+whether or not the *Windows Agent* manages it.
+
+### GUI
+
+The `ubuntupro.exe` graphical app on the Windows host: the end-user configuration surface. Starts the
+*Windows Agent* via the *Launcher* if not running and submits *Pro Token*/*Landscape* configuration
+to the agent over gRPC — never writes configuration to the registry or filesystem itself.
+
+### Instance
+
+Synonym for *Distro instance* in WSL context. Prefer *Distro instance* in internal prose; bare
+*instance* may appear in user-facing text and external vocabularies (e.g. the Landscape web portal
+calls the Windows host itself an "instance").
+
+### Landscape
+
+A Canonical system-management product. Each distro instance's *Landscape client* connects to a
+configured Landscape server so sysadmins can monitor and enforce compliance fleet-wide.
+
+### Landscape client
+
+The `landscape-client` daemon pre-installed in every distro instance. Connects to the *Landscape*
+server, reports status, and executes server instructions locally. *wsl-pro-service*
+enables/configures/disables it per the *Windows Agent*'s configuration.
+
+### Landscape Host Agent
+
+The role the *Windows Agent* plays toward the *Landscape* server: connects to the Landscape
+HostAgent API, reports the Windows host and its distro instances (managed and unmanaged) as
+inventory, and executes host-level commands (install/start/stop/uninstall instances, shut down
+host). Addressed by its *Landscape Host Agent UID*, assigned on first contact.
+
+### Landscape Host Agent UID
+
+The identifier the *Landscape* server assigns the *Windows Agent* on first contact; persisted and
+injected into every distro instance's `landscape-client` config as `hostagent_uid`, grouping all
+instances under their host in Landscape. Any user-supplied `hostagent_uid` is overridden, but may
+cause server rejection.
+
+### Launcher
+
+The `ubuntu-pro-agent-launcher.exe` process on the Windows host: a windowless Win32 app hosting the
+*Windows Agent* under an invisible pseudo-console so console processes spawned on the agent's behalf
+never surface windows. A startup entrypoint — the MSIX startup task and the *GUI* both launch it,
+never the agent directly.
+
+### Microsoft Store subscription
+
+A Store subscription add-on for Ubuntu Pro for WSL, purchased e.g. via the *GUI*. A *Configuration
+Source* of a *Pro Token*: the purchase lives in Microsoft's systems and only yields a Pro Token once
+the *Contracts Server* validates the entitlement. Not itself an Ubuntu Pro subscription — the
+purchase that, once validated, unlocks one.
+
+### Private Directory
+
+The filesystem directory `%LocalAppData%\Ubuntu Pro` on the Windows host (virtualized when deployed
+via msix), accessed only by the *Windows Agent*. Holds its private state: config store, distro
+database, per-distro task queues, single-instance lock file. Contrast with the *Public Directory*,
+located for easy access from within distro instances.
+
+### Pro Token
+
+An opaque credential from Canonical's Contracts API authorising a machine to access Ubuntu Pro
+services (ESM, FIPS, etc.). The *Windows Agent* holds the active token and instructs each distro
+instance's *Ubuntu Pro client* to attach with it.
+
+### Public Directory
+
+The filesystem directory `%UserProfile%\.ubuntupro` on the Windows host: the trust boundary across
+which the Windows Agent (sole legitimate author) writes files consumed by the root-privileged
+`wsl-pro-service` inside each distro instance. Every node at or below it must carry a *Secure
+Projection* so unprivileged Linux processes can't tamper with or read its contents. The guarantee
+covers the directory and all descendants; tamperability of its parent (`%UserProfile%`) via the WSL
+user is an accepted WSL-design limitation.
+
+### Reverse unary call
+
+An RPC whose direction is inverted relative to the connection: the party that accepted the connection
+(the *Windows Agent*, gRPC server) issues the call, and the dialling party (a distro instance's
+*wsl-pro-service*, gRPC client) executes it and returns the result on the same bidirectional stream.
+How commands reach a distro instance over its *control stream*.
+
+### Secure Projection
+
+The property of a node under the *Public Directory* whereby the WSL 9P server translates its NT
+Extended Attributes (`$LXUID`, `$LXGID`, `$LXMOD`) into Linux-visible ownership/mode, appearing
+root-owned (`uid=0`, `gid=0`) with mode `0600` (files) or `0700` (directories). Denies all access to
+unprivileged Linux processes, preserving confidentiality, integrity, and availability within any
+distro instance.
+
+### `securefiles`
+
+The internal Windows Agent component (`windows-agent/internal/securefiles`), sole custodian of the
+*Public Directory*. Constructed once with the base path; exposes creation primitives (`MkdirAll`,
+`WriteFile`, `Create`) that stamp every node with the correct NT Extended Attributes (`$LXUID=0`,
+`$LXGID=0`, `$LXMOD`) before content is written. No other agent component creates nodes there
+directly.
+
+### Task
+
+A unit of configuration work (Pro attachment, Landscape config) queued for a distro instance and
+executed over its `wsl-pro-service` gRPC connection. Persisted to disk, so pending work survives
+*Windows Agent* restarts; retryable failed tasks are re-queued.
+
+### Ubuntu Pro client
+
+The `pro` command-line tool (package `ubuntu-pro-client`, formerly `ubuntu-advantage-tools`)
+pre-installed in every *Distro*. In-distro executor of Pro attachment: `wsl-pro-service` invokes it
+to attach with the active *Pro Token*, detach, and query attachment status.
+
+### Ubuntu Pro for WSL
+
+The product this repository builds: the *Windows Agent*, *Launcher*, and *GUI* packaged for Windows,
+plus the *wsl-pro-service* deb shipped in Ubuntu, automating Pro attachment and Landscape enrollment
+of distro instances. Abbreviated **UP4W** in code (the `UP4W_*` env-var prefix, gRPC TLS server name)
+and build machinery (CMake project name). An internal convenience acronym — never in user-facing
+text.
+
+### Unmanaged distro instance
+
+A distro instance the *Windows Agent* doesn't and can't manage: no database entry, no control
+channel, so no Pro attachment or Landscape config can be enforced. Discovered on demand and reported
+to *Landscape* as host inventory; the server may still request its uninstallation. Becomes managed
+when its *wsl-pro-service* first connects to the agent.
+
+### User JWT
+
+The Microsoft Store "user ID key": a JWT minted on demand by the Store runtime, binding an Azure AD
+token (vended by the *Contracts Server*) to an anonymous hash of the local Windows user. The *Windows
+Agent* sends it to the Contracts Server, which queries Microsoft about the user's purchases on the
+app's behalf. Neither a *Pro Token* nor a user credential.
+
+### Windows Agent
+
+The `ubuntu-pro-agent.exe` process on the Windows host, running with user privileges: the system's
+orchestrator. Reads configuration from the registry and its *Private Directory*, manages the
+lifecycle of all managed distro instances, and writes authoritative runtime state (address,
+certificates, cloud-init data) to the *Public Directory* for `wsl-pro-service`.
+
+### Worker
+
+The per-distro-instance component owning and executing that instance's *Task* queue. Persists queued
+tasks to disk (surviving *Windows Agent* restarts), processes them one at a time against the
+instance's gRPC connection, and distinguishes an unreachable instance (invalidating its *Distro
+Database* entry) from a task requesting retry at the instance's next connection.
+
+### `wsl-pro-service`
+
+A systemd unit running inside each distro instance with root privileges. Reads runtime state from the
+*Public Directory* (projected via 9P/DrvFs), connects to the *Windows Agent* over mTLS gRPC, and
+applies Pro attachment and Landscape configuration locally.

--- a/docs/internal/domain.md
+++ b/docs/internal/domain.md
@@ -1,11 +1,11 @@
-# Domain Model
+# Domain model
 
 Ubiquitous language for Ubuntu Pro for WSL. This is a glossary — definitions only, no implementation
 details, no specs, no scratch-pad content. Keep entries sorted alphabetically.
 
 ---
 
-### Address File
+### Address file
 
 The file the *Windows Agent* writes under the *Public Directory* at every startup, holding its
 current gRPC listening address. Removed on clean shutdown, rewritten on every restart (which also
@@ -24,7 +24,7 @@ an empty payload resets to unconfigured — empty Pro token detaches, empty Land
 registration. Contrast with commands a *Landscape* server sends to the *Landscape Host Agent*, a
 separate channel.
 
-### Configuration Source
+### Configuration source
 
 The provenance of a configuration parameter (*Pro Token* or *Landscape* client configuration): *User*
 (manual GUI input), *Microsoft Store* (a *Microsoft Store subscription* purchase), or *Organization*
@@ -32,7 +32,7 @@ The provenance of a configuration parameter (*Pro Token* or *Landscape* client c
 Microsoft Store > User — and a lower-precedence source cannot replace an active higher-precedence
 value.
 
-### Contracts Server
+### Contracts server
 
 Canonical's hosted backend bridging Microsoft Store purchases to Ubuntu Pro. The *Windows Agent*
 calls it to obtain an ephemeral Azure AD token and validate a *Microsoft Store subscription*
@@ -46,7 +46,7 @@ type (Pro attachment, Landscape). The only channel between a distro instance and
 stream opens with a handshake carrying the instance's WSL name, binding all its streams to one
 identity.
 
-### Deferred Task
+### Deferred task
 
 A *Task* submitted without waking the distro instance: it waits until the instance next runs (e.g.
 its next connection) before executing.
@@ -63,7 +63,7 @@ The (name, GUID) pair uniquely identifying a distro instance. Name alone isn't s
 unregistering and re-registering under the same name — so the *Windows Agent* validates the stored
 GUID against the system and treats a mismatch as a different instance, invalidating the old entry.
 
-### Distro Database
+### Distro database
 
 The *Windows Agent*'s persisted registry of managed distro instances, held in the *Private
 Directory*. Each entry stores a *Distro identity* and configuration state, validated against the
@@ -127,20 +127,20 @@ Source* of a *Pro Token*: the purchase lives in Microsoft's systems and only yie
 the *Contracts Server* validates the entitlement. Not itself an Ubuntu Pro subscription — the
 purchase that, once validated, unlocks one.
 
-### Private Directory
+### Private directory
 
 The filesystem directory `%LocalAppData%\Ubuntu Pro` on the Windows host (virtualized when deployed
 via msix), accessed only by the *Windows Agent*. Holds its private state: config store, distro
 database, per-distro task queues, single-instance lock file. Contrast with the *Public Directory*,
 located for easy access from within distro instances.
 
-### Pro Token
+### Pro token
 
 An opaque credential from Canonical's Contracts API authorising a machine to access Ubuntu Pro
 services (ESM, FIPS, etc.). The *Windows Agent* holds the active token and instructs each distro
 instance's *Ubuntu Pro client* to attach with it.
 
-### Public Directory
+### Public directory
 
 The filesystem directory `%UserProfile%\.ubuntupro` on the Windows host: the trust boundary across
 which the Windows Agent (sole legitimate author) writes files consumed by the root-privileged
@@ -156,7 +156,7 @@ An RPC whose direction is inverted relative to the connection: the party that ac
 *wsl-pro-service*, gRPC client) executes it and returns the result on the same bidirectional stream.
 How commands reach a distro instance over its *control stream*.
 
-### Secure Projection
+### Secure projection
 
 The property of a node under the *Public Directory* whereby the WSL 9P server translates its NT
 Extended Attributes (`$LXUID`, `$LXGID`, `$LXMOD`) into Linux-visible ownership/mode, appearing
@@ -206,7 +206,7 @@ token (vended by the *Contracts Server*) to an anonymous hash of the local Windo
 Agent* sends it to the Contracts Server, which queries Microsoft about the user's purchases on the
 app's behalf. Neither a *Pro Token* nor a user credential.
 
-### Windows Agent
+### Windows agent
 
 The `ubuntu-pro-agent.exe` process on the Windows host, running with user privileges: the system's
 orchestrator. Reads configuration from the registry and its *Private Directory*, manages the

--- a/docs/internal/go-standards.md
+++ b/docs/internal/go-standards.md
@@ -20,6 +20,8 @@
 - At a given layer, either log an error or return it with context. Avoid duplicating the same failure message in both places unless each layer adds distinct operational value.
 - Keep empty lines separating logical blocks, making lines closely related standing out as a group.
 
+### Example of good code style
+
 ```go
 // normalizeLandscapeConfig ensures that the landscape config has the expected computer_title and SSL certificate path
 // transformed in a Linux path.

--- a/docs/internal/go-standards.md
+++ b/docs/internal/go-standards.md
@@ -74,7 +74,9 @@ func normalizeLandscapeConfig(ctx context.Context, s *System, iniFile *ini.File)
 - Use lowercase error messages without trailing punctuation.
 - Avoid exporting foreign implementation details by default. Expose them only when callers have a concrete need to branch on them.
 - Do not automatically return sentinel errors from underlying libraries, unless the caller is expected to match them. Use `fmt.Errorf("<message>: %v", err)` instead.
-
+ 
+ ### Example of good error handling
+ 
 ```go
 // ProStatus returns whether this distro is pro-attached.
 func (s System) ProStatus(ctx context.Context) (attached bool, err error) {
@@ -111,6 +113,7 @@ func (s System) ProStatus(ctx context.Context) (attached bool, err error) {
 - Update golden files intentionally with `TESTS_UPDATE_GOLDEN=yes`, then commit the updated golden artifacts in the same PR.
 - Prefer explicit, stable assertions over ad hoc string-contains checks.
 
+### Example of good test
 
 ```go
 tests := map[string]struct {

--- a/docs/internal/go-standards.md
+++ b/docs/internal/go-standards.md
@@ -1,0 +1,155 @@
+# Coding Standards for Go
+
+## Style guide
+
+- Prefer small, explicit functions over clever abstractions.
+- Document exported symbols with complete sentences, starting with its name.
+- Validate required inputs and dependencies early, then return immediately on invalid state.
+- Strive for making invalid states non-representable to avoid spreading validation everywhere.
+- Keep control flow flat: prefer guard clauses and early returns over nested `else` blocks.
+- Keep exported APIs narrow, beware of Hyrum's Law.
+- Do not widen visibility just to satisfy tests; use the existing `export_test.go` pattern instead.
+- Prefer descriptive names over abbreviations, except for well-known abbreviations (`URL`, `JSON`, `HTTP`) and conventional short receiver names.
+- Short variable names are preferred when their scope is small and obvious.
+- Keep constructors and options pragmatic:
+  - Use a constructor when required dependencies or invariants must be enforced.
+  - Do not introduce option plumbing for a type that can be configured more clearly with direct fields or simple arguments.
+- Prefer package-level sentinel errors only for conditions callers need to branch on.
+- Keep comments for non-obvious invariants, edge cases, or intent; avoid comments that restate the code.
+- Avoid unnecessary helper extraction. A short local block is usually better than a helper that obscures the main path.
+- At a given layer, either log an error or return it with context. Avoid duplicating the same failure message in both places unless each layer adds distinct operational value.
+- Keep empty lines separating logical blocks, making lines closely related standing out as a group.
+
+```go
+// normalizeLandscapeConfig ensures that the landscape config has the expected computer_title and SSL certificate path
+// transformed in a Linux path.
+func normalizeLandscapeConfig(ctx context.Context, s *System, iniFile *ini.File) (modifiedLandscapeConfig string, didChange bool, err error) {
+	clientSection, err := iniFile.GetSection("client")
+	if err != nil {
+		return "", false, err
+	}
+
+	// Add or refresh computer title
+	distroName, err := s.WslDistroName(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	titleChanged := false
+	oldComputerTitle, err := clientSection.GetKey("computer_title")
+	if err != nil {
+		if _, err = clientSection.NewKey("computer_title", distroName); err != nil {
+			return "", false, err
+		}
+		titleChanged = true
+	} else if oldComputerTitle.String() != distroName {
+		oldComputerTitle.SetValue(distroName)
+		titleChanged = true
+	}
+
+	// Refresh SSL certificate path if any
+	certChanged, err := overrideSSLCertificate(ctx, s, clientSection)
+	if err != nil {
+		return "", false, fmt.Errorf("could not override SSL certificate path: %v", err)
+	}
+
+	// Return the modified config as a string.
+	w := &bytes.Buffer{}
+	if _, err := iniFile.WriteTo(w); err != nil {
+		return "", false, fmt.Errorf("could not regenerate modified config: %v", err)
+	}
+
+	didChange = titleChanged || certChanged
+	return w.String(), didChange, nil
+}
+```
+
+## Error handling
+
+- Use `decoreate.OnError` to add context to errors returned from functions at a single location.
+- Prefer `errors.New` for static sentinel errors and declare them as `var ErrSomething = errors.New("...")`.
+- Use `%w` only when callers are expected to match the underlying error later with `errors.Is` or `errors.As`.
+- If the underlying error is only being included for human consumption, use `%v` instead of `%w`.
+- Prefer one meaningful layer of context at the abstraction boundary that changes what the operation means to the caller.
+- When a caller needs to match a domain-specific condition and still retain extra detail, prefer `errors.Join` with a sentinel error.
+- Use lowercase error messages without trailing punctuation.
+- Avoid exporting foreign implementation details by default. Expose them only when callers have a concrete need to branch on them.
+- Do not automatically return sentinel errors from underlying libraries, unless the caller is expected to match them. Use `fmt.Errorf("<message>: %v", err)` instead.
+
+```go
+// ProStatus returns whether this distro is pro-attached.
+func (s System) ProStatus(ctx context.Context) (attached bool, err error) {
+	defer decorate.OnError(&err, "pro status")
+
+	cmd := s.backend.ProExecutable(ctx, "status", "--format=json")
+	out, err := runCommand(cmd)
+	if err != nil {
+		return false, err
+	}
+
+	var attachedStatus struct {
+		Attached bool
+	}
+	if err = json.Unmarshal(out, &attachedStatus); err != nil {
+		return false, fmt.Errorf("could not parse output: %v. Output: %s", err, string(out))
+	}
+
+	return attachedStatus.Attached, nil
+}
+```
+
+## Testing
+
+- Prefer table-driven tests keyed by name in a map/dict (`map[string]struct{...}`), iterated as `for name, tc := range tests { ... }`.
+- Use sub-tests for each case: `t.Run(name, func(t *testing.T) { ... })` 
+- Strive to call `t.Parallel()` inside the sub-tests, comment in the test if parallelization is not possible.
+- Keep test cases deterministic and self-contained; avoid hidden shared mutable state between cases.
+- Prefix assertion messages with "Setup: " when a setup step fails before the actual test assertion.
+- Use golden files when expected output is large, structured, or hard to maintain inline.
+- Use shared helpers from `common/testutils/golden.go`:
+  - `LoadWithUpdateFromGolden` for plain text expectations.
+  - `LoadWithUpdateFromGoldenYAML` for structured/YAML expectations.
+- Update golden files intentionally with `TESTS_UPDATE_GOLDEN=yes`, then commit the updated golden artifacts in the same PR.
+- Prefer explicit, stable assertions over ad hoc string-contains checks.
+
+
+```go
+tests := map[string]struct {
+    input string
+    want  string
+}{
+    "simple case": {input: "x", want: "y"},
+}
+
+for name, tc := range tests {
+    t.Run(name, func(t *testing.T) {
+        got := run(tc.input)
+        want := testutils.LoadWithUpdateFromGolden(t, got)
+        require.Equal(t, want, got)
+    })
+}
+```
+
+## Linting
+
+The project uses `golangci-lint` with config at `.golangci.yaml` in the repo root. Run it as:
+
+```
+golangci-lint run <module>/... --fix
+```
+
+Where `<module>` is the Go module directory being changed (e.g. `windows-agent`, `common`,
+`wsl-pro-service`). All findings must be resolved before committing — a lint error is as blocking
+as a failing test.
+
+Key rules to know before writing code:
+
+- `ioutil.*` is forbidden — use `os` or `io` equivalents (`forbidigo`).
+- Bare `print`/`println` are forbidden — use the project logger (`forbidigo`).
+- All exported symbols must have doc comments ending with a period (`godot`).
+- Error type names must end in `Error` or implement `error` as `*T` (`errname`).
+- Use `%w` only when callers will match with `errors.Is`/`errors.As`; use `%v` otherwise (`errorlint`).
+- Test helpers must call `t.Helper()` (`thelper`).
+- Parallel sub-tests must call `t.Parallel()` (`tparallel`).
+- Use the correct `testify` assertion variant (`testifylint`).
+- Never use naked type assertions — always check the `ok` form or use a type switch (`forcetypeassert`).
+


### PR DESCRIPTION
I'm trying to be generic about the harness in use, thus not relying on some GH Copilot specific features (I myself don't use it as my main harness).

`AGENTS.md` is written as a general map that helps code base exploration and maybe even avoid it at times. Also helps pointing to the files at the `docs/internal` subfolder and instruct agents to keep those current. There we define some documentation useful not only to AI coding agents but also to human contributors that may need clarification about a term used in the project or surprised about some design decision:

- `domain.md` - a glossary for the project ubiquitous language, terms frequently used in the codebase (shouldn't overlap with glossary present in the docs website, which only concerns with user-facing concepts) and concepts perhaps mentioned in comments but not immediately clear without extra context.
- `adr.md` - Architectural Decision Records, capturing important decisions taken due a real tradeoff, or facts about the architecture and design that are surprising without context or truly hard to revert. Contributors should be aware of those decisions to either avoid conflicting with them or to bring complete solutions when deciding to break free from them.
- coding standards - I'm focusing on Go for now. I'll bring more as needed, before implementing future PRs using other languages.

This documentation is not meant to be rendered in the docs website because it's too specific for developers that want a deeper understanding of the project and avoid contributions that would conflict with those terms, thus added to the RtD config `exclude_patterns` key.

This is a non-trivial codebase with different moving parts. I hope this meta-documentation pays off the token input cost and constrain agents for more precision and consistency in their outputs. It's already being used to implement my next PR, thus I had to iterate over both at the same time managing understanding and guessing costs. The language is intentionally terse because it targets mostly LLMs and developers familiar with the principles but not as much with the specifics of this repository.


UDENG-11051
