### PR TITLE
maint(CI): Use upstream winappCli release v0.6

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -87,7 +87,7 @@ jobs:
           channel: stable
           flutter-version: ${{ steps.flutter-version.outputs.contents }}
           pub-cache: true
-      - uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.1
+      - uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
       - name: Build components
         shell: powershell
         run: |

--- a/.github/workflows/publish-msix.yaml
+++ b/.github/workflows/publish-msix.yaml
@@ -108,24 +108,14 @@ jobs:
           # End result should then be: [dist/arm64/ dist/x64].
           path: dist
           merge-multiple: true
-      # - name: Install winappCLI
-      # uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
-      # TODO: Revert this back to the setup-WinappCli action once the commit is released: https://github.com/microsoft/winappCli/commit/881d8bf0d77ad30bc995a274a631b1b5ef1dab15
-      - name: Set up winappCli
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: powershell
-        run: |
-          New-Item -Type Directory "${env:USERPROFILE}\.winappcli" -Force
-          # This CI artifact will expire in about 2 months, hopefully we'll have a new release by then.
-          gh run download 29867852444 --repo 'microsoft/winappCli' --name 'cli-binaries' --dir "${env:USERPROFILE}\.winappcli"
+      - name: Install winappCLI
+        uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
       - name: Pack MSIX bundle
         id: bundle
         # The Pack action with a password protected PFX certificate requires PowerShell 7.
         shell: pwsh
         run: |
           $platform = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
-          $env:PATH = "${env:USERPROFILE}\.winappcli\win-$platform\;${env:PATH}"
           # Decode certificate
           New-Item -ItemType directory -Path certificate
           Set-Content -Path certificate\certificate.txt -Value '${{ secrets.CERTIFICATE }}'


### PR DESCRIPTION
Pinning to the specific CI artefact no longer needed. MS recent version ships with my patch for the MSIX bundle version.