### PR TITLE
maint(common): Redesign the shared certificate package around an ephemeral PKI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
+# GCI is very picky when a Windows checkout puts some CRLF pairs in the Go files
+*.go text eol=lf
+
 # Declare files that will always have CRLF line endings on checkout.
 *.appxmanifest text eol=crlf
 *.props text eol=crlf

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,6 +70,9 @@ linters:
        # SA4009 (argument homedir is overwritten before first use) gives false positives
       - path: (.+)\.go$
         text: SA4009
+      # mTLS uses TLS 1.2 intentionally to support Windows 10 hosts.
+      - path: '(common[\/]certs[\/](certs|certs_test)|wsl-pro-service[\/]internal[\/]daemon[\/]daemon|wsl-pro-service[\/]internal[\/]testutils[\/]mock_agent|windows-agent[\/]internal[\/]proservices[\/]proservices_test)\.go$'
+        text: G402
     paths:
       - third_party$
       - builtin$

--- a/common/certs/certs.go
+++ b/common/certs/certs.go
@@ -11,55 +11,82 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/ubuntu/decorate"
 )
 
-// Heavily inspired in:
-// - https://go.dev/src/crypto/tls/generate_cert.go
-// - https://github.com/grpc/grpc-go/blob/master/examples/features/encryption/mTLS
-// - and https://gist.github.com/annanay25/43e3846e21b30818d8dcd5f9987e852d.
+// PublishableFile represents a single certificate file that must be published to disk.
+type PublishableFile struct {
+	Name  string
+	Bytes []byte
+}
 
-// CreateRootCA creates a new root certificate authority (CA) certificate and private key pair with the common name provided.
-// Only the cert is written into destDir in the PEM format. Being a CA, the certificate and private key returned can be used to sign other certificates.
-func CreateRootCA(commonName string, destDir string) (rootCert *x509.Certificate, rootKey *ecdsa.PrivateKey, err error) {
-	// generate a new key-pair for the root certificate based on the P256 elliptic curve
-	rootKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// PKI represents an ephemeral Public Key Infrastructure instance.
+type PKI struct {
+	AgentTLSConfig *tls.Config
+	Publishable    [3]PublishableFile
+}
+
+// GenerateEphemeralPKI creates a self-signed root CA authority, agent identity, and shared client identity.
+// It returns a PKI holding the agent's TLS config (in memory) and the publishable byte streams for clients.
+func GenerateEphemeralPKI() (pki PKI, err error) {
+	defer decorate.OnError(&err, "could not generate ephemeral PKI:")
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate random key: %v", err)
+		return PKI{}, fmt.Errorf("failed to generate CA key: %v", err)
 	}
 
-	rootCertTmpl := template(commonName)
+	rootCertTmpl := template(common.GRPCServerNameOverride)
 	rootCertTmpl.IsCA = true
-	rootCertTmpl.Subject.CommonName = commonName + " CA"
+	rootCertTmpl.Subject.CommonName = common.GRPCServerNameOverride + " CA"
 	rootCertTmpl.KeyUsage = x509.KeyUsageCertSign
 
 	// We pass the template as the parent as well so that the certificate is self-signed.
 	rootCert, rootDER, err := createCert(rootCertTmpl, rootCertTmpl, &rootKey.PublicKey, rootKey)
 	if err != nil {
-		return nil, nil, err
+		return PKI{}, fmt.Errorf("failed to create root CA cert: %v", err)
 	}
 
-	// Write the CA certificate to disk.
-	// Notice that we don't write the private key to disk. Only the caller of this function can create other certificates signed by this root CA.
-	if err = writeCert(filepath.Join(destDir, common.RootCACertFileName), rootDER); err != nil {
-		return nil, nil, err
+	agentTLS, err := createIdentity(common.AgentCertFilePrefix, common.GRPCServerNameOverride, rootCert, rootKey)
+	if err != nil {
+		return PKI{}, fmt.Errorf("failed to create agent certificate: %v", err)
 	}
 
-	return rootCert, rootKey, nil
+	clientCertDER, clientKeyPEM, err := createClientIdentity(common.GRPCServerNameOverride, rootCert, rootKey)
+	if err != nil {
+		return PKI{}, fmt.Errorf("failed to create client certificate: %v", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AddCert(rootCert)
+
+	agentTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{*agentTLS},
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	return PKI{
+		AgentTLSConfig: agentTLSConfig,
+		Publishable: [3]PublishableFile{
+			{Name: common.RootCACertFileName, Bytes: caPEM},
+			{Name: common.ClientsCertFilePrefix + common.CertificateSuffix, Bytes: clientCertPEM},
+			{Name: common.ClientsCertFilePrefix + common.KeySuffix, Bytes: clientKeyPEM},
+		},
+	}, nil
 }
 
-// CreateTLSCertificateSignedBy creates a certificate and key pair usable for authentication signed by the root certificate authority (root CA) certificate and key provided and write them into destDir in the PEM format.
-func CreateTLSCertificateSignedBy(name, certCN string, rootCACert *x509.Certificate, rootCAKey *ecdsa.PrivateKey, destDir string) (tlsCert *tls.Certificate, err error) {
-	defer decorate.OnError(&err, "could not create root signed certificate pair for %s:", name)
-
+func createIdentity(name, certCN string, rootCACert *x509.Certificate, rootCAKey *ecdsa.PrivateKey) (*tls.Certificate, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate random key: %v", err)
+		return nil, fmt.Errorf("failed to generate key for %s: %v", name, err)
 	}
 
 	certTmpl := template(certCN)
@@ -82,18 +109,42 @@ func CreateTLSCertificateSignedBy(name, certCN string, rootCACert *x509.Certific
 		return nil, fmt.Errorf("certificate verification failed: %v", err)
 	}
 
-	if err = writeCert(filepath.Join(destDir, name+common.CertificateSuffix), der); err != nil {
-		return nil, err
-	}
-	if err = writeKey(filepath.Join(destDir, name+common.KeySuffix), key); err != nil {
-		return nil, err
-	}
-
 	return &tls.Certificate{
 		Certificate: [][]byte{der},
 		PrivateKey:  key,
 		Leaf:        cert,
 	}, nil
+}
+
+func createClientIdentity(certCN string, rootCACert *x509.Certificate, rootCAKey *ecdsa.PrivateKey) (der []byte, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate key for client: %v", err)
+	}
+
+	certTmpl := template(certCN)
+	certTmpl.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment
+	certTmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	certTmpl.AuthorityKeyId = rootCACert.SubjectKeyId
+
+	cert, der, err := createCert(certTmpl, rootCACert, &key.PublicKey, rootCAKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AddCert(rootCACert)
+	if _, err = cert.Verify(x509.VerifyOptions{Roots: caCertPool}); err != nil {
+		return nil, nil, fmt.Errorf("certificate verification failed: %v", err)
+	}
+
+	pkcs8Key, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal client key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8Key})
+
+	return der, keyPEM, nil
 }
 
 // createCert invokes x509.CreateCertificate and returns the certificate and it's DER as bytes for serialization.
@@ -107,7 +158,6 @@ func createCert(template, parent *x509.Certificate, pub, parentPriv any) (cert *
 
 	// parse the resulting certificate so we can use it again
 	cert, err = x509.ParseCertificate(certDER)
-
 	return cert, certDER, err
 }
 
@@ -121,31 +171,4 @@ func template(commonName string) *x509.Certificate {
 		NotAfter:              time.Now().Add(time.Hour * 24 * 30), // arbitrarily chosen expiration in a month
 		BasicConstraintsValid: true,
 	}
-}
-
-// writeCert writes a certificate to disk in PEM format to the given filename.
-func writeCert(filename string, DER []byte) error {
-	w, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to open %q for writing: %v", filename, err)
-	}
-	defer w.Close()
-
-	return pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: DER})
-}
-
-// writeKey writes a private key to disk in PEM format to the given filename.
-func writeKey(filename string, priv *ecdsa.PrivateKey) error {
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open %q for writing: %v", filename, err)
-	}
-	defer w.Close()
-
-	p, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err != nil {
-		return fmt.Errorf("failed to marshal private key: %v", err)
-	}
-
-	return pem.Encode(w, &pem.Block{Type: "PRIVATE KEY", Bytes: p})
 }

--- a/common/certs/certs.go
+++ b/common/certs/certs.go
@@ -29,12 +29,15 @@ type PKI struct {
 	Publishable    [3]PublishableFile
 }
 
+// generateKey is assigned to a package-level variable so tests can simulate key generation failures.
+var generateKey = ecdsa.GenerateKey
+
 // GenerateEphemeralPKI creates a self-signed root CA authority, agent identity, and shared client identity.
 // It returns a PKI holding the agent's TLS config (in memory) and the publishable byte streams for clients.
 func GenerateEphemeralPKI() (pki PKI, err error) {
 	defer decorate.OnError(&err, "could not generate ephemeral PKI:")
 
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	rootKey, err := generateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return PKI{}, fmt.Errorf("failed to generate CA key: %v", err)
 	}
@@ -84,7 +87,7 @@ func GenerateEphemeralPKI() (pki PKI, err error) {
 }
 
 func createIdentity(name, certCN string, rootCACert *x509.Certificate, rootCAKey *ecdsa.PrivateKey) (*tls.Certificate, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := generateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key for %s: %v", name, err)
 	}
@@ -117,7 +120,7 @@ func createIdentity(name, certCN string, rootCACert *x509.Certificate, rootCAKey
 }
 
 func createClientIdentity(certCN string, rootCACert *x509.Certificate, rootCAKey *ecdsa.PrivateKey) (der []byte, keyPEM []byte, err error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := generateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate key for client: %v", err)
 	}

--- a/common/certs/certs.go
+++ b/common/certs/certs.go
@@ -23,7 +23,8 @@ type PublishableFile struct {
 	Bytes []byte
 }
 
-// PKI represents an ephemeral Public Key Infrastructure instance.
+// PKI represents an ephemeral Public Key Infrastructure instance. Consume the bits you need at
+// startup and drop it.
 type PKI struct {
 	AgentTLSConfig *tls.Config
 	Publishable    [3]PublishableFile

--- a/common/certs/certs.go
+++ b/common/certs/certs.go
@@ -23,17 +23,11 @@ import (
 // same minimum on both sides to avoid handshake surprises.
 const MinTLSVersion = tls.VersionTLS12
 
-// PublishableFile represents a single certificate file that must be published to disk.
-type PublishableFile struct {
-	Name  string
-	Bytes []byte
-}
-
 // PKI represents an ephemeral Public Key Infrastructure instance. Consume the bits you need at
 // startup and drop it.
 type PKI struct {
 	AgentTLSConfig *tls.Config
-	Publishable    [3]PublishableFile
+	PEMFiles       map[string][]byte
 }
 
 // generateKey is assigned to a package-level variable so tests can simulate key generation failures.
@@ -88,10 +82,10 @@ func GenerateEphemeralPKI() (pki PKI, err error) {
 
 	return PKI{
 		AgentTLSConfig: agentTLSConfig,
-		Publishable: [3]PublishableFile{
-			{Name: common.RootCACertFileName, Bytes: caPEM},
-			{Name: common.ClientsCertFilePrefix + common.CertificateSuffix, Bytes: clientCertPEM},
-			{Name: common.ClientsCertFilePrefix + common.KeySuffix, Bytes: clientKeyPEM},
+		PEMFiles: map[string][]byte{
+			common.RootCACertFileName:                               caPEM,
+			common.ClientsCertFilePrefix + common.CertificateSuffix: clientCertPEM,
+			common.ClientsCertFilePrefix + common.KeySuffix:         clientKeyPEM,
 		},
 	}, nil
 }

--- a/common/certs/certs.go
+++ b/common/certs/certs.go
@@ -17,6 +17,12 @@ import (
 	"github.com/ubuntu/decorate"
 )
 
+// MinTLSVersion is the minimum TLS version used for the PKI-generated mTLS connections.
+//
+// We pin TLS 1.2 rather than 1.3 because the mTLS channel must work on Windows 10 hosts. We keep the
+// same minimum on both sides to avoid handshake surprises.
+const MinTLSVersion = tls.VersionTLS12
+
 // PublishableFile represents a single certificate file that must be published to disk.
 type PublishableFile struct {
 	Name  string
@@ -35,6 +41,9 @@ var generateKey = ecdsa.GenerateKey
 
 // GenerateEphemeralPKI creates a self-signed root CA authority, agent identity, and shared client identity.
 // It returns a PKI holding the agent's TLS config (in memory) and the publishable byte streams for clients.
+//
+// We use ECDSA P-256 rather than Ed25519 because Flutter's BoringSSL-based TLS stack does not support
+// Ed25519 certificates when the connection is constrained to TLS 1.2.
 func GenerateEphemeralPKI() (pki PKI, err error) {
 	defer decorate.OnError(&err, "could not generate ephemeral PKI:")
 
@@ -74,7 +83,7 @@ func GenerateEphemeralPKI() (pki PKI, err error) {
 		Certificates: []tls.Certificate{*agentTLS},
 		ClientCAs:    caCertPool,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   MinTLSVersion,
 	}
 
 	return PKI{

--- a/common/certs/certs_test.go
+++ b/common/certs/certs_test.go
@@ -17,19 +17,17 @@ func TestGenerateEphemeralPKI(t *testing.T) {
 	require.NoError(t, err, "GenerateEphemeralPKI failed")
 	require.NotNil(t, pki.AgentTLSConfig, "AgentTLSConfig should not be nil")
 
-	// Verify publishable set names exactly the three files: ca_cert.pem, client_cert.pem, client_key.pem
-	expectedFiles := [3]string{
-		common.RootCACertFileName,
-		common.ClientsCertFilePrefix + common.CertificateSuffix,
-		common.ClientsCertFilePrefix + common.KeySuffix,
+	// Verify publishable set contains exactly the three expected files.
+	expectedFiles := map[string]struct{}{
+		common.RootCACertFileName:                               {},
+		common.ClientsCertFilePrefix + common.CertificateSuffix: {},
+		common.ClientsCertFilePrefix + common.KeySuffix:         {},
 	}
 
-	require.Equal(t, expectedFiles[0], pki.Publishable[0].Name, "First publishable file should be CA cert")
-	require.Equal(t, expectedFiles[1], pki.Publishable[1].Name, "Second publishable file should be client cert")
-	require.Equal(t, expectedFiles[2], pki.Publishable[2].Name, "Third publishable file should be client key")
-
-	for i := range 3 {
-		require.NotEmpty(t, pki.Publishable[i].Bytes, "Publishable file %s should not be empty", pki.Publishable[i].Name)
+	require.Len(t, pki.PEMFiles, len(expectedFiles), "PEMFiles should contain exactly %d files", len(expectedFiles))
+	for name := range expectedFiles {
+		require.Contains(t, pki.PEMFiles, name, "PEMFiles should contain %s", name)
+		require.NotEmpty(t, pki.PEMFiles[name], "PEM file %s should not be empty", name)
 	}
 }
 
@@ -42,11 +40,14 @@ func TestHandshake(t *testing.T) {
 	pki2, err := certs.GenerateEphemeralPKI()
 	require.NoError(t, err)
 
-	clientCert1, err := tls.X509KeyPair(pki1.Publishable[1].Bytes, pki1.Publishable[2].Bytes)
+	clientCert1, err := tls.X509KeyPair(
+		pki1.PEMFiles[common.ClientsCertFilePrefix+common.CertificateSuffix],
+		pki1.PEMFiles[common.ClientsCertFilePrefix+common.KeySuffix],
+	)
 	require.NoError(t, err)
 
 	caPool1 := x509.NewCertPool()
-	require.True(t, caPool1.AppendCertsFromPEM(pki1.Publishable[0].Bytes))
+	require.True(t, caPool1.AppendCertsFromPEM(pki1.PEMFiles[common.RootCACertFileName]))
 
 	clientTLSConfig1 := &tls.Config{
 		Certificates: []tls.Certificate{clientCert1},
@@ -55,11 +56,14 @@ func TestHandshake(t *testing.T) {
 		MinVersion:   certs.MinTLSVersion,
 	}
 
-	clientCert2, err := tls.X509KeyPair(pki2.Publishable[1].Bytes, pki2.Publishable[2].Bytes)
+	clientCert2, err := tls.X509KeyPair(
+		pki2.PEMFiles[common.ClientsCertFilePrefix+common.CertificateSuffix],
+		pki2.PEMFiles[common.ClientsCertFilePrefix+common.KeySuffix],
+	)
 	require.NoError(t, err)
 
 	caPool2 := x509.NewCertPool()
-	require.True(t, caPool2.AppendCertsFromPEM(pki2.Publishable[0].Bytes))
+	require.True(t, caPool2.AppendCertsFromPEM(pki2.PEMFiles[common.RootCACertFileName]))
 
 	clientTLSConfig2 := &tls.Config{
 		Certificates: []tls.Certificate{clientCert2},
@@ -86,8 +90,7 @@ func TestHandshake(t *testing.T) {
 			done <- nil
 			return
 		}
-		err = tlsConn.Handshake()
-		done <- err
+		done <- tlsConn.Handshake()
 	}()
 
 	// Connect with matching client (pki1) -> success
@@ -112,8 +115,7 @@ func TestHandshake(t *testing.T) {
 			done <- nil
 			return
 		}
-		err = tlsConn.Handshake()
-		done <- err
+		done <- tlsConn.Handshake()
 	}()
 
 	conn2, err := tls.Dial("tcp", listener.Addr().String(), clientTLSConfig2)

--- a/common/certs/certs_test.go
+++ b/common/certs/certs_test.go
@@ -1,8 +1,8 @@
 package certs_test
 
 import (
-	"os"
-	"path/filepath"
+	"crypto/tls"
+	"crypto/x509"
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
@@ -10,94 +10,120 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateRooCA(t *testing.T) {
+func TestGenerateEphemeralPKI(t *testing.T) {
 	t.Parallel()
 
-	testcases := map[string]struct {
-		breakCertPem bool
+	pki, err := certs.GenerateEphemeralPKI()
+	require.NoError(t, err, "GenerateEphemeralPKI failed")
+	require.NotNil(t, pki.AgentTLSConfig, "AgentTLSConfig should not be nil")
 
-		wantErr bool
-	}{
-		"Success": {},
-
-		"Error when the root CA certificate file cannot be written": {breakCertPem: true, wantErr: true},
+	// Verify publishable set names exactly the three files: ca_cert.pem, client_cert.pem, client_key.pem
+	expectedFiles := [3]string{
+		common.RootCACertFileName,
+		common.ClientsCertFilePrefix + common.CertificateSuffix,
+		common.ClientsCertFilePrefix + common.KeySuffix,
 	}
 
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+	require.Equal(t, expectedFiles[0], pki.Publishable[0].Name, "First publishable file should be CA cert")
+	require.Equal(t, expectedFiles[1], pki.Publishable[1].Name, "Second publishable file should be client cert")
+	require.Equal(t, expectedFiles[2], pki.Publishable[2].Name, "Third publishable file should be client key")
 
-			dir := t.TempDir()
-
-			if tc.breakCertPem {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, common.RootCACertFileName), 0700), "Setup: failed to create a directory that should break cert.pem")
-			}
-
-			rootCert, rootKey, err := certs.CreateRootCA("test-root-ca", dir)
-
-			if tc.wantErr {
-				require.Error(t, err, "CreateRootCA should have failed")
-				return
-			}
-			require.NoError(t, err, "CreateRootCA failed")
-			require.NotNil(t, rootCert, "CreateRootCA didn't return a certificate")
-			require.NotNil(t, rootKey, "CreateRootCA didn't return a private key")
-			require.FileExists(t, filepath.Join(dir, common.RootCACertFileName), "CreateRootCA failed to write the certificate to disk")
-		})
+	for i := range 3 {
+		require.NotEmpty(t, pki.Publishable[i].Bytes, "Publishable file %s should not be empty", pki.Publishable[i].Name)
 	}
 }
 
-func TestCreateTLSCertificateSignedBy(t *testing.T) {
+func TestHandshake(t *testing.T) {
 	t.Parallel()
 
-	testcases := map[string]struct {
-		rootIsNotCA  bool
-		breakCertPem bool
-		breakKeyPem  bool
+	pki1, err := certs.GenerateEphemeralPKI()
+	require.NoError(t, err)
 
-		wantErr bool
-	}{
-		"Success": {},
+	pki2, err := certs.GenerateEphemeralPKI()
+	require.NoError(t, err)
 
-		"Error when the signing certificate is not an authority": {rootIsNotCA: true, wantErr: true},
-		"Error when the cert.pem file cannot be written":         {breakCertPem: true, wantErr: true},
-		"Error when the key.pem file cannot be written":          {breakKeyPem: true, wantErr: true},
+	clientCert1, err := tls.X509KeyPair(pki1.Publishable[1].Bytes, pki1.Publishable[2].Bytes)
+	require.NoError(t, err)
+
+	caPool1 := x509.NewCertPool()
+	require.True(t, caPool1.AppendCertsFromPEM(pki1.Publishable[0].Bytes))
+
+	clientTLSConfig1 := &tls.Config{
+		Certificates: []tls.Certificate{clientCert1},
+		RootCAs:      caPool1,
+		ServerName:   common.GRPCServerNameOverride,
+		MinVersion:   tls.VersionTLS13,
 	}
 
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+	clientCert2, err := tls.X509KeyPair(pki2.Publishable[1].Bytes, pki2.Publishable[2].Bytes)
+	require.NoError(t, err)
 
-			rootCert, rootKey, err := certs.CreateRootCA("test-root-ca", t.TempDir())
-			require.NoError(t, err, "Setup: failed to generate root CA cert")
-			if tc.rootIsNotCA {
-				rootCert.IsCA = false
-				rootCert.AuthorityKeyId = nil
-			}
+	caPool2 := x509.NewCertPool()
+	require.True(t, caPool2.AppendCertsFromPEM(pki2.Publishable[0].Bytes))
 
-			dir := t.TempDir()
-
-			agentCertName := common.AgentCertFilePrefix + common.CertificateSuffix
-			agentKeyName := common.AgentCertFilePrefix + common.KeySuffix
-
-			if tc.breakCertPem {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, agentCertName), 0700), "Setup: failed to create a directory that should break cert.pem")
-			}
-
-			if tc.breakKeyPem {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, agentKeyName), 0700), "Setup: failed to create a directory that should break key.pem")
-			}
-
-			tlsCert, err := certs.CreateTLSCertificateSignedBy(common.AgentCertFilePrefix, "test-server-cn", rootCert, rootKey, dir)
-
-			if tc.wantErr {
-				require.Error(t, err, "CreateTLSCertificateSignedBy should have failed")
-				return
-			}
-			require.NoError(t, err, "CreateTLSCertificateSignedBy failed")
-			require.NotNil(t, tlsCert, "CreateTLSCertificateSignedBy returned a nil certificate")
-			require.FileExists(t, filepath.Join(dir, agentCertName), "CreateTLSCertificateSignedBy failed to write the certificate")
-			require.FileExists(t, filepath.Join(dir, agentKeyName), "CreateTLSCertificateSignedBy failed to write the certificate")
-		})
+	clientTLSConfig2 := &tls.Config{
+		Certificates: []tls.Certificate{clientCert2},
+		RootCAs:      caPool2,
+		ServerName:   common.GRPCServerNameOverride,
+		MinVersion:   tls.VersionTLS13,
 	}
+
+	// Start listener with pki1's AgentTLSConfig
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", pki1.AgentTLSConfig)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			done <- nil
+			return
+		}
+		err = tlsConn.Handshake()
+		done <- err
+	}()
+
+	// Connect with matching client (pki1) -> success
+	conn, err := tls.Dial("tcp", listener.Addr().String(), clientTLSConfig1)
+	require.NoError(t, err)
+	require.NoError(t, conn.Handshake())
+	conn.Close()
+
+	serverErr := <-done
+	require.NoError(t, serverErr)
+
+	// Now try connecting with a client from a different PKI (pki2) -> rejected
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			done <- nil
+			return
+		}
+		err = tlsConn.Handshake()
+		done <- err
+	}()
+
+	conn2, err := tls.Dial("tcp", listener.Addr().String(), clientTLSConfig2)
+	if err == nil {
+		err = conn2.Handshake()
+		conn2.Close()
+		require.Error(t, err, "Client from different PKI should fail handshake")
+	} else {
+		require.Error(t, err, "Dial with different PKI client should fail")
+	}
+
+	<-done // accept routine finished
 }

--- a/common/certs/certs_test.go
+++ b/common/certs/certs_test.go
@@ -52,7 +52,7 @@ func TestHandshake(t *testing.T) {
 		Certificates: []tls.Certificate{clientCert1},
 		RootCAs:      caPool1,
 		ServerName:   common.GRPCServerNameOverride,
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   certs.MinTLSVersion,
 	}
 
 	clientCert2, err := tls.X509KeyPair(pki2.Publishable[1].Bytes, pki2.Publishable[2].Bytes)
@@ -65,7 +65,7 @@ func TestHandshake(t *testing.T) {
 		Certificates: []tls.Certificate{clientCert2},
 		RootCAs:      caPool2,
 		ServerName:   common.GRPCServerNameOverride,
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   certs.MinTLSVersion,
 	}
 
 	// Start listener with pki1's AgentTLSConfig

--- a/common/certs/internal_test.go
+++ b/common/certs/internal_test.go
@@ -1,0 +1,96 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRootCA returns a self-signed root certificate and its key. When isCA is
+// false the certificate is not a CA: it can still sign (so certificate creation
+// succeeds) but anything it signs must fail verification against it.
+func newTestRootCA(t *testing.T, isCA bool) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "Setup: could not generate the root key")
+
+	tmpl := template("test-root")
+	tmpl.IsCA = isCA
+	tmpl.KeyUsage = x509.KeyUsageCertSign
+	cert, _, err = createCert(tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err, "Setup: could not create the root certificate")
+
+	return cert, key
+}
+
+// stubGenerateKey replaces the generateKey seam with a generator that fails on the
+// n-th invocation, returning a function that restores the original behaviour.
+// Tests using it must not be marked parallel: the seam is package-global.
+func stubGenerateKey(failOnCall int) (restore func()) {
+	original := generateKey
+	calls := 0
+	generateKey = func(c elliptic.Curve, r io.Reader) (*ecdsa.PrivateKey, error) {
+		calls++
+		if calls == failOnCall {
+			return nil, errors.New("injected key generation failure")
+		}
+		return original(c, r)
+	}
+	return func() { generateKey = original }
+}
+
+func TestGenerateEphemeralPKIErrors(t *testing.T) {
+	// No t.Parallel: this test stubs the package-global generateKey seam.
+	testcases := map[string]struct {
+		failOnCall int
+	}{
+		"Error when the root CA key cannot be generated":         {failOnCall: 1},
+		"Error when the agent identity key cannot be generated":  {failOnCall: 2},
+		"Error when the client identity key cannot be generated": {failOnCall: 3},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			defer stubGenerateKey(tc.failOnCall)()
+
+			_, err := GenerateEphemeralPKI()
+			require.Error(t, err, "GenerateEphemeralPKI should have failed")
+		})
+	}
+}
+
+func TestIdentityCreationErrors(t *testing.T) {
+	t.Parallel()
+
+	rootCert, _ := newTestRootCA(t, true)
+	mismatchingKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "Setup: could not generate the mismatching key")
+	notCA, notCAKey := newTestRootCA(t, false)
+
+	testcases := map[string]struct {
+		cert *x509.Certificate
+		key  *ecdsa.PrivateKey
+	}{
+		"Error when the signing key does not match the root certificate": {cert: rootCert, key: mismatchingKey},
+		"Error when the root is not a CA":                                {cert: notCA, key: notCAKey},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := createIdentity("agent", "agent-cn", tc.cert, tc.key)
+			require.Error(t, err, "createIdentity should have failed")
+
+			_, _, err = createClientIdentity("client-cn", tc.cert, tc.key)
+			require.Error(t, err, "createClientIdentity should have failed")
+		})
+	}
+}

--- a/docs/internal/adr.md
+++ b/docs/internal/adr.md
@@ -152,9 +152,10 @@ Numbered sequentially, grouped by section. 'Who' and 'when' are captured by Git.
   local process could otherwise connect — and a public CA doesn't fit (no DNS name, dynamic addresses).
 * **Decision**: At every startup the agent generates a fresh self-signed root CA, an agent cert, and
   one client key pair shared by the GUI and all instances, written to the Public Directory under Secure
-  Projection. Both sides require/verify peer certs (TLS 1.3 min); certs expire after 30 days, rotating
-  naturally on restart; clients re-read material on every (re)connection and pin the fixed server name
-  "UP4W".
+  Projection. Both sides require/verify peer certs. We pin TLS 1.2 as the minimum version (Windows 10
+  compatibility) and use ECDSA P-256 certificates because Flutter's BoringSSL-based TLS stack does not
+  support Ed25519 certificates together with TLS 1.2. Certs expire after 30 days, rotating naturally on
+  restart; clients re-read material on every (re)connection and pin the fixed server name "UP4W".
 * **Consequences**:
   - Positive: No external PKI, zero user setup; compromise window bounded by process lifetime + cert
     expiry; reuses ADR-2.01 secure projection.

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 use (
 	./agentapi

--- a/windows-agent/internal/proservices/certs.go
+++ b/windows-agent/internal/proservices/certs.go
@@ -11,16 +11,32 @@ import (
 	"github.com/ubuntu/decorate"
 )
 
+// newTLSCertificatesOpts holds the configurable dependencies for newTLSCertificates.
+// It exists primarily so tests can inject failures without mutating global state.
+type newTLSCertificatesOpts struct {
+	generatePKI func() (certs.PKI, error)
+}
+
+// newTLSCertificatesOption configures newTLSCertificatesOpts.
+type newTLSCertificatesOption func(*newTLSCertificatesOpts)
+
 // newTLSCertificates creates a fresh ephemeral PKI and writes the publishable set
 // (root CA certificate, client certificate and client key) into the certificates
 // subdirectory of publicDir. Any stale files left over from a previous run or a
 // previous code version are removed first. The agent's own identity is held in
 // memory and returned as a TLS server config; nothing of the agent is ever
 // written to disk.
-func newTLSCertificates(publicDir string) (cfg *tls.Config, err error) {
+func newTLSCertificates(publicDir string, opts ...newTLSCertificatesOption) (cfg *tls.Config, err error) {
 	defer decorate.OnError(&err, "could not create TLS credentials:")
 
-	pki, err := certs.GenerateEphemeralPKI()
+	options := newTLSCertificatesOpts{
+		generatePKI: certs.GenerateEphemeralPKI,
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	pki, err := options.generatePKI()
 	if err != nil {
 		return nil, err
 	}

--- a/windows-agent/internal/proservices/certs.go
+++ b/windows-agent/internal/proservices/certs.go
@@ -13,8 +13,10 @@ import (
 
 // newTLSCertificates creates a fresh ephemeral PKI and writes the publishable set
 // (root CA certificate, client certificate and client key) into the certificates
-// subdirectory of publicDir. The agent's own identity is held in memory and returned
-// as a TLS server config; nothing of the agent is ever written to disk.
+// subdirectory of publicDir. Any stale files left over from a previous run or a
+// previous code version are removed first. The agent's own identity is held in
+// memory and returned as a TLS server config; nothing of the agent is ever
+// written to disk.
 func newTLSCertificates(publicDir string) (cfg *tls.Config, err error) {
 	defer decorate.OnError(&err, "could not create TLS credentials:")
 
@@ -24,6 +26,28 @@ func newTLSCertificates(publicDir string) (cfg *tls.Config, err error) {
 	}
 
 	destDir := filepath.Join(publicDir, common.CertificatesDir)
+
+	// Clean any stale certificate material from a previous run. We only remove
+	// the directory contents, not the directory itself, so that the
+	// "certificates dir cannot be created" error path (a file exists at the
+	// destination path) is preserved.
+	if info, err := os.Stat(destDir); err == nil && info.IsDir() {
+		entries, err := os.ReadDir(destDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificates directory: %v", err)
+		}
+		for _, entry := range entries {
+			// Leave directories untouched: a directory occupying the path of a
+			// file we need to write is a legitimate error condition we preserve.
+			if entry.IsDir() {
+				continue
+			}
+			if err := os.Remove(filepath.Join(destDir, entry.Name())); err != nil {
+				return nil, fmt.Errorf("failed to clean certificates directory: %v", err)
+			}
+		}
+	}
+
 	if err := os.MkdirAll(destDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create certificates directory: %v", err)
 	}

--- a/windows-agent/internal/proservices/certs.go
+++ b/windows-agent/internal/proservices/certs.go
@@ -28,9 +28,9 @@ func newTLSCertificates(publicDir string) (cfg *tls.Config, err error) {
 		return nil, fmt.Errorf("failed to create certificates directory: %v", err)
 	}
 
-	for _, f := range pki.Publishable {
-		if err := os.WriteFile(filepath.Join(destDir, f.Name), f.Bytes, 0600); err != nil {
-			return nil, fmt.Errorf("failed to write %s: %v", f.Name, err)
+	for name, data := range pki.PEMFiles {
+		if err := os.WriteFile(filepath.Join(destDir, name), data, 0600); err != nil {
+			return nil, fmt.Errorf("failed to write %s: %v", name, err)
 		}
 	}
 

--- a/windows-agent/internal/proservices/certs.go
+++ b/windows-agent/internal/proservices/certs.go
@@ -2,51 +2,37 @@ package proservices
 
 import (
 	"crypto/tls"
-	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/certs"
 	"github.com/ubuntu/decorate"
 )
 
-// newTLSCertificates creates a self-signed root CA, agent and clients certificates and writes them into destDir.
-func newTLSCertificates(destDir string) (c agentCerts, err error) {
+// newTLSCertificates creates a fresh ephemeral PKI and writes the publishable set
+// (root CA certificate, client certificate and client key) into the certificates
+// subdirectory of publicDir. The agent's own identity is held in memory and returned
+// as a TLS server config; nothing of the agent is ever written to disk.
+func newTLSCertificates(publicDir string) (cfg *tls.Config, err error) {
 	defer decorate.OnError(&err, "could not create TLS credentials:")
 
-	rootCert, rootKey, err := certs.CreateRootCA(common.GRPCServerNameOverride, destDir)
+	pki, err := certs.GenerateEphemeralPKI()
 	if err != nil {
-		return agentCerts{}, err
+		return nil, err
 	}
 
-	// Create and write the agent and clients certificates signed by the root certificate created above.
-	agentCert, err := certs.CreateTLSCertificateSignedBy(common.AgentCertFilePrefix, common.GRPCServerNameOverride, rootCert, rootKey, destDir)
-	if err != nil {
-		return agentCerts{}, err
-	}
-	// We won't store the TLS client certificate, because only the agent should access this function and it's not interested in the client TLS certificate.
-	// But we still need to write them to disk, so clients can construct their TLS configs from there.
-	_, err = certs.CreateTLSCertificateSignedBy(common.ClientsCertFilePrefix, common.GRPCServerNameOverride, rootCert, rootKey, destDir)
-	if err != nil {
-		return agentCerts{}, err
+	destDir := filepath.Join(publicDir, common.CertificatesDir)
+	if err := os.MkdirAll(destDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create certificates directory: %v", err)
 	}
 
-	return agentCerts{rootCA: rootCert, agentCert: *agentCert}, nil
-}
-
-// agentTLSConfig returns a TLS config for the agent that require and verify client certificates.
-func (c agentCerts) agentTLSConfig() *tls.Config {
-	ca := x509.NewCertPool()
-	ca.AddCert(c.rootCA)
-	return &tls.Config{
-		Certificates: []tls.Certificate{c.agentCert},
-		ClientCAs:    ca,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS13,
+	for _, f := range pki.Publishable {
+		if err := os.WriteFile(filepath.Join(destDir, f.Name), f.Bytes, 0600); err != nil {
+			return nil, fmt.Errorf("failed to write %s: %v", f.Name, err)
+		}
 	}
-}
 
-// agentCerts conveniently holds the root CA and the agent certificates to make it easy to create a TLS config.
-type agentCerts struct {
-	rootCA    *x509.Certificate
-	agentCert tls.Certificate
+	return pki.AgentTLSConfig, nil
 }

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -1,7 +1,6 @@
 package proservices
 
 import (
-	"crypto/rand"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/certs"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/config"
 	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/distros/distro"
 	"github.com/stretchr/testify/require"
@@ -142,22 +142,20 @@ func TestNewTLSCertificatesFilesystemFailures(t *testing.T) {
 	}
 }
 
-// failingReader is used to make x509.CreateCertificate fail while generating
-// certificates, exercising the error path in newTLSCertificates without
-// mocking it directly.
-type failingReader struct{}
-
-func (failingReader) Read(p []byte) (int, error) {
-	return 0, errors.New("injected random reader failure")
+// newTLSCertificatesWithFailingPKI is a newTLSCertificatesOption that makes PKI
+// generation fail, exercising the error path without mutating global state.
+func newTLSCertificatesWithFailingPKI() newTLSCertificatesOption {
+	return func(o *newTLSCertificatesOpts) {
+		o.generatePKI = func() (certs.PKI, error) {
+			return certs.PKI{}, errors.New("injected PKI failure")
+		}
+	}
 }
 
 func TestNewTLSCertificatesPKIFailure(t *testing.T) {
-	// Do not run in parallel: this test mutates rand.Reader.
-	orig := rand.Reader
-	rand.Reader = failingReader{}
-	defer func() { rand.Reader = orig }()
+	t.Parallel()
 
-	_, err := newTLSCertificates(t.TempDir())
+	_, err := newTLSCertificates(t.TempDir(), newTLSCertificatesWithFailingPKI())
 	require.Error(t, err, "newTLSCertificates should have failed")
 }
 

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -1,8 +1,11 @@
 package proservices
 
 import (
+	"crypto/rand"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
@@ -86,6 +89,76 @@ func TestNewTLSCertificates(t *testing.T) {
 			require.True(t, os.IsNotExist(err), "agent private key must not be written to disk")
 		})
 	}
+}
+
+func TestNewTLSCertificatesFilesystemFailures(t *testing.T) {
+	t.Parallel()
+	// Permission-based failures work differently (or not at all) on Windows, so
+	// we verify these branches on Unix-like systems only.
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based filesystem failures are not portable to Windows")
+	}
+
+	testcases := map[string]struct {
+		breakReadDir bool
+		breakRemove  bool
+	}{
+		"Error when the certificates directory cannot be read":  {breakReadDir: true},
+		"Error when a stale certificate file cannot be removed": {breakRemove: true},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			certsDir := filepath.Join(dir, common.CertificatesDir)
+			require.NoError(t, os.MkdirAll(certsDir, 0700), "Setup: could not create certificates directory")
+
+			if tc.breakReadDir {
+				// Remove read permission so os.ReadDir fails while os.Stat still succeeds.
+				//nolint:gosec // G302 - test setup needs directory execute permission.
+				require.NoError(t, os.Chmod(certsDir, 0100), "Setup: could not remove read permission")
+				defer func() {
+					//nolint:gosec // G302 - test teardown restores directory permissions.
+					require.NoError(t, os.Chmod(certsDir, 0700), "Teardown: could not restore permissions")
+				}()
+			}
+
+			if tc.breakRemove {
+				require.NoError(t, os.WriteFile(filepath.Join(certsDir, "stale.pem"), []byte("stale"), 0600), "Setup: could not create stale certificate file")
+				// Remove write permission from the directory so os.Remove fails.
+				//nolint:gosec // G302 - test setup removes directory write permission.
+				require.NoError(t, os.Chmod(certsDir, 0500), "Setup: could not remove write permission")
+				defer func() {
+					//nolint:gosec // G302 - test teardown restores directory permissions.
+					require.NoError(t, os.Chmod(certsDir, 0700), "Teardown: could not restore permissions")
+				}()
+			}
+
+			_, err := newTLSCertificates(dir)
+			require.Error(t, err, "newTLSCertificates should have failed")
+		})
+	}
+}
+
+// failingReader is used to make x509.CreateCertificate fail while generating
+// certificates, exercising the error path in newTLSCertificates without
+// mocking it directly.
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("injected random reader failure")
+}
+
+func TestNewTLSCertificatesPKIFailure(t *testing.T) {
+	// Do not run in parallel: this test mutates rand.Reader.
+	orig := rand.Reader
+	rand.Reader = failingReader{}
+	defer func() { rand.Reader = orig }()
+
+	_, err := newTLSCertificates(t.TempDir())
+	require.Error(t, err, "newTLSCertificates should have failed")
 }
 
 func TestNewInstanceHook(t *testing.T) {

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -18,10 +18,13 @@ func TestNewTLSCertificates(t *testing.T) {
 	testcases := map[string]struct {
 		breakCertificatesDir bool
 		breakPublishableFile bool
+		leaveStaleFile       bool
 
 		wantErr bool
 	}{
 		"Success": {},
+
+		"Success removes stale certificate files": {leaveStaleFile: true},
 
 		"Error when the certificates directory cannot be created": {breakCertificatesDir: true, wantErr: true},
 		"Error when a publishable file cannot be written":         {breakPublishableFile: true, wantErr: true},
@@ -36,6 +39,13 @@ func TestNewTLSCertificates(t *testing.T) {
 			if tc.breakCertificatesDir {
 				err := os.WriteFile(filepath.Join(dir, common.CertificatesDir), []byte{}, 0600)
 				require.NoError(t, err, "Setup: could not create the file that should break the certificates directory")
+			}
+			if tc.leaveStaleFile {
+				staleDir := filepath.Join(dir, common.CertificatesDir)
+				err := os.MkdirAll(staleDir, 0700)
+				require.NoError(t, err, "Setup: could not create the stale certificates directory")
+				err = os.WriteFile(filepath.Join(staleDir, "stale.pem"), []byte("stale"), 0600)
+				require.NoError(t, err, "Setup: could not create stale certificate file")
 			}
 			if tc.breakPublishableFile {
 				err := os.MkdirAll(filepath.Join(dir, common.CertificatesDir, common.RootCACertFileName), 0700)
@@ -64,6 +74,11 @@ func TestNewTLSCertificates(t *testing.T) {
 				delete(wantNames, entry.Name())
 			}
 			require.Empty(t, wantNames, "not all expected publishable files were written")
+
+			if tc.leaveStaleFile {
+				_, err = os.Stat(filepath.Join(certsDir, "stale.pem"))
+				require.True(t, os.IsNotExist(err), "stale certificate file should have been removed")
+			}
 
 			_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.CertificateSuffix))
 			require.True(t, os.IsNotExist(err), "agent certificate must not be written to disk")

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -14,42 +14,32 @@ import (
 
 func TestNewTLSCertificates(t *testing.T) {
 	t.Parallel()
-	testcases := map[string]struct {
-		inexistentDestDir bool
-		breakKeyFile      string
 
-		wantErr bool
-	}{
-		"Success": {},
+	dir := t.TempDir()
 
-		"Error when the destination directory does not exist":  {inexistentDestDir: true, wantErr: true},
-		"Error when the agent private key cannot be written":   {breakKeyFile: common.AgentCertFilePrefix + common.KeySuffix, wantErr: true},
-		"Error when the clients private key cannot be written": {breakKeyFile: common.ClientsCertFilePrefix + common.KeySuffix, wantErr: true},
+	cfg, err := newTLSCertificates(dir)
+	require.NoError(t, err, "newTLSCertificates failed")
+	require.NotNil(t, cfg, "newTLSCertificates should have returned a TLS config")
+
+	certsDir := filepath.Join(dir, common.CertificatesDir)
+	entries, err := os.ReadDir(certsDir)
+	require.NoError(t, err, "could not read certificates directory")
+	require.Len(t, entries, 3, "exactly three files should be published")
+
+	wantNames := map[string]struct{}{
+		common.RootCACertFileName:                               {},
+		common.ClientsCertFilePrefix + common.CertificateSuffix: {},
+		common.ClientsCertFilePrefix + common.KeySuffix:         {},
 	}
-
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			dir := t.TempDir()
-			if tc.inexistentDestDir {
-				dir = filepath.Join(dir, "inexistent")
-			}
-
-			if tc.breakKeyFile != "" {
-				err := os.MkdirAll(filepath.Join(dir, tc.breakKeyFile), 0700)
-				require.NoError(t, err, "Setup: could not write directory that should break %s", tc.breakKeyFile)
-			}
-
-			c, err := newTLSCertificates(dir)
-			if tc.wantErr {
-				require.Error(t, err, "NewTLSCertificates should have failed")
-				return
-			}
-			require.NoError(t, err, "NewTLSCertificates failed")
-			require.NotEmpty(t, c, "NewTLSCertificates should have returned a non-empty value")
-		})
+	for _, entry := range entries {
+		delete(wantNames, entry.Name())
 	}
+	require.Empty(t, wantNames, "not all expected publishable files were written")
+
+	_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.CertificateSuffix))
+	require.True(t, os.IsNotExist(err), "agent certificate must not be written to disk")
+	_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.KeySuffix))
+	require.True(t, os.IsNotExist(err), "agent private key must not be written to disk")
 }
 
 func TestNewInstanceHook(t *testing.T) {

--- a/windows-agent/internal/proservices/internal_test.go
+++ b/windows-agent/internal/proservices/internal_test.go
@@ -15,31 +15,62 @@ import (
 func TestNewTLSCertificates(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	testcases := map[string]struct {
+		breakCertificatesDir bool
+		breakPublishableFile bool
 
-	cfg, err := newTLSCertificates(dir)
-	require.NoError(t, err, "newTLSCertificates failed")
-	require.NotNil(t, cfg, "newTLSCertificates should have returned a TLS config")
+		wantErr bool
+	}{
+		"Success": {},
 
-	certsDir := filepath.Join(dir, common.CertificatesDir)
-	entries, err := os.ReadDir(certsDir)
-	require.NoError(t, err, "could not read certificates directory")
-	require.Len(t, entries, 3, "exactly three files should be published")
-
-	wantNames := map[string]struct{}{
-		common.RootCACertFileName:                               {},
-		common.ClientsCertFilePrefix + common.CertificateSuffix: {},
-		common.ClientsCertFilePrefix + common.KeySuffix:         {},
+		"Error when the certificates directory cannot be created": {breakCertificatesDir: true, wantErr: true},
+		"Error when a publishable file cannot be written":         {breakPublishableFile: true, wantErr: true},
 	}
-	for _, entry := range entries {
-		delete(wantNames, entry.Name())
-	}
-	require.Empty(t, wantNames, "not all expected publishable files were written")
 
-	_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.CertificateSuffix))
-	require.True(t, os.IsNotExist(err), "agent certificate must not be written to disk")
-	_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.KeySuffix))
-	require.True(t, os.IsNotExist(err), "agent private key must not be written to disk")
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			if tc.breakCertificatesDir {
+				err := os.WriteFile(filepath.Join(dir, common.CertificatesDir), []byte{}, 0600)
+				require.NoError(t, err, "Setup: could not create the file that should break the certificates directory")
+			}
+			if tc.breakPublishableFile {
+				err := os.MkdirAll(filepath.Join(dir, common.CertificatesDir, common.RootCACertFileName), 0700)
+				require.NoError(t, err, "Setup: could not create the directory that should break the publishable file")
+			}
+
+			cfg, err := newTLSCertificates(dir)
+			if tc.wantErr {
+				require.Error(t, err, "newTLSCertificates should have failed")
+				return
+			}
+			require.NoError(t, err, "newTLSCertificates failed")
+			require.NotNil(t, cfg, "newTLSCertificates should have returned a TLS config")
+
+			certsDir := filepath.Join(dir, common.CertificatesDir)
+			entries, err := os.ReadDir(certsDir)
+			require.NoError(t, err, "could not read certificates directory")
+			require.Len(t, entries, 3, "exactly three files should be published")
+
+			wantNames := map[string]struct{}{
+				common.RootCACertFileName:                               {},
+				common.ClientsCertFilePrefix + common.CertificateSuffix: {},
+				common.ClientsCertFilePrefix + common.KeySuffix:         {},
+			}
+			for _, entry := range entries {
+				delete(wantNames, entry.Name())
+			}
+			require.Empty(t, wantNames, "not all expected publishable files were written")
+
+			_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.CertificateSuffix))
+			require.True(t, os.IsNotExist(err), "agent certificate must not be written to disk")
+			_, err = os.Stat(filepath.Join(certsDir, common.AgentCertFilePrefix+common.KeySuffix))
+			require.True(t, os.IsNotExist(err), "agent private key must not be written to disk")
+		})
+	}
 }
 
 func TestNewInstanceHook(t *testing.T) {

--- a/windows-agent/internal/proservices/proservices.go
+++ b/windows-agent/internal/proservices/proservices.go
@@ -4,11 +4,8 @@ package proservices
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	agent_api "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
-	"github.com/canonical/ubuntu-pro-for-wsl/common"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/grpc/interceptorschain"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logconnections"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
@@ -152,16 +149,12 @@ func New(ctx context.Context, publicDir, privateDir string, args ...Option) (s M
 		log.Warning(ctx, err.Error())
 	}
 
-	destDir := filepath.Join(publicDir, common.CertificatesDir)
-	if err := os.MkdirAll(destDir, 0700); err != nil {
-		return s, fmt.Errorf("failed to create certificates directory: %s", err)
-	}
-	certs, err := newTLSCertificates(destDir)
+	tlsConfig, err := newTLSCertificates(publicDir)
 	if err != nil {
 		return s, fmt.Errorf("failed to create certificates: %s", err)
 	}
 
-	s.creds = credentials.NewTLS(certs.agentTLSConfig())
+	s.creds = credentials.NewTLS(tlsConfig)
 	return s, nil
 }
 

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -37,21 +37,17 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		breakConfig          bool
-		breakNewDistroDB     bool
-		breakCertificatesDir bool
-		breakCA              bool
-		breakCloudInit       bool
+		breakConfig      bool
+		breakNewDistroDB bool
+		breakCloudInit   bool
 
 		wantErr bool
 	}{
 		"When the subscription stays empty":               {},
 		"When the config cannot check if it is read-only": {breakConfig: true},
 
-		"Error when database cannot create its dump file":     {breakNewDistroDB: true, wantErr: true},
-		"Error when certificates directory cannot be created": {breakCertificatesDir: true, wantErr: true},
-		"Error when CA certificate cannot be created":         {breakCA: true, wantErr: true},
-		"Error when cloud-init dir cannot be created":         {breakCloudInit: true, wantErr: true},
+		"Error when database cannot create its dump file": {breakNewDistroDB: true, wantErr: true},
+		"Error when cloud-init dir cannot be created":     {breakCloudInit: true, wantErr: true},
 	}
 
 	for name, tc := range testCases {
@@ -71,12 +67,6 @@ func TestNew(t *testing.T) {
 				dbFile := filepath.Join(privateDir, consts.DatabaseFileName)
 				err := os.MkdirAll(dbFile, 0600)
 				require.NoError(t, err, "Setup: could not write directory where database wants to put a file")
-			}
-			if tc.breakCertificatesDir {
-				require.NoError(t, os.WriteFile(filepath.Join(publicDir, common.CertificatesDir), []byte{}, 0600), "Setup: could not create the file that should break writing the certificates")
-			}
-			if tc.breakCA {
-				require.NoError(t, os.MkdirAll(filepath.Join(publicDir, common.CertificatesDir, common.RootCACertFileName), 0700), "Setup: could not break the root CA certificate file")
 			}
 
 			if tc.breakCloudInit {

--- a/windows-agent/internal/proservices/proservices_test.go
+++ b/windows-agent/internal/proservices/proservices_test.go
@@ -12,6 +12,7 @@ import (
 
 	agentapi "github.com/canonical/ubuntu-pro-for-wsl/agentapi/go"
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/certs"
 	grpclog "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/testutils"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/wsltestutils"
@@ -353,7 +354,7 @@ func loadClientCertificates(t *testing.T, certsDir string) credentials.Transport
 	require.True(t, ca.AppendCertsFromPEM(caBytes), "failed to parse %q", caFilePath)
 
 	tlsConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   certs.MinTLSVersion,
 		ServerName:   common.GRPCServerNameOverride,
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      ca,

--- a/wsl-pro-service/go.mod
+++ b/wsl-pro-service/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34
-	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260812194205-492860dbd283
+	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/wsl-pro-service/go.mod
+++ b/wsl-pro-service/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34
-	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908
+	github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260819171103-a541afce0e5d
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/wsl-pro-service/go.sum
+++ b/wsl-pro-service/go.sum
@@ -1,7 +1,7 @@
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34 h1:zSQYvpsgcMxMFg2f1F3DZGmcpTaf5VT8ZUkXylHd6wI=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34/go.mod h1:/VN4jQYbY3rzPzIXf+kLhyL/sPGaTaw1MmbOUA4sbsA=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908 h1:ESTKoLanBRtUXeXcT971GYeybgLSCHNbzer6VrUP7/Q=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908/go.mod h1:JG36W1CE1dvmUdhXwfDLwRw29nlweMTYtgm0Gy7Z1FY=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260819171103-a541afce0e5d h1:mWE+YimAJnGxPzjTakDKYXXJ/EdJRClBVa6Z41wlpLY=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260819171103-a541afce0e5d/go.mod h1:JG36W1CE1dvmUdhXwfDLwRw29nlweMTYtgm0Gy7Z1FY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=

--- a/wsl-pro-service/go.sum
+++ b/wsl-pro-service/go.sum
@@ -1,7 +1,7 @@
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34 h1:zSQYvpsgcMxMFg2f1F3DZGmcpTaf5VT8ZUkXylHd6wI=
 github.com/canonical/ubuntu-pro-for-wsl/agentapi v0.0.0-20260812184813-22bb9134fc34/go.mod h1:/VN4jQYbY3rzPzIXf+kLhyL/sPGaTaw1MmbOUA4sbsA=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260812194205-492860dbd283 h1:i4c13Ticwj2icUJjxkQy4qy7V1Vepzj3MOIcEYn6RCo=
-github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260812194205-492860dbd283/go.mod h1:JG36W1CE1dvmUdhXwfDLwRw29nlweMTYtgm0Gy7Z1FY=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908 h1:ESTKoLanBRtUXeXcT971GYeybgLSCHNbzer6VrUP7/Q=
+github.com/canonical/ubuntu-pro-for-wsl/common v0.0.0-20260818143011-caa7a2121908/go.mod h1:JG36W1CE1dvmUdhXwfDLwRw29nlweMTYtgm0Gy7Z1FY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=

--- a/wsl-pro-service/internal/daemon/daemon.go
+++ b/wsl-pro-service/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/canonical/ubuntu-pro-for-wsl/common"
+	"github.com/canonical/ubuntu-pro-for-wsl/common/certs"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/grpc/interceptorschain"
 	log "github.com/canonical/ubuntu-pro-for-wsl/common/grpc/logstreamer"
 	"github.com/canonical/ubuntu-pro-for-wsl/common/i18n"
@@ -319,7 +320,7 @@ func newTLSConfigFromDir(certsPath string) (conf *tls.Config, err error) {
 		ServerName:   common.GRPCServerNameOverride,
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      ca,
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   certs.MinTLSVersion,
 	}, nil
 }
 

--- a/wsl-pro-service/internal/testutils/mock_agent.go
+++ b/wsl-pro-service/internal/testutils/mock_agent.go
@@ -116,7 +116,7 @@ func agentTLSCreds(t *testing.T, destDir string) (wslProService, agentCreds cred
 	require.True(t, ca.AppendCertsFromPEM(caBytes), "failed to parse CA certificate")
 
 	wslProService = credentials.NewTLS(&tls.Config{
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   certs.MinTLSVersion,
 		ServerName:   common.GRPCServerNameOverride,
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      ca,

--- a/wsl-pro-service/internal/testutils/mock_agent.go
+++ b/wsl-pro-service/internal/testutils/mock_agent.go
@@ -100,8 +100,8 @@ func agentTLSCreds(t *testing.T, destDir string) (wslProService, agentCreds cred
 	require.NoError(t, err, "failed to generate ephemeral PKI")
 
 	require.NoError(t, os.MkdirAll(destDir, 0700), "failed to create certificates directory")
-	for _, f := range pki.Publishable {
-		require.NoError(t, os.WriteFile(filepath.Join(destDir, f.Name), f.Bytes, 0600), "failed to write %s", f.Name)
+	for name, data := range pki.PEMFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(destDir, name), data, 0600), "failed to write %s", name)
 	}
 
 	clientCert, err := tls.LoadX509KeyPair(

--- a/wsl-pro-service/internal/testutils/mock_agent.go
+++ b/wsl-pro-service/internal/testutils/mock_agent.go
@@ -91,34 +91,37 @@ func NewMockWindowsAgent(t *testing.T, ctx context.Context, publicDir string) *M
 }
 
 // agentTLSCreds is a helper that creates a pair of TLS credentials for the agent and the WSL Pro service for testing.
+// It builds the ephemeral PKI in memory and writes the three publishable files directly to destDir,
+// mimicking what the real agent publishes through the securefiles custodian.
 func agentTLSCreds(t *testing.T, destDir string) (wslProService, agentCreds credentials.TransportCredentials) {
 	t.Helper()
 
+	pki, err := certs.GenerateEphemeralPKI()
+	require.NoError(t, err, "failed to generate ephemeral PKI")
+
 	require.NoError(t, os.MkdirAll(destDir, 0700), "failed to create certificates directory")
+	for _, f := range pki.Publishable {
+		require.NoError(t, os.WriteFile(filepath.Join(destDir, f.Name), f.Bytes, 0600), "failed to write %s", f.Name)
+	}
 
-	rootCert, rootKey, err := certs.CreateRootCA("UP4W Test", destDir)
-	require.NoError(t, err, "failed to create root CA")
-
-	// Create and write the server and client certificates signed by the root certificate created above.
-	agentCert, err := certs.CreateTLSCertificateSignedBy("server", common.GRPCServerNameOverride, rootCert, rootKey, destDir)
-	require.NoError(t, err, "failed to create agent certificate", err)
-	wslProServiceCert, err := certs.CreateTLSCertificateSignedBy("client", "wsl-pro-service-test", rootCert, rootKey, destDir)
-	require.NoError(t, err, "failed to create WSL Pro service certificate", err)
+	clientCert, err := tls.LoadX509KeyPair(
+		filepath.Join(destDir, common.ClientsCertFilePrefix+common.CertificateSuffix),
+		filepath.Join(destDir, common.ClientsCertFilePrefix+common.KeySuffix),
+	)
+	require.NoError(t, err, "failed to load client certificate")
 
 	ca := x509.NewCertPool()
-	ca.AddCert(rootCert)
+	caBytes, err := os.ReadFile(filepath.Join(destDir, common.RootCACertFileName))
+	require.NoError(t, err, "failed to read CA certificate")
+	require.True(t, ca.AppendCertsFromPEM(caBytes), "failed to parse CA certificate")
+
 	wslProService = credentials.NewTLS(&tls.Config{
 		MinVersion:   tls.VersionTLS13,
 		ServerName:   common.GRPCServerNameOverride,
-		Certificates: []tls.Certificate{*wslProServiceCert},
+		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      ca,
 	})
-	agentCreds = credentials.NewTLS(&tls.Config{
-		Certificates: []tls.Certificate{*agentCert},
-		ClientCAs:    ca,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS13,
-	})
+	agentCreds = credentials.NewTLS(pki.AgentTLSConfig)
 
 	return wslProService, agentCreds
 }


### PR DESCRIPTION
The key to this this refactor is the need for centralising all file system writes, thus we need this component to become just a in-memory generator, no file system access.

This replaces the file-writing CreateRootCA/CreateTLSCertificateSignedBy pair with certs.GenerateEphemeralPKI, which builds the whole PKI in memory: the agent's TLS server config is returned directly and only the three publishable artefacts (root CA certificate, client certificate and client key) leave the process.

This PR builds on a key fact: not all certs artefacts we previously wrote to disk are needed there. The agent private key can (and should) be held only in memory, given we always regenerate that entire PKI on agent startup (hence why we're calling it ephemeral now). The agent's private key is therefore never written to disk. Consumers publish the readable artefacts themselves: proservices writes them into the certificates subdirectory of the public directory, and the WSL test double mirrors that layout.

