### PR TITLE
fix(windows-agent): Addresses some flaky behaviour and tests

### DIFF
--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -213,6 +213,13 @@ func (d *Daemon) restart(ctx context.Context) {
 		return
 	}
 
+	select {
+	case <-ctx.Done():
+		log.Warning(ctx, "Restart daemon requested meanwhile context was canceled.")
+		return
+	default:
+	}
+
 	// This select binds the time this would block on sending via d.quit (when the channel is full) to the context cancellation.
 	select {
 	case <-ctx.Done():

--- a/windows-agent/internal/daemon/daemon.go
+++ b/windows-agent/internal/daemon/daemon.go
@@ -213,13 +213,6 @@ func (d *Daemon) restart(ctx context.Context) {
 		return
 	}
 
-	select {
-	case <-ctx.Done():
-		log.Warning(ctx, "Restart daemon requested meanwhile context was canceled.")
-		return
-	default:
-	}
-
 	// This select binds the time this would block on sending via d.quit (when the channel is full) to the context cancellation.
 	select {
 	case <-ctx.Done():

--- a/windows-agent/internal/daemon/daemon_test.go
+++ b/windows-agent/internal/daemon/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -223,10 +224,6 @@ func TestCanServeOnlyOnce(t *testing.T) {
 func TestServeWSLIP(t *testing.T) {
 	t.Parallel()
 
-	registerer := func(context.Context, bool) *grpc.Server {
-		return grpc.NewServer()
-	}
-
 	testcases := map[string]struct {
 		netmode      string
 		withAdapters daemontestutils.MockIPAdaptersState
@@ -258,6 +255,15 @@ func TestServeWSLIP(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 
+			registered := make(chan struct{}, 1)
+			registerer := func(context.Context, bool) *grpc.Server {
+				select {
+				case registered <- struct{}{}:
+				default:
+				}
+				return grpc.NewServer()
+			}
+
 			d := daemon.New(ctx, registerer, addrDir)
 			defer d.Quit(ctx, false)
 
@@ -266,7 +272,7 @@ func TestServeWSLIP(t *testing.T) {
 			}
 			mock := daemontestutils.NewHostIPConfigMock(tc.withAdapters)
 
-			serveErr := make(chan error)
+			serveErr := make(chan error, 1)
 			go func() {
 				serveErr <- d.Serve(ctx, daemon.WithWslNetworkingMode(tc.netmode), daemon.WithMockedGetAdapterAddresses(mock),
 					daemon.WithNetDevicesAPIProvider(
@@ -285,13 +291,14 @@ func TestServeWSLIP(t *testing.T) {
 				return
 			}
 
-			serverStopped := make(chan struct{})
-			go func() {
-				time.Sleep(500 * time.Millisecond)
-				d.Quit(ctx, false)
-				close(serverStopped)
-			}()
-			<-serverStopped
+			select {
+			case <-registered:
+			// Should never reach.
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "Timed out waiting for server registration")
+			}
+
+			d.Quit(ctx, false)
 
 			err := <-serveErr
 			if err != nil && strings.Contains(err.Error(), grpc.ErrServerStopped.Error()) {
@@ -315,13 +322,16 @@ func TestServeWSLIP(t *testing.T) {
 func TestAddingWSLAdapterRestarts(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	addrDir := t.TempDir()
+
+	registered := make(chan int, 10)
+	var gen atomic.Int32
 
 	registerer := func(context.Context, bool) *grpc.Server {
 		server := grpc.NewServer()
 		grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
+		registered <- int(gen.Add(1))
 		return server
 	}
 
@@ -341,27 +351,34 @@ func TestAddingWSLAdapterRestarts(t *testing.T) {
 	}()
 
 	addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
-
 	daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should create an address file")
-	addrSt, err := os.Stat(addrPath)
-	require.NoError(t, err, "Address file should be readable")
+
+	// Generation 1
+	select {
+	case g := <-registered:
+		require.Equal(t, 1, g, "Expected generation 1 on startup")
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Timed out waiting for generation 1")
+	}
 
 	// Now we know the GRPC server has started serving. Let's emulate the OS triggering a notification.
 	systemNotification <- nil
 
-	// d.Serve() shouldn't have exitted with an error yet at this point.
+	// Generation 2 after restart
 	select {
-	case err := <-serveErr:
-		require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
-	case <-time.After(200 * time.Millisecond):
-		// proceed.
+	case g := <-registered:
+		require.Equal(t, 2, g, "Expected generation 2 after restart")
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Timed out waiting for generation 2 after restart")
 	}
 
-	daemontestutils.RequireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
-	// Contents could be the same without our control, thus best to check the file time.
-	newAddrSt, err := os.Stat(addrPath)
-	require.NoError(t, err, "Address file should be readable")
-	require.NotEqual(t, addrSt.ModTime(), newAddrSt.ModTime(), "Address file should be overwritten after Restart")
+	d.Quit(ctx, false)
+
+	err := <-serveErr
+	if err != nil && strings.Contains(err.Error(), grpc.ErrServerStopped.Error()) {
+		err = nil
+	}
+	require.NoError(t, err, "Serve should not have caused error after Quit")
 }
 
 func TestServeError(t *testing.T) {
@@ -390,26 +407,38 @@ func TestQuitBeforeServe(t *testing.T) {
 	ctx := context.Background()
 	addrDir := t.TempDir()
 
+	registered := make(chan struct{}, 1)
 	registerer := func(context.Context, bool) *grpc.Server {
+		select {
+		case registered <- struct{}{}:
+		default:
+		}
 		return grpc.NewServer()
 	}
 
 	d := daemon.New(ctx, registerer, addrDir)
 	d.Quit(ctx, false)
 
-	serverErr := make(chan error)
+	serverErr := make(chan error, 1)
 	go func() {
-		defer close(serverErr)
 		serverErr <- d.Serve(ctx)
+		close(serverErr)
 	}()
 
 	select {
-	case err := <-serverErr:
-		require.Fail(t, "Calling Quit() before Serve() on a fresh daemon should not result in an error", err)
-	case <-time.After(1 * time.Second):
+	case <-registered:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Timed out waiting for server registration")
 	}
 
 	d.Quit(ctx, false)
+
+	err := <-serverErr
+	if err != nil && strings.Contains(err.Error(), grpc.ErrServerStopped.Error()) {
+		err = nil
+	}
+	require.NoError(t, err, "Serve should return without error after Quit")
+
 	daemontestutils.RequireWaitPathDoesNotExist(t, filepath.Join(addrDir, common.ListeningPortFileName), "Port file should not exist after returning from Serve()")
 }
 
@@ -439,35 +468,60 @@ func TestWaitReady(t *testing.T) {
 			addrDir := t.TempDir()
 
 			d := daemon.New(ctx, registerer, addrDir)
-			serverErr := make(chan error)
-			if !tc.skipServe {
-				go func() {
-					defer close(serverErr)
-					serverErr <- d.Serve(ctx)
-				}()
-			}
+			serverErr := make(chan error, 1)
 
+			waiterStarted := make(chan struct{})
 			ready := make(chan struct{})
 			go func() {
+				close(waiterStarted)
 				// This would block until the server is ready, potentially "forever" if the server never starts.
 				d.WaitReady()
 				close(ready)
 			}()
 
-			select {
-			case err := <-serverErr:
-				require.Fail(t, "Serve error", err)
-			case <-ctx.Done():
-				require.Fail(t, "Context should not be cancelled yet")
-			case <-ready:
-				if tc.wantBlock {
-					require.Fail(t, "WaitReady should not return as the server should not ready")
+			<-waiterStarted
+
+			if !tc.skipServe {
+				go func() {
+					serverErr <- d.Serve(ctx)
+					close(serverErr)
+				}()
+
+				select {
+				case err := <-serverErr:
+					require.Fail(t, "Serve error", err)
+				case <-ready:
+					// Success: unblocked upon Serve start
+				case <-time.After(5 * time.Second):
+					require.Fail(t, "WaitReady timed out waiting for Serve start")
 				}
-			case <-time.After(1 * time.Second):
-				if !tc.wantBlock {
-					require.Fail(t, "WaitReady should block forever in this case")
-				}
+
+				d.Quit(ctx, false)
+				<-serverErr
+				return
 			}
+
+			// In non-serving case, verify it is blocked
+			select {
+			case <-ready:
+				require.Fail(t, "WaitReady should not return as the server should not ready")
+			default:
+			}
+
+			// Clean waiter shutdown: start Serve to unblock the waiter goroutine so it doesn't leak
+			go func() {
+				serverErr <- d.Serve(ctx)
+				close(serverErr)
+			}()
+
+			select {
+			case <-ready:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "WaitReady timed out during shutdown")
+			}
+
+			d.Quit(ctx, false)
+			<-serverErr
 		})
 	}
 }

--- a/windows-agent/internal/daemon/internal_test.go
+++ b/windows-agent/internal/daemon/internal_test.go
@@ -2,8 +2,9 @@ package daemon
 
 import (
 	"context"
-	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +15,36 @@ import (
 	"google.golang.org/grpc"
 )
 
+const defaultTestTimeout = 5 * time.Second
+
+func waitForGeneration(t *testing.T, registered <-chan int, expectedGen int) {
+	t.Helper()
+	select {
+	case gen := <-registered:
+		require.Equal(t, expectedGen, gen, "Expected server generation")
+	case <-time.After(defaultTestTimeout):
+		require.Failf(t, "Timeout", "Timed out waiting for gRPC server generation %d", expectedGen)
+	}
+}
+
+func requireServeNoError(t *testing.T, serveErr <-chan error) {
+	t.Helper()
+	select {
+	case err := <-serveErr:
+		if err != nil && strings.Contains(err.Error(), grpc.ErrServerStopped.Error()) {
+			err = nil
+		}
+		require.NoError(t, err, "Serve should exit without error after Quit")
+	case <-time.After(defaultTestTimeout):
+		require.Fail(t, "Serve did not exit in time")
+	}
+}
+
+// TestRestart verifies the daemon's restart behavior across different lifecycle states:
+// - successful multi-generation restarts while serving;
+// - no-op when restarting before serving starts;
+// - no-op when restarting after the daemon has quit;
+// - no-op and no request enqueueing when the context is already cancelled.
 func TestRestart(t *testing.T) {
 	t.Parallel()
 
@@ -23,10 +54,9 @@ func TestRestart(t *testing.T) {
 		cancelEarly   bool
 
 		wantAddrFileDeleted bool
-		wantServeErr        bool
 	}{
 		"Success": {},
-		"Does nothing when the context is cancelled":  {cancelEarly: true, wantAddrFileDeleted: true, wantServeErr: true},
+		"Does nothing when the context is cancelled":  {cancelEarly: true, wantAddrFileDeleted: true},
 		"Does nothing when daemon is not serving yet": {beforeServing: true},
 		"Does nothing when the daemon is done":        {afterQuit: true, wantAddrFileDeleted: true},
 	}
@@ -35,90 +65,98 @@ func TestRestart(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := context.Background()
 			addrDir := t.TempDir()
+
+			registered := make(chan int, 10)
+			var gen atomic.Int32
 
 			registerer := func(context.Context, bool) *grpc.Server {
 				server := grpc.NewServer()
 				grpctestservice.RegisterTestServiceServer(server, testGRPCService{})
+				registered <- int(gen.Add(1))
 				return server
 			}
 
 			d := New(ctx, registerer, addrDir)
 
-			serveErr := make(chan error)
-
 			if tc.beforeServing {
+				done := make(chan struct{})
 				go func() {
 					d.restart(ctx)
-					serveErr <- nil
+					close(done)
 				}()
 
 				select {
-				case <-time.After(100 * time.Millisecond):
-					require.Fail(t, "Restart should return immediately when daemon is not serving")
-				case <-serveErr:
+				case <-done:
 					// proceed.
+				case <-time.After(defaultTestTimeout):
+					require.Fail(t, "Restart should return immediately when daemon is not serving")
 				}
+
+				require.Empty(t, registered, "No server generation should have registered")
 			}
 
+			serveErr := make(chan error, 1)
 			go func() {
 				serveErr <- d.Serve(ctx)
 				close(serveErr)
 			}()
 
 			addrPath := filepath.Join(addrDir, common.ListeningPortFileName)
+			daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should have created an address file")
 
-			daemontestutils.RequireWaitPathExists(t, addrPath, "Serve should have created a .address file")
-			addrSt, err := os.Stat(addrPath)
-			require.NoError(t, err, "Address file should be readable")
+			// Wait for initial server generation (generation 1)
+			waitForGeneration(t, registered, 1)
 
 			if tc.afterQuit {
 				d.Quit(ctx, false)
-			}
-			if tc.cancelEarly {
-				cancel()
-				<-ctx.Done()
-				// When calling d.restart with a context cancelled, sometimes the select statement still prefers the alternative path to the <- ctx.Done().
-				// To ensure the <- ctx.Done() case will be preferred in this test we need to send something via d.quit, so another send will block.
-				// While strange, the test becomes predictable.
-				d.restart(ctx)
-			}
-			// Now we know the GRPC server has started serving.
-			d.restart(ctx)
+				requireServeNoError(t, serveErr)
 
-			// d.Serve() shouldn't have exitted with an error yet at this point.
-			select {
-			case err := <-serveErr:
-				if tc.wantServeErr {
-					require.Error(t, err, "Serve should return with error when stopped by the context")
-				} else {
-					require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
+				done := make(chan struct{})
+				go func() {
+					d.restart(ctx)
+					close(done)
+				}()
+
+				select {
+				case <-done:
+					// proceed.
+				case <-time.After(defaultTestTimeout):
+					require.Fail(t, "Restart should return immediately when daemon is stopped")
 				}
-			case <-time.After(100 * time.Millisecond):
-				// proceed.
-			}
 
-			if tc.wantAddrFileDeleted {
-				daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should have been removed after quitting the server")
+				require.Empty(t, registered, "No new server generation should have registered after quit")
+				daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should be removed after Quit")
 				return
 			}
 
-			daemontestutils.RequireWaitPathExists(t, addrPath, "Restart should have caused creation of another .address file")
-			// Contents could be the same without our control, thus best to check the file time.
-			newAddrSt, err := os.Stat(addrPath)
-			require.NoError(t, err, "Address file should be readable")
-			require.NotEqual(t, addrSt.ModTime(), newAddrSt.ModTime(), "Address file should be overwritten after Restart")
+			if tc.cancelEarly {
+				cancelCtx, cancel := context.WithCancel(ctx)
+				cancel()
 
-			// Restart a second time
+				d.restart(cancelCtx)
+
+				require.Empty(t, d.quit, "d.quit channel should remain empty after cancelled restart")
+
+				d.Quit(ctx, false)
+				requireServeNoError(t, serveErr)
+				daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should be removed after Quit")
+				return
+			}
+
+			// Normal flow: restart twice and verify generation increases each time
 			d.restart(ctx)
-			// d.Serve() shouldn't have exitted with an error yet at this point.
-			select {
-			case err := <-serveErr:
-				require.NoError(t, err, "Restart should not have caused Serve() to exit with an error")
-			case <-time.After(100 * time.Millisecond):
-				// proceed.
+			waitForGeneration(t, registered, 2)
+
+			d.restart(ctx)
+			waitForGeneration(t, registered, 3)
+
+			d.Quit(ctx, false)
+			requireServeNoError(t, serveErr)
+
+			if tc.wantAddrFileDeleted {
+				daemontestutils.RequireWaitPathDoesNotExist(t, addrPath, "Address file should be removed after Quit")
 			}
 		})
 	}

--- a/windows-agent/internal/proservices/registrywatcher/export_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/export_test.go
@@ -1,0 +1,12 @@
+package registrywatcher
+
+import (
+	"context"
+
+	"github.com/canonical/ubuntu-pro-for-wsl/windows-agent/internal/proservices/registrywatcher/registry"
+)
+
+// WaitForSingleObject exports waitForSingleObject for testing.
+func (s *Service) WaitForSingleObject(ctx context.Context, event registry.Event) error {
+	return s.waitForSingleObject(ctx, event)
+}

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_linux.go
@@ -50,6 +50,11 @@ func (Windows) WaitForSingleObject(ev Event) (err error) {
 	panic("the Windows registry is not available on Linux")
 }
 
+// SetEvent triggers an event.
+func (Windows) SetEvent(ev Event) error {
+	panic("the Windows registry is not available on Linux")
+}
+
 // CloseEvent releases the event.
 func (Windows) CloseEvent(ev Event) {
 	panic("the Windows registry is not available on Linux")

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
@@ -183,29 +183,25 @@ func (r *Mock) RequireNoLeaks(t *testing.T) {
 
 // HKCUOpenKey mocks opening a key in the specified path under the HK_CURRENT_USER registry.
 func (r *Mock) HKCUOpenKey(path string) (Key, error) {
-	k := r.getKey(path)
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
 	if r.CannotOpen.Load() {
 		return 0, ErrMock
 	}
 
+	_ = r.getKey(path)
 	return r.openKey(path, true), nil
 }
 
 // HKCUCreateKey opens a key in the specified path under the HK_CURRENT_USER registry with write permissions.
 func (r *Mock) HKCUCreateKey(path string) (Key, error) {
-	k := r.getKey(path)
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
 	if r.CannotCreate.Load() {
 		return 0, ErrMock
 	}
 
+	k := r.getKey(path)
 	if k == &r.ubuntuPro {
+		r.ubuntuPro.mu.Lock()
 		r.keyExists = true
+		r.ubuntuPro.mu.Unlock()
 	}
 
 	return r.openKey(path, false), nil
@@ -242,12 +238,11 @@ func (r *Mock) openKey(path string, readOnly bool) Key {
 
 // CloseKey mocks releasing a key, triggering any associated events.
 func (r *Mock) CloseKey(ptr Key) {
-	defer r.keyHandles.free(ptr)
-
 	r.keyHandles.mu.Lock()
-	defer r.keyHandles.mu.Unlock()
-
 	handle, ok := r.keyHandles.data[ptr]
+	r.keyHandles.mu.Unlock()
+
+	r.keyHandles.free(ptr)
 
 	if !ok {
 		return
@@ -293,9 +288,9 @@ func (r *Mock) RegNotifyChangeKeyValue(ptr Key) (Event, error) {
 	}
 
 	r.keyHandles.mu.Lock()
-	defer r.keyHandles.mu.Unlock()
-
 	handle, ok := r.keyHandles.data[ptr]
+	r.keyHandles.mu.Unlock()
+
 	if !ok {
 		return 0, ErrKeyNotExist
 	}
@@ -312,9 +307,8 @@ func (r *Mock) RegNotifyChangeKeyValue(ptr Key) (Event, error) {
 
 	// Attach event to key
 	handle.key.mu.Lock()
-	defer handle.key.mu.Unlock()
-
 	handle.key.events = append(handle.key.events, evHandle)
+	handle.key.mu.Unlock()
 
 	select {
 	case r.watchRegistered <- struct{}{}:
@@ -417,9 +411,8 @@ func (r *Mock) ReadDWordValue(ptr Key, field string) (uint64, error) {
 // SetDWordValue sets the value of the specified DWORD field in the specified key.
 func (r *Mock) SetDWordValue(ptr Key, field string, value uint32) error {
 	r.keyHandles.mu.Lock()
-	defer r.keyHandles.mu.Unlock()
-
 	handle, ok := r.keyHandles.data[ptr]
+	r.keyHandles.mu.Unlock()
 
 	if !ok {
 		return ErrKeyNotExist

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
@@ -32,6 +32,9 @@ type Mock struct {
 	// a "pointer", which is just a key into this map.
 	eventHandles mockedHeap[Event, *eventHandle]
 
+	watchRegistered chan struct{}
+	activeWaits     atomic.Int32
+
 	// Settings to break the registry
 	CannotCreate atomic.Bool
 	CannotOpen   atomic.Bool
@@ -151,6 +154,7 @@ func NewMock() *Mock {
 
 	m.keyHandles.data = make(map[Key]*keyHandle)
 	m.eventHandles.data = make(map[Event]*eventHandle)
+	m.watchRegistered = make(chan struct{}, 1)
 
 	return m
 }
@@ -166,8 +170,15 @@ func (r *Mock) UbuntuProKeyExists() bool {
 // RequireNoLeaks is a test helper to ensure we freed all allocations.
 func (r *Mock) RequireNoLeaks(t *testing.T) {
 	t.Helper()
+
+	r.keyHandles.mu.Lock()
+	defer r.keyHandles.mu.Unlock()
+	r.eventHandles.mu.Lock()
+	defer r.eventHandles.mu.Unlock()
+
 	require.Empty(t, r.keyHandles.data, "registry mock: leaking registry key handles")
 	require.Empty(t, r.eventHandles.data, "registry mock: leaking event handles")
+	require.Zero(t, r.activeWaits.Load(), "registry mock: active WaitForSingleObject waits remaining")
 }
 
 // HKCUOpenKey mocks opening a key in the specified path under the HK_CURRENT_USER registry.
@@ -262,7 +273,9 @@ func (r *Mock) ReadValue(ptr Key, field string) (value string, err error) {
 		return "", ErrMock
 	}
 
+	r.keyHandles.mu.Lock()
 	handle, ok := r.keyHandles.data[ptr]
+	r.keyHandles.mu.Unlock()
 
 	if !ok {
 		return "", ErrKeyNotExist
@@ -303,11 +316,29 @@ func (r *Mock) RegNotifyChangeKeyValue(ptr Key) (Event, error) {
 
 	handle.key.events = append(handle.key.events, evHandle)
 
+	select {
+	case r.watchRegistered <- struct{}{}:
+	default:
+	}
+
 	return evHandle, nil
+}
+
+// WaitForWatch waits until RegNotifyChangeKeyValue installs a watch or the context is cancelled.
+func (r *Mock) WaitForWatch(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-r.watchRegistered:
+		return nil
+	}
 }
 
 // WaitForSingleObject waits until the event is triggered. This is a blocking function.
 func (r *Mock) WaitForSingleObject(handle Event) error {
+	r.activeWaits.Add(1)
+	defer r.activeWaits.Add(-1)
+
 	if r.CannotWait.Load() {
 		return ErrMock
 	}
@@ -372,7 +403,9 @@ func (r *Mock) ReadDWordValue(ptr Key, field string) (uint64, error) {
 		return 0, ErrMock
 	}
 
+	r.keyHandles.mu.Lock()
 	handle, ok := r.keyHandles.data[ptr]
+	r.keyHandles.mu.Unlock()
 
 	if !ok {
 		return 0, ErrKeyNotExist

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_mock.go
@@ -324,6 +324,20 @@ func (r *Mock) WaitForSingleObject(handle Event) error {
 	return nil
 }
 
+// SetEvent triggers an event.
+func (r *Mock) SetEvent(handle Event) error {
+	r.eventHandles.mu.Lock()
+	event, ok := r.eventHandles.data[handle]
+	r.eventHandles.mu.Unlock()
+
+	if !ok {
+		return errors.New("invalid event")
+	}
+
+	event.trigger()
+	return nil
+}
+
 // WriteValue is used to write a value into the registry.
 func (r *Mock) WriteValue(ptr Key, field, value string, multiString bool) error {
 	r.keyHandles.mu.Lock()

--- a/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
+++ b/windows-agent/internal/proservices/registrywatcher/registry/registry_windows.go
@@ -131,6 +131,7 @@ func (Windows) RegNotifyChangeKeyValue(k Key) (ev Event, err error) {
 
 	err = windows.RegNotifyChangeKeyValue(windows.Handle(k), true, notifyFilter, event, true)
 	if err != nil {
+		_ = windows.CloseHandle(event)
 		return 0, fmt.Errorf("in call to RegNotifyChangeKeyValue: %v", err)
 	}
 

--- a/windows-agent/internal/proservices/registrywatcher/watcher.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher.go
@@ -53,6 +53,7 @@ type Registry interface {
 	// Win32 stuff: not strictly registry but not worth separating out
 	RegNotifyChangeKeyValue(k registry.Key) (registry.Event, error)
 	WaitForSingleObject(event registry.Event) error
+	SetEvent(event registry.Event) error
 	CloseEvent(ev registry.Event)
 }
 
@@ -225,7 +226,9 @@ func (s *Service) waitForSingleObject(ctx context.Context, event registry.Event)
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		signalErr := s.registry.SetEvent(event)
+		waitErr := <-ch
+		return errors.Join(ctx.Err(), signalErr, waitErr)
 	case err := <-ch:
 		return err
 	}

--- a/windows-agent/internal/proservices/registrywatcher/watcher_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher_test.go
@@ -117,13 +117,12 @@ func TestRegistryWatcher(t *testing.T) {
 				reg.CannotOpen.Store(false)
 				reg.CannotRead.Store(false)
 			} else {
-				// Nothing broken: registry data is pushed during call to Start
-				require.Eventually(t, func() bool {
-					return conf.Received(config.RegistryData{
-						UbuntuProToken:  startingProToken,
-						LandscapeConfig: startingLandscapeConfig,
-					})
-				}, maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config")
+				// Nothing broken: registry data is pushed synchronously during call to Start
+				startingData := config.RegistryData{
+					UbuntuProToken:  startingProToken,
+					LandscapeConfig: startingLandscapeConfig,
+				}
+				require.True(t, conf.Received(startingData), "Registry watcher should have updated the config")
 			}
 
 			if !tc.breakReadValue && !tc.breakOpenKey && !tc.breakNotifyChangeKeyValue && !tc.breakWaitForSingleObject {

--- a/windows-agent/internal/proservices/registrywatcher/watcher_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher_test.go
@@ -289,3 +289,26 @@ func (conf *mockConfig) LatestReceived() config.RegistryData {
 
 	return conf.received[len(conf.received)-1]
 }
+
+func TestWaitForSingleObjectCancellation(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewMock()
+	defer reg.RequireNoLeaks(t)
+
+	k, err := reg.HKCUCreateKey("Software/Canonical/UbuntuPro")
+	require.NoError(t, err, "Setup: could not create key")
+	defer reg.CloseKey(k)
+
+	ev, err := reg.RegNotifyChangeKeyValue(k)
+	require.NoError(t, err, "Setup: could not watch key")
+	defer reg.CloseEvent(ev)
+
+	w := registrywatcher.New(context.Background(), &mockConfig{}, nil, registrywatcher.WithRegistry(reg))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = w.WaitForSingleObject(ctx, ev)
+	require.ErrorIs(t, err, context.Canceled, "WaitForSingleObject should return context.Canceled on cancellation")
+}

--- a/windows-agent/internal/proservices/registrywatcher/watcher_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher_test.go
@@ -3,6 +3,7 @@ package registrywatcher_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -110,33 +111,27 @@ func TestRegistryWatcher(t *testing.T) {
 				require.True(t, reg.UbuntuProKeyExists(), "UbuntuPro key should exist after the watcher starts")
 			}
 
-			// wantMsgLen is the expected number of times that data is sent to the config
-			var wantMsgLen int
-
 			if tc.wantCannotRead {
 				// Cannot read from the registry: no data should be pushed
-				time.Sleep(30 * time.Second)
-				require.Equal(t, wantMsgLen, conf.ReceivedLen(), "Registry watcher should not have updated the config")
+				require.True(t, conf.Empty(), "Registry watcher should not have updated the config")
 				reg.CannotOpen.Store(false)
 				reg.CannotRead.Store(false)
 			} else {
 				// Nothing broken: registry data is pushed during call to Start
-				wantMsgLen++
-				require.Equal(t, wantMsgLen, conf.ReceivedLen(), "Registry watcher should have updated the config")
-				require.Equal(t, startingProToken, conf.LatestReceived().UbuntuProToken, "Ubuntu Pro token config should have contained the registry value")
-				require.Equal(t, startingLandscapeConfig, conf.LatestReceived().LandscapeConfig, "Landscape config should have contained the registry value")
+				require.Eventually(t, func() bool {
+					return conf.Received(config.RegistryData{
+						UbuntuProToken:  startingProToken,
+						LandscapeConfig: startingLandscapeConfig,
+					})
+				}, maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config")
 			}
 
-			// The watcher makes a redundant config push when it starts watching, except if readValue was broken.
-			if !tc.breakReadValue {
-				wantMsgLen++
-				require.Eventually(t, func() bool { return conf.ReceivedLen() >= wantMsgLen },
-					time.Minute, 100*time.Millisecond, "Registry watcher should have started watching")
-				require.Equal(t, startingProToken, conf.LatestReceived().UbuntuProToken, "Ubuntu Pro token config should have contained the registry value")
-				require.Equal(t, startingLandscapeConfig, conf.LatestReceived().LandscapeConfig, "Landscape config should have contained the registry value")
+			if !tc.breakReadValue && !tc.breakOpenKey && !tc.breakNotifyChangeKeyValue && !tc.breakWaitForSingleObject {
+				watchCtx, watchCancel := context.WithTimeout(ctx, maxUpdateTime)
+				defer watchCancel()
+				err = reg.WaitForWatch(watchCtx)
+				require.NoError(t, err, "Registry watcher should have started watching")
 			}
-
-			wantMsgLen = conf.ReceivedLen() + 1
 
 			if tc.breakCreateKey {
 				// We disable the mock's broken CreateKey.
@@ -148,23 +143,25 @@ func TestRegistryWatcher(t *testing.T) {
 			require.NoError(t, err, "Setup: could not create key")
 			defer reg.CloseKey(k)
 
-			wantMsgLen = conf.ReceivedLen() + 1
 			err = reg.WriteValue(k, "UbuntuProToken", newProToken, false)
 			require.NoError(t, err, "Setup: could not write UbuntuProToken into the registry")
 
-			require.Eventuallyf(t, func() bool { return conf.ReceivedLen() >= wantMsgLen },
-				maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config after changing the registry")
-			require.Equal(t, newProToken, conf.LatestReceived().UbuntuProToken, "Ubuntu Pro token config should have contained the new registry value")
-			require.Equal(t, startingLandscapeConfig, conf.LatestReceived().LandscapeConfig, "Landscape config should have contained the new registry value")
+			require.Eventually(t, func() bool {
+				return conf.Received(config.RegistryData{
+					UbuntuProToken:  newProToken,
+					LandscapeConfig: startingLandscapeConfig,
+				})
+			}, maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config after changing the registry")
 
-			wantMsgLen = conf.ReceivedLen() + 1
 			err = reg.WriteValue(k, "LandscapeConfig", newLandscapeConfig, true)
 			require.NoError(t, err, "Setup: could not write LandscapeConfig into the registry")
 
-			require.Eventually(t, func() bool { return conf.ReceivedLen() >= wantMsgLen },
-				maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config after changing the registry")
-			require.Equal(t, newProToken, conf.LatestReceived().UbuntuProToken, "Ubuntu Pro token config should have contained the new registry value")
-			require.Equal(t, newLandscapeConfig, conf.LatestReceived().LandscapeConfig, "Landscape config should have contained the new registry value")
+			require.Eventually(t, func() bool {
+				return conf.Received(config.RegistryData{
+					UbuntuProToken:  newProToken,
+					LandscapeConfig: newLandscapeConfig,
+				})
+			}, maxUpdateTime, 100*time.Millisecond, "Registry watcher should have updated the config after changing the registry")
 		})
 	}
 }
@@ -274,20 +271,20 @@ func (conf *mockConfig) UpdateRegistryData(ctx context.Context, data config.Regi
 	return nil
 }
 
-// ReceivedLen is the number of times data has been pushed to the config.
-func (conf *mockConfig) ReceivedLen() int {
+// Received returns whether the given config data was received.
+func (conf *mockConfig) Received(data config.RegistryData) bool {
 	conf.mu.RLock()
 	defer conf.mu.RUnlock()
 
-	return len(conf.received)
+	return slices.Contains(conf.received, data)
 }
 
-// LatestReceived is the latest data pushed to the config.
-func (conf *mockConfig) LatestReceived() config.RegistryData {
+// Empty returns whether no config data has been received.
+func (conf *mockConfig) Empty() bool {
 	conf.mu.RLock()
 	defer conf.mu.RUnlock()
 
-	return conf.received[len(conf.received)-1]
+	return len(conf.received) == 0
 }
 
 func TestWaitForSingleObjectCancellation(t *testing.T) {
@@ -311,4 +308,36 @@ func TestWaitForSingleObjectCancellation(t *testing.T) {
 
 	err = w.WaitForSingleObject(ctx, ev)
 	require.ErrorIs(t, err, context.Canceled, "WaitForSingleObject should return context.Canceled on cancellation")
+}
+
+func TestMockWaitForWatchTimeout(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewMock()
+	defer reg.RequireNoLeaks(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := reg.WaitForWatch(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestMockConfigPredicates(t *testing.T) {
+	t.Parallel()
+
+	conf := &mockConfig{}
+	require.True(t, conf.Empty())
+
+	dummy := config.RegistryData{UbuntuProToken: "test-token"}
+	require.False(t, conf.Received(dummy))
+
+	db, err := database.New(context.Background(), t.TempDir())
+	require.NoError(t, err)
+
+	err = conf.UpdateRegistryData(context.Background(), dummy, db)
+	require.NoError(t, err)
+
+	require.False(t, conf.Empty())
+	require.True(t, conf.Received(dummy))
 }

--- a/windows-agent/internal/proservices/registrywatcher/watcher_test.go
+++ b/windows-agent/internal/proservices/registrywatcher/watcher_test.go
@@ -17,6 +17,9 @@ import (
 	wslmock "github.com/ubuntu/gowsl/mock"
 )
 
+// TestRegistryWatcher exercises the entire lifecycle of registrywatcher.Service: initial synchronous registry read,
+// transition to continuous watching via Win32 registry notifications (RegNotifyChangeKeyValue), push of updated data
+// to config upon registry edits, and clean resource cleanup on w.Stop().
 func TestRegistryWatcher(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +168,8 @@ func TestRegistryWatcher(t *testing.T) {
 	}
 }
 
+// TestDefaultTelemetryConsent tests how the registry watcher initializes and validates the Ubuntu telemetry consent
+// DWORD value under HKCU\Software\Canonical\Ubuntu\UbuntuInsightsConsent.
 func TestDefaultTelemetryConsent(t *testing.T) {
 	t.Parallel()
 
@@ -286,6 +291,8 @@ func (conf *mockConfig) Empty() bool {
 	return len(conf.received) == 0
 }
 
+// TestWaitForSingleObjectCancellation asserts that Service.waitForSingleObject returns context.Canceled without blocking, triggering
+// s.registry.SetEvent to wake and join the waiter goroutine so no background wait goroutine or Win32 handle remains open on shutdown.
 func TestWaitForSingleObjectCancellation(t *testing.T) {
 	t.Parallel()
 
@@ -309,6 +316,8 @@ func TestWaitForSingleObjectCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled, "WaitForSingleObject should return context.Canceled on cancellation")
 }
 
+// TestMockWaitForWatchTimeout tests the mock, it verifies that Mock.WaitForWatch respects context cancellation and
+// returns context.DeadlineExceeded rather than blocking forever.
 func TestMockWaitForWatchTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -322,6 +331,7 @@ func TestMockWaitForWatchTimeout(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+// TestMockConfigPredicates verifies that the test mock's locked predicates accurately report received configuration state under a read lock.
 func TestMockConfigPredicates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Every burst of dependabot's PRs reveals some flakiness in this project. This PR concentrates on two sources of flaky behaviour: 

1. Registry watcher tests infer watcher readiness from callback counts and then read callback data separately.
2. Daemon lifecycle tests infer state from sleeps, lack of channel activity, and filesystem modification timestamps.

This PR replace those timing proxies with synchronisation at existing seams:

- the in-memory registry mock signals when `RegNotifyChangeKeyValue` has installed a watch;
- the config mock exposes predicate-based access to a complete received payload while holding one lock;
- registry shutdown explicitly signals the existing manual-reset event and joins the Win32 wait before closing either the event or registry key;
- daemon test registerers signal every construction of a gRPC server, which identifies initial startup and each restart;
- daemon lifecycle requests check an already-cancelled context before entering a select where both cancellation and a writable request channel could otherwise be ready.

There are also two identified production-code contributors:

- **Confirmed daemon nondeterminism:** in `Quit` and `restart`, an already-cancelled context and a writable buffered `d.quit` channel can both be ready in the same `select`; Go may choose the request send and perform work that the cancelled caller expected to suppress.
- **Confirmed registry lifecycle defect, not proven as the CI trigger:** `registrywatcher.Service.waitForSingleObject` starts a goroutine in the blocking Win32 wait. On cancellation it returns without joining that goroutine, after which deferred cleanup closes the event/key handles while the wait may still be active. Closing a handle that another thread is waiting on is unsafe, and repeated start/stop cycles can leave transient wait goroutines behind.

The remaining registry test flakiness is caused by test observation: production deliberately permits redundant config pushes and one-shot watch re-registration, while the test treats callback counts as stable milestones.

## Make registry watcher tests deterministic

This PR builds on the following observations:

- `RegNotifyChangeKeyValue(..., event, true)` arms one asynchronous registry notification and Windows reports it by setting `event`.
- `CreateEvent(nil, 1, 0, nil)` creates a manual-reset event. Once signalled, it remains signalled until `ResetEvent`; this code never resets it and discards the handle after the one-shot wait.
- A timeout from `WaitForSingleObject` would not itself disarm the registry notification or reset the event, so finite polling would not create a rearming gap. Nevertheless, polling is unnecessary and introduces cancellation latency.
- The revised design retains `INFINITE`. Cancellation uses `SetEvent` only to release that specific wait; the child context tells the caller whether the wake was cancellation rather than a registry update.
- The cancellation path joins the waiter before `Service.run` executes deferred `CloseEvent` and `CloseKey`, avoiding the undefined behavior documented for closing a handle while a wait is pending.

We also modify the registry mock to add lifecycle and watch synchronization to the registry mock and replace split count/value reads with locked predicates.


## Make daemon lifecycle behavior and tests deterministic

- Give already-cancelled contexts deterministic precedence
- Add deterministic test synchronization at the registerer seam

In daemon tests, use the existing `GRPCServiceRegisterer` callback:

1. For tests that need to observe startup/restart, we introduce a buffered `registered` channel sized for all expected server generations.
2. In the registerer, we construct/register the gRPC server and then send one value to `registered`.
3. Add a small test helper, local to the relevant test file, that waits for one channel value with a bounded timeout and fails with a generation-specific message.
4. The timeout is only a failure bound. Correctness comes from receiving the callback, not from elapsed time.
5. Use buffered `serveErr` channels so a failed assertion cannot strand the serving goroutine trying to report an error.

### Rewrite daemon tests in `daemon_test.go`

#### `TestServeWSLIP`

1. Add a `registered` channel to the per-case registerer.
2. For success cases, wait for registration before calling `Quit`; remove the 500 ms sleep goroutine.
3. For expected setup failures, continue reading `serveErr` directly and assert the error.
4. Always join `serveErr` after `Quit`.

#### `TestAddingWSLAdapterRestarts`

1. Signal from the registerer on each server construction.
2. Start `Serve` and wait for generation 1 before sending `systemNotification`.
3. Send the simulated adapter notification.
4. Wait for generation 2. This is the restart assertion.
5. Call `Quit`, join `Serve`, and require no error.
6. Remove:
   - address-file stat/mtime comparisons;
   - the 200 ms “Serve did not exit” select.

#### `TestQuitBeforeServe`

1. Call `Quit` before `Serve` as today.
2. Start `Serve`, wait for the registerer signal, then call `Quit` again.
3. Read and assert the final `Serve` error is nil.
4. Assert the address file is removed.
5. Remove the one-second select; startup registration proves the first `Quit` did not poison the daemon.

#### `TestWaitReady`

For each case:

1. Start the goroutine that calls `WaitReady`, with a separate `waiterStarted` channel closed immediately before the call and a `ready` channel closed after it returns.
2. Wait for `waiterStarted` so scheduler delay cannot be mistaken for blocking behavior.
3. **Serving case:** start `Serve`, require `ready` before a bounded timeout, then `Quit` and join `Serve`.
4. **Not-serving case:**
   - before starting `Serve`, use a non-blocking select on `ready` and require it is not closed;
   - then start `Serve` during cleanup, require `ready` closes, call `Quit`, and join `Serve`.
5. This guarantees no `WaitReady` goroutine remains blocked after the test.
