### PR TITLE
fix(CI): TiCS requires running on windows-2022

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -322,7 +322,7 @@ jobs:
 
   tics-windows:
     name: TiCS for the Windows components
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs:
       - codecoverage
       - tics-linux


### PR DESCRIPTION
Because that's the runner that comes with VS 2022.

That was an oversight from the previous PR related to TiCS.