### PR TITLE
docs: Explicit winget source to install Pro for WSL

### DIFF
--- a/docs/howto/set-up-up4w.md
+++ b/docs/howto/set-up-up4w.md
@@ -43,7 +43,7 @@ Open the store page and install the app.
 Run the following command in PowerShell to install the app:
 
 ```{code-block} text
-> winget install Canonical.UbuntuProforWSL
+> winget install --source winget Canonical.UbuntuProforWSL
 ```
 ````
 ``````


### PR DESCRIPTION
In #1728 the user describes a winget issue that affects installing Pro for WSL (and likely any other package) due outdated certificates and a flaw in the error handling causing the tool to fail to install the only app found as if it was ambiguous. With this PR I propose a simple and harmless workaround that should work always, with or without that issue in place: explicitly telling the tool which package source to use.

```
PS C:\Users\Administrator> winget --version
v1.9.25200

PS C:\Users\Administrator> winget source ls
Name    Argument                                      Explicit
--------------------------------------------------------------
msstore https://storeedgefd.dsx.mp.microsoft.com/v9.0 false
winget  https://cdn.winget.microsoft.com/cache        false

PS C:\Users\Administrator> winget search Canonical.UbuntuProforWSL
Failed when searching source; results will not be included: msstore
Name               Id                        Version Source
------------------------------------------------------------
Ubuntu Pro for WSL Canonical.UbuntuProforWSL 1.1.1   winget

PS C:\Users\Administrator> winget search Canonical.UbuntuProforWSL --source msstore
Failed when opening source(s); try the 'source reset' command if the problem persists.
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.

PS C:\Users\Administrator> winget search Ubuntu --source msstore
Failed when opening source(s); try the 'source reset' command if the problem persists.
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.

PS C:\Users\Administrator> winget install Canonical.UbuntuProforWSL
Failed when searching source: msstore
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.

The following packages were found among the working sources.
Please specify one of them using the --source option to proceed.
Name               Id                        Source
---------------------------------------------------
Ubuntu Pro for WSL Canonical.UbuntuProforWSL winget
```

Closes: #1728